### PR TITLE
More control over the rendered dimensions

### DIFF
--- a/src/phantomjs.cpp
+++ b/src/phantomjs.cpp
@@ -131,7 +131,7 @@ class Phantom: public QObject
     Q_PROPERTY(QVariantMap version READ version)
     Q_PROPERTY(QVariantMap viewportSize READ viewportSize WRITE setViewportSize)
     Q_PROPERTY(QVariantMap paperSize READ paperSize WRITE setPaperSize)
-    Q_PROPERTY(QVariantMap clipSize READ clipSize WRITE setClipSize)
+    Q_PROPERTY(QVariantMap clipRect READ clipRect WRITE setClipRect)
 
 public:
     Phantom(QObject *parent = 0);
@@ -157,8 +157,8 @@ public:
     void setViewportSize(const QVariantMap &size);
     QVariantMap viewportSize() const;
 
-    void setClipSize(const QVariantMap &size);
-    QVariantMap clipSize() const;
+    void setClipRect(const QVariantMap &size);
+    QVariantMap clipRect() const;
 
     void setPaperSize(const QVariantMap &size);
     QVariantMap paperSize() const;
@@ -493,7 +493,7 @@ QVariantMap Phantom::viewportSize() const
     return result;
 }
 
-void Phantom::setClipSize(const QVariantMap &size)
+void Phantom::setClipRect(const QVariantMap &size)
 {
     int w = size.value("width").toInt();
     int h = size.value("height").toInt();
@@ -510,7 +510,7 @@ void Phantom::setClipSize(const QVariantMap &size)
       m_clipRect = QRect(left, top, w, h);
 }
 
-QVariantMap Phantom::clipSize() const
+QVariantMap Phantom::clipRect() const
 {
     QVariantMap result;
     result["width"] = m_clipRect.width();

--- a/src/phantomjs.cpp
+++ b/src/phantomjs.cpp
@@ -392,10 +392,10 @@ bool Phantom::render(const QString &fileName)
     QSize pageSize = m_page.mainFrame()->contentsSize(); 
     
     QSize bufferSize;
-    if(!m_clipRect.isEmpty()){
-      bufferSize = m_clipRect.size();
+    if (!m_clipRect.isEmpty()) {
+        bufferSize = m_clipRect.size();
     } else {
-      bufferSize = m_page.mainFrame()->contentsSize();
+        bufferSize = m_page.mainFrame()->contentsSize();
     }
     
     if (pageSize.isEmpty())
@@ -411,11 +411,11 @@ bool Phantom::render(const QString &fileName)
 
     m_page.setViewportSize(pageSize);
         
-    if(!m_clipRect.isEmpty()){
-      p.translate(-m_clipRect.left(), -m_clipRect.top());
-      m_page.mainFrame()->render(&p, QRegion(m_clipRect));
+    if (!m_clipRect.isEmpty()) {
+        p.translate(-m_clipRect.left(), -m_clipRect.top());
+        m_page.mainFrame()->render(&p, QRegion(m_clipRect));
     } else {
-      m_page.mainFrame()->render(&p);
+        m_page.mainFrame()->render(&p);
     }
     
     p.end();
@@ -509,13 +509,13 @@ void Phantom::setClipRect(const QVariantMap &size)
     int left = size.value("left").toInt();
     
     if (top < 0)
-      top = 0;
+        top = 0;
       
     if (left < 0)
-      left = 0;
+        left = 0;
     
     if (w > 0 && h > 0)
-      m_clipRect = QRect(left, top, w, h);
+        m_clipRect = QRect(left, top, w, h);
 }
 
 QVariantMap Phantom::clipRect() const

--- a/src/phantomjs.cpp
+++ b/src/phantomjs.cpp
@@ -131,6 +131,7 @@ class Phantom: public QObject
     Q_PROPERTY(QVariantMap version READ version)
     Q_PROPERTY(QVariantMap viewportSize READ viewportSize WRITE setViewportSize)
     Q_PROPERTY(QVariantMap paperSize READ paperSize WRITE setPaperSize)
+    Q_PROPERTY(QVariantMap renderSize READ renderSize WRITE setRenderSize)
 
 public:
     Phantom(QObject *parent = 0);
@@ -155,6 +156,9 @@ public:
 
     void setViewportSize(const QVariantMap &size);
     QVariantMap viewportSize() const;
+
+    void setRenderSize(const QVariantMap &size);
+    QVariantMap renderSize() const;
 
     void setPaperSize(const QVariantMap &size);
     QVariantMap paperSize() const;
@@ -183,6 +187,7 @@ private:
     QString m_state;
     CSConverter *m_converter;
     QVariantMap m_paperSize; // For PDF output via render()
+    QSize m_renderSize;
 };
 
 Phantom::Phantom(QObject *parent)
@@ -383,7 +388,12 @@ bool Phantom::render(const QString &fileName)
         return renderPdf(fileName);
 
     QSize viewportSize = m_page.viewportSize();
-    QSize pageSize = m_page.mainFrame()->contentsSize();
+    QSize pageSize;
+    if(!m_renderSize.isEmpty()) {
+      pageSize = m_renderSize;
+    } else {
+      pageSize = m_page.mainFrame()->contentsSize();
+    }
     if (pageSize.isEmpty())
         return false;
 
@@ -475,6 +485,22 @@ QVariantMap Phantom::viewportSize() const
     QSize size = m_page.viewportSize();
     result["width"] = size.width();
     result["height"] = size.height();
+    return result;
+}
+
+void Phantom::setRenderSize(const QVariantMap &size)
+{
+    int w = size.value("width").toInt();
+    int h = size.value("height").toInt();
+    if (w > 0 && h > 0)
+      m_renderSize = QSize(w,h);
+}
+
+QVariantMap Phantom::renderSize() const
+{
+    QVariantMap result;
+    result["width"] = m_renderSize.width();
+    result["height"] = m_renderSize.height();
     return result;
 }
 

