### PR TITLE
Fixes for waitfor and pizza examples

### DIFF
--- a/examples/pizza.js
+++ b/examples/pizza.js
@@ -5,7 +5,7 @@ if (phantom.state.length === 0) {
     phantom.open('http://www.google.com/m/local?site=local&q=pizza+in+new+york');
 } else {
     var list = document.querySelectorAll('div.bf');
-    for (var i in list) {
+    for (var i = 0; i < list.length; i++) {
         console.log(list[i].innerText);
     }
     phantom.exit();

--- a/examples/waitfor.coffee
+++ b/examples/waitfor.coffee
@@ -1,0 +1,40 @@
+###
+ Wait until the test condition is true or a timeout occurs. Useful for waiting
+ on a server response or for a ui change (fadeIn, etc.) to occur.
+
+ @param testFx javascript condition that evaluates to a boolean,
+ it can be passed in as a string (e.g.: "1 == 1" or "$('#bar').is(':visible')" or
+ as a callback function.
+ @param message a message describing e.g. the ui change
+ @param timeOutMillis the max amount of time to wait. If not specified, 3 sec is used.
+###
+waitFor = (testFx, message, maxtimeOutMillis = 3000) ->
+    start = new Date().getTime()
+    condition = false
+    while (new Date().getTime() - start) < maxtimeOutMillis
+        phantom.sleep(250)
+        if typeof(testFx) is "string"
+            condition = eval testFx
+        else
+            condition = testFx()
+        if condition
+            break
+    if not condition
+        console.log "Timeout: " + message
+        phantom.exit 1
+    else
+        console.log message
+        console.log "+++ waitUntil finished in " + (new Date().getTime() - start) + " millis."
+
+# example use:
+if not phantom.state
+    # load a twitter page
+    phantom.state = "loaded"
+    phantom.open "http://twitter.com/#!/senchainc"
+else
+    # click the "sign in" link
+    $(".signin-link").click()
+
+    # wait for the sign in dialog to pop up
+    waitFor (-> $("#signin-dropdown").is ":visible"), "The sign-in dialog should be visible"
+    phantom.exit()

--- a/examples/waitfor.js
+++ b/examples/waitfor.js
@@ -18,9 +18,11 @@ function waitFor(testFx, message, timeOutMillis) {
         if(condition) break;
     }
     if(!condition) {
-        throw Error("Timeout: " + message);
+        console.log("Timeout: " + message);
+        phantom.exit(1)
+    } else {
+        console.log("+++ waitUntil finished in " + (new Date().getTime() - start) + " millis.");
     }
-    console.log("+++ waitUntil finished in " + (new Date().getTime() - start) + " millis.");
 }
 
 // example use:

--- a/examples/waitfor.js
+++ b/examples/waitfor.js
@@ -6,10 +6,10 @@
  * it can be passed in as a string (e.g.: "1 == 1" or "$('#bar').is(':visible')" or
  * as a callback function.
  * @param message a message to show on failure
- * @param timeOutMillis the max amount of time to wait. If not specified, 30sec-s is used.
+ * @param timeOutMillis the max amount of time to wait. If not specified, 3 sec is used.
  */
 function waitFor(testFx, message, timeOutMillis) {
-    var maxtimeOutMillis = timeOutMillis ? timeOutMillis : 30000;
+    var maxtimeOutMillis = timeOutMillis ? timeOutMillis : 3000;
     var start = new Date().getTime();
     var condition = false;
     while(new Date().getTime() - start < maxtimeOutMillis) {

--- a/examples/waitfor.js
+++ b/examples/waitfor.js
@@ -5,7 +5,7 @@
  * @param testFx javascript condition that evaluates to a boolean,
  * it can be passed in as a string (e.g.: "1 == 1" or "$('#bar').is(':visible')" or
  * as a callback function.
- * @param message a message to show on failure
+ * @param message a message describing e.g. the ui change
  * @param timeOutMillis the max amount of time to wait. If not specified, 3 sec is used.
  */
 function waitFor(testFx, message, timeOutMillis) {
@@ -21,6 +21,7 @@ function waitFor(testFx, message, timeOutMillis) {
         console.log("Timeout: " + message);
         phantom.exit(1)
     } else {
+        console.log(message);
         console.log("+++ waitUntil finished in " + (new Date().getTime() - start) + " millis.");
     }
 }

--- a/examples/waitfor.js
+++ b/examples/waitfor.js
@@ -13,12 +13,12 @@ function waitFor(testFx, message, timeOutMillis) {
     var start = new Date().getTime();
     var condition = false;
     while(new Date().getTime() - start < maxtimeOutMillis) {
-	phantom.sleep(250);
-	condition = (typeof(testFx) == "string" ? eval(testFx) : testFx());
-	if(condition) break;
+        phantom.sleep(250);
+        condition = (typeof(testFx) == "string" ? eval(testFx) : testFx());
+        if(condition) break;
     }
     if(!condition) {
-	throw Error("Timeout: " + message);
+        throw Error("Timeout: " + message);
     }
     console.log("+++ waitUntil finished in " + (new Date().getTime() - start) + " millis.");
 }
@@ -34,7 +34,7 @@ if(!phantom.state) {
 
     // wait for the sign in dialog to pop up
     waitFor(function() {
-	return $("#signin_menu").is(":visible");
+        return $("#signin_menu").is(":visible");
     }, "The sign-in dialog should be visible");
     phantom.exit();
 }

--- a/examples/waitfor.js
+++ b/examples/waitfor.js
@@ -27,14 +27,14 @@ function waitFor(testFx, message, timeOutMillis) {
 if(!phantom.state) {
     // load a twitter page
     phantom.state = "loaded";
-    phantom.open("http://twitter.com/WiIlFerreII");
+    phantom.open("http://twitter.com/#!/senchainc");
 } else {
     // click the "sign in" link
-    $(".signin").click();
+    $(".signin-link").click();
 
     // wait for the sign in dialog to pop up
     waitFor(function() {
-        return $("#signin_menu").is(":visible");
+        return $("#signin-dropdown").is(":visible");
     }, "The sign-in dialog should be visible");
     phantom.exit();
 }


### PR DESCRIPTION
The `waitfor.js` example does not work, because 
- the Twitter account used in the example doesn't exist and 
- Twitter changed the structure of their page.

This should work now, I used the senchainc account as in the tweets.js example.
I made some further changes to the example to display the UI change that was waited for and to exit the program if an error occurs.
Also added a Coffeescript version.

The `pizza.js`  example did loop through item and length as well, leading to
undefined
being output.
(The Coffeescript version does the right thing :-) ...)
