### PR TITLE
Add "phantom.exec"

### DIFF
--- a/examples/exec.coffee
+++ b/examples/exec.coffee
@@ -1,0 +1,8 @@
+if phantom.args.length is 0
+  console.log 'Try to pass some args when invoking this script!'
+  phantom.exit()
+else
+  argstr = ''
+  for arg, i in phantom.args
+    argstr += arg + ' '
+  phantom.exec(argstr)

--- a/examples/exec.js
+++ b/examples/exec.js
@@ -1,0 +1,10 @@
+if (phantom.args.length === 0) {
+    console.log('Try to pass some args when invoking this script!');
+    phantom.exit();
+} else {
+    var argstr = '';
+    phantom.args.forEach(function(arg, i) {
+            argstr += arg + ' ';
+    });
+    phantom.exec(argstr);
+}

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -268,6 +268,11 @@ void Phantom::exit(int code)
     QApplication::instance()->exit(code);
 }
 
+void Phantom::exec(const QString &command) {
+    char *args[4] = {"sh", "-c", (char*)command.toUtf8().constData(), NULL};
+    execv("/bin/sh", args);
+}
+
 void Phantom::_destroy(QObject *page) {
     m_pages.removeOne((WebPage*)page);
     delete page;

--- a/src/phantom.h
+++ b/src/phantom.h
@@ -68,6 +68,7 @@ public slots:
     QObject *createWebPage();
     bool injectJs(const QString &jsFilePath);
     void exit(int code = 0);
+    void exec(const QString &command);
     void _destroy(QObject *page);
 
 private slots:


### PR DESCRIPTION
The 'exec' function mimics a shells exec function and allows you to execute another command, replacing the phantomjs process.

I use this in my screenscraping scripts, a lot of which now use phantomjs, to launch other commands. For instance a script to start mplayer with the correct URL for the tour de france: http://paste.pocoo.org/show/440700/

(The nasty sed hack is because phantomjs/webkit tries to play the asf file instead of downloading it and letting me process it).
