### PR TITLE
I added a new option: --ignore-ssl-errors=[yes|no]

### DIFF
--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -37,8 +37,8 @@
 #include "networkaccessmanager.h"
 
 // public:
-NetworkAccessManager::NetworkAccessManager(QObject *parent, bool diskCacheEnabled)
-    : QNetworkAccessManager(parent), m_networkDiskCache(0)
+NetworkAccessManager::NetworkAccessManager(QObject *parent, bool diskCacheEnabled, bool ignoreSslErrors)
+    : QNetworkAccessManager(parent), m_networkDiskCache(0), m_ignoreSslErrors(ignoreSslErrors)
 {
     if (diskCacheEnabled) {
         m_networkDiskCache = new QNetworkDiskCache();
@@ -94,7 +94,11 @@ QNetworkReply *NetworkAccessManager::createRequest(Operation op, const QNetworkR
     qDebug() << "URL" << qPrintable(req.url().toString());
 
     // Pass duty to the superclass - Nothing special to do here (yet?)
-    return QNetworkAccessManager::createRequest(op, req, outgoingData);
+    QNetworkReply *reply = QNetworkAccessManager::createRequest(op, req, outgoingData);
+    if(m_ignoreSslErrors) {
+        reply->ignoreSslErrors();
+    }
+    return reply;
 }
 
 // private slots:

--- a/src/networkaccessmanager.h
+++ b/src/networkaccessmanager.h
@@ -39,10 +39,11 @@ class NetworkAccessManager : public QNetworkAccessManager
     Q_OBJECT
     QNetworkDiskCache* m_networkDiskCache;
 public:
-    NetworkAccessManager(QObject *parent = 0, bool diskCacheEnabled = false);
+    NetworkAccessManager(QObject *parent = 0, bool diskCacheEnabled = false, bool ignoreSslErrors = false);
     virtual ~NetworkAccessManager();
 
 protected:
+    bool m_ignoreSslErrors;
     QNetworkReply *createRequest(Operation op, const QNetworkRequest & req, QIODevice * outgoingData = 0);
 
 private slots:

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -64,6 +64,7 @@ Phantom::Phantom(QObject *parent)
     bool autoLoadImages = true;
     bool pluginsEnabled = false;
     bool diskCacheEnabled = false;
+    bool ignoreSslErrors = false;
 
     // second argument: script name
     QStringList args = QApplication::arguments();
@@ -105,6 +106,14 @@ Phantom::Phantom(QObject *parent)
         }
         if (arg == "--disk-cache=no") {
             diskCacheEnabled = false;
+            continue;
+        }
+        if (arg == "--ignore-ssl-errors=yes") {
+            ignoreSslErrors = true;
+            continue;
+        }
+        if (arg == "--ignore-ssl-errors=no") {
+            ignoreSslErrors = false;
             continue;
         }
         if (arg.startsWith("--proxy=")) {
@@ -150,7 +159,7 @@ Phantom::Phantom(QObject *parent)
     }
 
     // Provide WebPage with a non-standard Network Access Manager
-    m_netAccessMan = new NetworkAccessManager(this, diskCacheEnabled);
+    m_netAccessMan = new NetworkAccessManager(this, diskCacheEnabled, ignoreSslErrors);
     m_page.setNetworkAccessManager(m_netAccessMan);
 
     connect(m_page.mainFrame(), SIGNAL(javaScriptWindowObjectCleared()), SLOT(inject()));

--- a/src/usage.txt
+++ b/src/usage.txt
@@ -8,3 +8,4 @@ Options:
     --upload-file fileId=/file/path    Upload a file by creating a '<input type="file" id="foo" />'
                                        and calling phantom.setFormInputFile(document.getElementById('foo'), 'fileId').
     --disk-cache=[yes|no]              Enable disk cache (at desktop services cache storage location, default is 'no').
+    --ignore-ssl-errors=[yes|no]       Ignore SSL errors (i.e. expired or self-signed certificate errors).


### PR DESCRIPTION
It resolves this issue: 
http://code.google.com/p/phantomjs/issues/detail?id=38

This allows users to run phantomjs on webpages with invalid or self-signed SSL certificates.
