### PR TITLE
Persistent cookie support

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,10 @@ Version 1.3.0
       
       * Added Filesystem API, based on CommonJS Filesystem draft specs (issue 129)
 
+    New features
+
+      * Presistent cookie support using --cookies=cookies.ini
+
     Examples
 
       * Added a new example on using Modernizr to detect features.

--- a/src/cookiejar.h
+++ b/src/cookiejar.h
@@ -2,6 +2,7 @@
   This file is part of the PhantomJS project from Ofi Labs.
 
   Copyright (C) 2011 Ariya Hidayat <ariya.hidayat@gmail.com>
+  Copyright (C) 2010 Ariya Hidayat <ariya.hidayat@gmail.com>
 
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
@@ -27,39 +28,21 @@
   THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#ifndef NETWORKACCESSMANAGER_H
-#define NETWORKACCESSMANAGER_H
+#ifndef COOKIEJAR_H
+#define COOKIEJAR_H
 
-#include <QHash>
-#include <QNetworkAccessManager>
-#include <QSet>
+#include <QNetworkCookieJar>
 
-class QNetworkDiskCache;
-
-class NetworkAccessManager : public QNetworkAccessManager
+class CookieJar: public QNetworkCookieJar
 {
-    Q_OBJECT
-    QNetworkDiskCache* m_networkDiskCache;
-public:
-    NetworkAccessManager(QObject *parent = 0, bool diskCacheEnabled = false, QString cookieFile = "", bool ignoreSslErrors = false);
-    virtual ~NetworkAccessManager();
-
-protected:
-    bool m_ignoreSslErrors;
-    QNetworkReply *createRequest(Operation op, const QNetworkRequest & req, QIODevice * outgoingData = 0);
-
-signals:
-    void resourceRequested(const QVariant& data);
-    void resourceReceived(const QVariant& data);
-
-private slots:
-    void handleStarted();
-    void handleFinished(QNetworkReply *reply);
-
 private:
-    QHash<QNetworkReply*, int> m_ids;
-    QSet<QNetworkReply*> m_started;
-    int m_idCounter;
+    QString m_cookieFile;
+
+public:
+    CookieJar(QString cookieFile);
+
+    bool setCookiesFromUrl(const QList<QNetworkCookie> & cookieList, const QUrl & url);
+    QList<QNetworkCookie> cookiesForUrl (const QUrl & url) const;
 };
 
-#endif // NETWORKACCESSMANAGER_H
+#endif // COOKIEJAR_H

--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -35,6 +35,7 @@
 #include <QNetworkDiskCache>
 
 #include "networkaccessmanager.h"
+#include "cookiejar.h"
 
 static const char *toString(QNetworkAccessManager::Operation op)
 {
@@ -63,12 +64,16 @@ static const char *toString(QNetworkAccessManager::Operation op)
 }
 
 // public:
-NetworkAccessManager::NetworkAccessManager(QObject *parent, bool diskCacheEnabled, bool ignoreSslErrors)
+NetworkAccessManager::NetworkAccessManager(QObject *parent, bool diskCacheEnabled, QString cookieFile, bool ignoreSslErrors)
     : QNetworkAccessManager(parent)
     , m_networkDiskCache(0)
     , m_ignoreSslErrors(ignoreSslErrors)
     , m_idCounter(0)
 {
+    if (!cookieFile.isEmpty()) {
+        setCookieJar(new CookieJar(cookieFile));
+    }
+
     if (diskCacheEnabled) {
         m_networkDiskCache = new QNetworkDiskCache();
         m_networkDiskCache->setCacheDirectory(QDesktopServices::storageLocation(QDesktopServices::CacheLocation));

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -54,6 +54,7 @@ Phantom::Phantom(QObject *parent)
     m_pages.append(m_page);
 
     QString proxyHost;
+    QString cookieFile;
     int proxyPort = 1080;
     bool autoLoadImages = true;
     bool pluginsEnabled = false;
@@ -128,6 +129,10 @@ Phantom::Phantom(QObject *parent)
             }
             continue;
         }
+        if (arg.startsWith("--cookies=")) {
+            cookieFile = arg.mid(10).trimmed();
+            continue;
+        }
         if (arg.startsWith("--")) {
             std::cerr << "Unknown option '" << qPrintable(arg) << "'" << std::endl;
             m_terminated = true;
@@ -157,7 +162,7 @@ Phantom::Phantom(QObject *parent)
     }
 
     // Provide WebPage with a non-standard Network Access Manager
-    m_netAccessMan = new NetworkAccessManager(this, diskCacheEnabled, ignoreSslErrors);
+    m_netAccessMan = new NetworkAccessManager(this, diskCacheEnabled, cookieFile, ignoreSslErrors);
     m_page->setNetworkAccessManager(m_netAccessMan);
 
     connect(m_page, SIGNAL(javaScriptConsoleMessageSent(QString, int, QString)),

--- a/src/phantomjs.pro
+++ b/src/phantomjs.pro
@@ -16,6 +16,7 @@ HEADERS += csconverter.h \
     consts.h \
     utils.h \
     networkaccessmanager.h \
+    cookiejar.h \
     filesystem.h
 SOURCES += phantom.cpp \
     webpage.cpp \
@@ -23,6 +24,7 @@ SOURCES += phantom.cpp \
     csconverter.cpp \
     utils.cpp \
     networkaccessmanager.cpp \
+    cookiejar.cpp \
     filesystem.cpp
 
 OTHER_FILES = bootstrap.js


### PR DESCRIPTION
This commit adds persistent cookie support using QNetworkCookieJar.

Cookies will be stored in a user supplied ini file using QSettings. The ini file has a clear layout and is easily editable.

Simply add --cookies=/path/to/your/cookies.ini to store and load cookies.