--- a/src/phantomjs.cpp
+++ b/src/phantomjs.cpp
@@ -131,7 +131,7 @@ class Phantom: public QObject
     Q_PROPERTY(QVariantMap version READ version)
     Q_PROPERTY(QVariantMap viewportSize READ viewportSize WRITE setViewportSize)
     Q_PROPERTY(QVariantMap paperSize READ paperSize WRITE setPaperSize)
-    Q_PROPERTY(QVariantMap renderSize READ renderSize WRITE setRenderSize)
+    Q_PROPERTY(QVariantMap clipSize READ clipSize WRITE setClipSize)
 
 public:
     Phantom(QObject *parent = 0);
@@ -157,8 +157,8 @@ public:
     void setViewportSize(const QVariantMap &size);
     QVariantMap viewportSize() const;
 
-    void setRenderSize(const QVariantMap &size);
-    QVariantMap renderSize() const;
+    void setClipSize(const QVariantMap &size);
+    QVariantMap clipSize() const;
 
     void setPaperSize(const QVariantMap &size);
     QVariantMap paperSize() const;
@@ -187,7 +187,7 @@ private:
     QString m_state;
     CSConverter *m_converter;
     QVariantMap m_paperSize; // For PDF output via render()
-    QRect m_renderSize;
+    QRect m_clipRect;
 };
 
 Phantom::Phantom(QObject *parent)
@@ -390,7 +390,6 @@ bool Phantom::render(const QString &fileName)
     QSize viewportSize = m_page.viewportSize();
     
     QSize pageSize; 
-    QRegion clipRegion;
     
     pageSize = m_page.mainFrame()->contentsSize();
     
@@ -410,8 +409,8 @@ bool Phantom::render(const QString &fileName)
     p.end();
     m_page.setViewportSize(viewportSize);
 
-    if(!m_renderSize.isEmpty()){
-      buffer = buffer.copy(m_renderSize);
+    if(!m_clipRect.isEmpty()){
+      buffer = buffer.copy(m_clipRect);
     }
 
     if (fileName.toLower().endsWith(".gif")) {
@@ -494,7 +493,7 @@ QVariantMap Phantom::viewportSize() const
     return result;
 }
 
-void Phantom::setRenderSize(const QVariantMap &size)
+void Phantom::setClipSize(const QVariantMap &size)
 {
     int w = size.value("width").toInt();
     int h = size.value("height").toInt();
@@ -508,16 +507,16 @@ void Phantom::setRenderSize(const QVariantMap &size)
       left = 0;
     
     if (w > 0 && h > 0)
-      m_renderSize = QRect(top, left, w, h);
+      m_clipRect = QRect(left, top, w, h);
 }
 
-QVariantMap Phantom::renderSize() const
+QVariantMap Phantom::clipSize() const
 {
     QVariantMap result;
-    result["width"] = m_renderSize.width();
-    result["height"] = m_renderSize.height();
-    result["top"] = m_renderSize.top();
-    result["left"] = m_renderSize.left();
+    result["width"] = m_clipRect.width();
+    result["height"] = m_clipRect.height();
+    result["top"] = m_clipRect.top();
+    result["left"] = m_clipRect.left();
     return result;
 }
 


### PR DESCRIPTION
Hi!

I've added phantom.renderSize() to be able to control the dimensions of the output. This is done by simply adding m_renderSize and the additional getters/setters. From the JS size, it works the same as setting the viewportSize. If no renderSize is set, render() will fallback to using the mainFrame()->contentsSize().

Cheers!

Wouter

ps. awesome project! :)
