### PR TITLE
phantomjs, Jasmine, and CI

### DIFF
--- a/examples/run-jasmine.js
+++ b/examples/run-jasmine.js
@@ -1,26 +1,55 @@
-if (phantom.state.length === 0) {
-    if (phantom.args.length !== 1) {
-        console.log('Usage: run-jasmine.js URL');
-        phantom.exit();
-    } else {
-        phantom.state = 'run-jasmine';
-        phantom.open(phantom.args[0]);
-    }
-} else {
-    window.setInterval(function () {
-        var list, el, desc, i, j;
-        if (document.body.querySelector('.finished_at')) {
-            console.log(document.body.querySelector('.description').innerText);
-            list = document.body.querySelectorAll('div.jasmine_reporter > div.suite.failed');
-            for (i = 0; i < list.length; ++i) {
-                el = list[i];
-                desc = el.querySelectorAll('.description');
-                console.log('');
-                for (j = 0; j < desc.length; ++j) {
-                    console.log(desc[j].innerText);
+var logSpecFailures = function(specs) {
+    for (var i = 0; i < specs.length; i++) {
+        var spec = specs[i];
+
+        var results = spec.results();
+        if (!results.passed()) {
+            console.log("");
+            console.log(spec.suite.getFullName() + " " + spec.description + " failed:");
+
+            var items = results.getItems();
+            for (var j = 0; j < items.length; j++) {
+                var result = items[j];
+                if (result.passed && !result.passed()) {
+                  console.log(result.toString());
                 }
             }
-            phantom.exit();
+        }
+    }
+};
+
+if (phantom.state.length === 0) {
+    if (phantom.args.length < 1) {
+        console.log("Usage: phantomjs.exe run-jasmine.js path/to/spec/runner/html/file [output file]");
+        phantom.exit(1);
+    } else {
+        phantom.state = "run-jasmine";
+        phantom.openFile(phantom.args[0]);
+    }
+} else {
+    var file = phantom.args[1];
+    window.fileWriter = {
+        write: function(content) {
+            if (file) {
+                phantom.writeToFile(file, content);
+            }
+        }
+    };
+
+    window.setInterval(function () {
+        var status = document.body.querySelector(".runner .description");
+        if (status && window.jasmine) {
+            var runner = window.jasmine.getEnv().currentRunner();
+
+            var failures = runner.results().failedCount;
+            if (failures) {
+                logSpecFailures(runner.specs());
+            }
+
+            console.log("");
+            console.log(status.innerText);
+
+            phantom.exit(failures ? 1 : 0);
         }
     }, 100);
 }

--- a/src/phantomjs.cpp
+++ b/src/phantomjs.cpp
@@ -140,8 +140,10 @@ public:
 public slots:
     void exit(int code = 0);
     void open(const QString &address);
+    void openFile(const QString &file);
     void setFormInputFile(QWebElement el, const QString &fileTag);
     bool render(const QString &fileName);
+    bool writeToFile(const QString &fileName, const QString &contents);
     void sleep(int ms);
 
 private slots:
@@ -271,6 +273,14 @@ void Phantom::open(const QString &address)
     m_page.mainFrame()->setUrl(address);
 }
 
+void Phantom::openFile(const QString &file)
+{
+    QFileInfo fileInfo(file);
+    QUrl url = QUrl::fromLocalFile(fileInfo.absoluteFilePath());
+
+    Phantom::open(url.toString());
+}
+
 bool Phantom::render(const QString &fileName)
 {
     QFileInfo fileInfo(fileName);
@@ -301,6 +311,23 @@ bool Phantom::render(const QString &fileName)
     p.end();
     m_page.setViewportSize(viewportSize);
     return buffer.save(fileName);
+}
+
+bool Phantom::writeToFile(const QString &fileName, const QString &contents)
+{
+    QFileInfo fileInfo(fileName);
+    QDir dir;
+    dir.mkpath(fileInfo.absolutePath());
+
+    QFile file(fileName);
+    file.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text);
+
+    QTextStream output(&file);
+    output << contents;
+
+    file.close();
+
+    return true;
 }
 
 int Phantom::returnValue() const


### PR DESCRIPTION
Great tool!  I wanted to use it to run my Jasmine tests headless as a part of my CI, which, for reporting purposes, needs results written to a file in an XML format.  I made some updates that allow for file writing and also loading up a local file using relative paths rather than using the file:/// notation.  I edited the run-jasmine.js example to use these features. run-jasmine.js now exposes a window.fileWriter object which can be used by a custom Jasmine reporter to write results to disk (see https://github.com/gmusick/jasmine-reporters/blob/master/nunit-reporter.js for an example reporter that does this).

Thanks,

Greg
