### PR TITLE
Added option for disk cache use

### DIFF
--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -31,14 +31,27 @@
 #include <QNetworkRequest>
 #include <QList>
 #include <QNetworkReply>
+#include <QDesktopServices>
+#include <QNetworkDiskCache>
 
 #include "networkaccessmanager.h"
 
 // public:
-NetworkAccessManager::NetworkAccessManager(QObject *parent)
-    : QNetworkAccessManager(parent)
+NetworkAccessManager::NetworkAccessManager(QObject *parent, bool diskCacheEnabled)
+    : QNetworkAccessManager(parent), m_networkDiskCache(0)
 {
+    if (diskCacheEnabled) {
+        m_networkDiskCache = new QNetworkDiskCache();
+        m_networkDiskCache->setCacheDirectory(QDesktopServices::storageLocation(QDesktopServices::CacheLocation));
+        setCache(m_networkDiskCache);
+    }
     connect(this, SIGNAL(finished(QNetworkReply*)), SLOT(handleFinished(QNetworkReply*)));
+}
+
+NetworkAccessManager::~NetworkAccessManager()
+{
+    if (m_networkDiskCache)
+        delete m_networkDiskCache;
 }
 
 // protected:

--- a/src/networkaccessmanager.h
+++ b/src/networkaccessmanager.h
@@ -32,11 +32,16 @@
 
 #include <QNetworkAccessManager>
 
+class QNetworkDiskCache;
+
 class NetworkAccessManager : public QNetworkAccessManager
 {
     Q_OBJECT
+    QNetworkDiskCache* m_networkDiskCache;
 public:
-    NetworkAccessManager(QObject *parent = 0);
+    NetworkAccessManager(QObject *parent = 0, bool diskCacheEnabled = false);
+    void enableDiskCache();
+    virtual ~NetworkAccessManager();
 
 protected:
     QNetworkReply *createRequest(Operation op, const QNetworkRequest & req, QIODevice * outgoingData = 0);

--- a/src/networkaccessmanager.h
+++ b/src/networkaccessmanager.h
@@ -40,7 +40,6 @@ class NetworkAccessManager : public QNetworkAccessManager
     QNetworkDiskCache* m_networkDiskCache;
 public:
     NetworkAccessManager(QObject *parent = 0, bool diskCacheEnabled = false);
-    void enableDiskCache();
     virtual ~NetworkAccessManager();
 
 protected:

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -63,6 +63,7 @@ Phantom::Phantom(QObject *parent)
 
     bool autoLoadImages = true;
     bool pluginsEnabled = false;
+    bool diskCacheEnabled = false;
 
     // second argument: script name
     QStringList args = QApplication::arguments();
@@ -96,6 +97,14 @@ Phantom::Phantom(QObject *parent)
         }
         if (arg == "--load-plugins=no") {
             pluginsEnabled = false;
+            continue;
+        }
+        if (arg == "--disk-cache=yes") {
+            diskCacheEnabled = true;
+            continue;
+        }
+        if (arg == "--disk-cache=no") {
+            diskCacheEnabled = false;
             continue;
         }
         if (arg.startsWith("--proxy=")) {
@@ -139,7 +148,7 @@ Phantom::Phantom(QObject *parent)
     }
 
     // Provide WebPage with a non-standard Network Access Manager
-    m_netAccessMan = new NetworkAccessManager(this);
+    m_netAccessMan = new NetworkAccessManager(this, diskCacheEnabled);
     m_page.setNetworkAccessManager(m_netAccessMan);
 
     connect(m_page.mainFrame(), SIGNAL(javaScriptWindowObjectCleared()), SLOT(inject()));

--- a/src/usage.txt
+++ b/src/usage.txt
@@ -7,4 +7,4 @@ Options:
     --proxy=address:port               Set the network proxy.
     --upload-file fileId=/file/path    Upload a file by creating a '<input type="file" id="foo" />'
                                        and calling phantom.setFormInputFile(document.getElementById('foo'), 'fileId').
-
+    --disk-cache=[yes|no]              Enable disk cache (at desktop services cache storage location, default is 'no').


### PR DESCRIPTION
My branch adds knowledge of flags --disk-cache=[yes|no], defaulting to no. If yes the NetworkAccessManager will have its cache set to a QNetworkDiskCache with location of QDesktopServices::CacheLocation. This allows for conditional GET requests which may have a response of 'Not Modified' (304) to reduce network transfer and increase performance in many scenarios.
