### PR TITLE
Sort out the nitpicks

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,10 @@ Version 1.3.0
     Bug fixes
 
       * Fixed open() and POST method, without specifying the finished handler.
+    
+    New features
+      
+      * Added Filesystem API, based on CommonJS Filesystem draft specs (issue 129)
 
     Examples
 

--- a/examples/echoToFile.coffee
+++ b/examples/echoToFile.coffee
@@ -10,8 +10,9 @@ else
   while i < phantom.args.length
     content += phantom.args[i] + (if i == phantom.args.length - 1 then "" else " ")
     ++i
-  f = fs.open(phantom.args[0], "w")
-  if f
+  try
+    f = fs.open(phantom.args[0], "w")
     f.writeLine content
-    f.close()
+  catch e
+    console.log e
   phantom.exit()

--- a/examples/echoToFile.coffee
+++ b/examples/echoToFile.coffee
@@ -10,7 +10,7 @@ else
   while i < phantom.args.length
     content += phantom.args[i] + (if i == phantom.args.length - 1 then "" else " ")
     ++i
-  f = phantom.fs.open(phantom.args[0], "w")
+  f = fs.open(phantom.args[0], "w")
   if f
     f.writeLine content
     f.close()

--- a/examples/echoToFile.js
+++ b/examples/echoToFile.js
@@ -10,10 +10,11 @@ if (phantom.args.length < 2) {
         content += phantom.args[i] + (i === phantom.args.length-1 ? '' : ' ');
     }
     
-    f = fs.open(phantom.args[0], "w");
-    if ( f ) {
+    try {
+        f = fs.open(phantom.args[0], "w");
         f.writeLine(content);
-        f.close();
+    } catch (e) {
+        console.log(e);
     }
 
     phantom.exit();

--- a/examples/echoToFile.js
+++ b/examples/echoToFile.js
@@ -10,7 +10,7 @@ if (phantom.args.length < 2) {
         content += phantom.args[i] + (i === phantom.args.length-1 ? '' : ' ');
     }
     
-    f = phantom.fs.open(phantom.args[0], "w");
+    f = fs.open(phantom.args[0], "w");
     if ( f ) {
         f.writeLine(content);
         f.close();

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -14,7 +14,7 @@ window.WebPage = function() {
             handlers[signalName] = f;
             this[signalName].connect(handlers[signalName]);
         });
-    }
+    };
 
     // deep copy
     page.settings = JSON.parse(JSON.stringify(phantom.defaultPageSettings));
@@ -79,4 +79,13 @@ window.WebPage = function() {
     };
 
     return page;
-}
+};
+
+// Make "fs.open" throw an exception in case it fails
+window.fs.open = function(path, mode) {
+    var file = window.fs._open(path, mode);
+    if (file) {
+        return file;
+    }
+    throw "Unable to open file '"+ path +"'";
+};

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -55,7 +55,7 @@ QString File::read()
         return m_fileStream.readAll();
     }
     qDebug() << "File::read - " << "Couldn't read:" << m_file->fileName();
-    return NULL;
+    return QString();
 }
 
 bool File::write(const QString &data)
@@ -74,7 +74,7 @@ QString File::readLine()
         return m_fileStream.readLine();
     }
     qDebug() << "File::readLine - " << "Couldn't read:" << m_file->fileName();
-    return NULL;
+    return QString();
 }
 
 bool File::writeLine(const QString &data)
@@ -208,17 +208,17 @@ QObject *FileSystem::open(const QString &path, const QString &mode) const
     // Ensure only one "mode character" has been selected
     if ( mode.length() != 1) {
         qDebug() << "FileSystem::open - " << "Wrong Mode string length:" << mode;
-        return false;
+        return NULL;
     }
 
     // Determine the OpenMode
     switch(mode[0].toAscii()) {
     case 'r': case 'R': {
         modeCode |= QFile::ReadOnly;
-        // Make sure there is something to read, otherwise return "false"
+        // Make sure there is something to read
         if ( !_f->exists() ) {
             qDebug() << "FileSystem::open - " << "Trying to read a file that doesn't exist:" << path;
-            return false;
+            return NULL;
         }
         break;
     }
@@ -228,26 +228,28 @@ QObject *FileSystem::open(const QString &path, const QString &mode) const
     }
     case 'w': case 'W': {
         modeCode |= QFile::WriteOnly;
-        // If the file doesn't exist and the desired path can't be created, return "false"
+        // Make sure the file exists OR it can be created at the required path
         if ( !_f->exists() && !makeTree(QFileInfo(path).dir().absolutePath()) ) {
             qDebug() << "FileSystem::open - " << "Full path coulnd't be created:" << path;
-            return false;
+            return NULL;
         }
         break;
     }
     default: {
         qDebug() << "FileSystem::open - " << "Wrong Mode:" << mode;
-        return false;
+        return NULL;
     }
     }
 
     // Try to Open
     if ( _f->open(modeCode) ) {
         f = new File(_f);
-        if ( f ) { return f; }
+        if ( f ) {
+            return f;
+        }
     }
 
-    // Return "false" if the file couldn't be opened as requested
+    // Return "NULL" if the file couldn't be opened as requested
     qDebug() << "FileSystem::open - " << "Couldn't be opened:" << path;
-    return false;
+    return NULL;
 }

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -199,7 +199,7 @@ QString FileSystem::separator() const
     return QDir::separator();
 }
 
-QObject *FileSystem::open(const QString &path, const QString &mode) const
+QObject *FileSystem::_open(const QString &path, const QString &mode) const
 {
     File *f = NULL;
     QFile *_f = new QFile(path);

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -88,7 +88,7 @@ public slots:
 
     QString separator() const;
 
-    QObject *open(const QString &path, const QString &mode) const;
+    QObject *_open(const QString &path, const QString &mode) const;
 };
 
 #endif // FILESYSTEM_H

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -172,6 +172,7 @@ Phantom::Phantom(QObject *parent)
     setLibraryPath(QFileInfo(m_scriptFile).dir().absolutePath());
 
     m_page->mainFrame()->addToJavaScriptWindowObject("phantom", this);
+    m_page->mainFrame()->addToJavaScriptWindowObject("fs", &m_filesystem);
 
     QFile file(":/bootstrap.js");
     if (!file.open(QFile::ReadOnly)) {
@@ -240,11 +241,6 @@ QVariantMap Phantom::version() const
     result["minor"] = PHANTOMJS_VERSION_MINOR;
     result["patch"] = PHANTOMJS_VERSION_PATCH;
     return result;
-}
-
-QObject *Phantom::filesystem()
-{
-    return &m_filesystem;
 }
 
 // public slots:

--- a/src/phantom.h
+++ b/src/phantom.h
@@ -46,7 +46,6 @@ class Phantom: public QObject
     Q_PROPERTY(QString libraryPath READ libraryPath WRITE setLibraryPath)
     Q_PROPERTY(QString scriptName READ scriptName)
     Q_PROPERTY(QVariantMap version READ version)
-    Q_PROPERTY(QObject* fs READ filesystem)
 
 public:
     Phantom(QObject *parent = 0);
@@ -64,8 +63,6 @@ public:
     QString scriptName() const;
 
     QVariantMap version() const;
-
-    QObject *filesystem();
 
 public slots:
     QObject *createWebPage();


### PR DESCRIPTION
1) Changelog updated
2) "phantom.fs" -> "window.fs" - there is no real reason for attaching "fs" to the phantom object (and we will get this sorted out even better if we implement CommonJS Modules specs)
3) "fs.open" throws an exception if fails (done with a JS shim :( )
