### PR TITLE
Untitled

### DIFF
--- a/src/phantomjs.cpp
+++ b/src/phantomjs.cpp
@@ -169,6 +169,7 @@ public slots:
     void setFormInputFile(QWebElement el, const QString &fileTag);
     bool render(const QString &fileName);
     void sleep(int ms);
+    bool waitFor(const QString &jstest, int ms);
 
 private slots:
     void inject();
@@ -443,6 +444,20 @@ void Phantom::sleep(int ms)
     }
 }
 
+bool Phantom::waitFor(const QString &jstest, int ms)
+{
+  QTime startTime = QTime::currentTime();
+  while (true) {
+    QApplication::processEvents(QEventLoop::AllEvents, 250);
+    if (startTime.msecsTo(QTime::currentTime()) > ms)
+      return false;
+    QVariant v = m_page.mainFrame()->evaluateJavaScript(jstest);
+    if(v.toBool()) {
+      return true;
+    }
+  }
+  return true;
+}
 
 void Phantom::setFormInputFile(QWebElement el, const QString &fileTag)
 {


### PR DESCRIPTION
Added waitFor method. It re-evaluates a javascript condition waiting until it either returns true or a timeout occurs.

I find this useful in situations like "clicking" a link and waiting for something to happen (a div to become visible, etc.)

To use it, you'd pass in some javascript as a string:
var result = phantom.waitFor('$("#myHiddenForm").is(":visible")', 30000);

If result is true, #myHiddenForm became visible, if it's false waiting on the condition timed out.

Great project, thanks!
