### PR TITLE
Fix crash on exit (Issues #136, #148 and #149)

### DIFF
--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -52,6 +52,7 @@ Phantom::Phantom(QObject *parent)
     , m_netAccessMan(0)
 {
     m_page = new WebPage(this);
+    m_pages.append(m_page);
 
     QString proxyHost;
     int proxyPort = 1080;
@@ -251,6 +252,7 @@ QObject *Phantom::filesystem()
 QObject *Phantom::createWebPage()
 {
     WebPage *page = new WebPage(this);
+    m_pages.append(page);
     page->applySettings(m_defaultPageSettings);
     page->setNetworkAccessManager(m_netAccessMan);
     page->setLibraryPath(QFileInfo(m_scriptFile).dir().absolutePath());
@@ -265,7 +267,8 @@ void Phantom::exit(int code)
 {
     m_terminated = true;
     m_returnValue = code;
-    delete m_page;
+    qDeleteAll(m_pages);
+    m_pages.clear();
     m_page = 0;
     QApplication::instance()->exit(code);
 }

--- a/src/phantom.h
+++ b/src/phantom.h
@@ -86,6 +86,7 @@ private:
     NetworkAccessManager *m_netAccessMan;
     QVariantMap m_defaultPageSettings;
     FileSystem m_filesystem;
+    QList<WebPage*> m_pages;
 };
 
 #endif // PHANTOM_H


### PR DESCRIPTION
Workaround: Apparently, all QWebPages need to be deleted before
the QApplication gets destroyed.
