### PR TITLE
Issue186 script and terminal encoding

### DIFF
--- a/src/csconverter.cpp
+++ b/src/csconverter.cpp
@@ -29,10 +29,10 @@
 
 #include "csconverter.h"
 
-#include <iostream>
-
 #include <QFile>
 #include <QWebFrame>
+
+#include "registry.h"
 
 // public:
 CSConverter::CSConverter(QObject *parent)
@@ -40,7 +40,7 @@ CSConverter::CSConverter(QObject *parent)
 {
     QFile file(":/coffee-script.js");
     if (!file.open(QFile::ReadOnly)) {
-        std::cerr << "CoffeeScript compiler is not available!" << std::endl;
+        Registry::terminal().cerr("CoffeeScript compiler is not available!");
         exit(1);
     }
     QString script = QString::fromUtf8(file.readAll());

--- a/src/encoding.cpp
+++ b/src/encoding.cpp
@@ -35,6 +35,11 @@ Encoding::Encoding()
     m_codec = QTextCodec::codecForLocale();
 }
 
+Encoding::Encoding(const QString &encoding)
+{
+    setEncoding(encoding);
+}
+
 Encoding::~Encoding()
 {
     m_codec = (QTextCodec *)NULL;
@@ -66,6 +71,8 @@ void Encoding::setEncoding(const QString &encoding)
         }
     }
 }
+
+const Encoding Encoding::UTF8 = Encoding("UTF-8");
 
 // private:
 QTextCodec *Encoding::getCodec() const

--- a/src/encoding.cpp
+++ b/src/encoding.cpp
@@ -1,0 +1,80 @@
+/*
+  This file is part of the PhantomJS project from Ofi Labs.
+
+  Copyright (C) 2011 Ariya Hidayat <ariya.hidayat@gmail.com>
+  Copyright (C) 2011 execjosh, http://execjosh.blogspot.com
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "encoding.h"
+
+Encoding::Encoding()
+{
+    m_codec = QTextCodec::codecForLocale();
+}
+
+Encoding::~Encoding()
+{
+    m_codec = (QTextCodec *)NULL;
+}
+
+QString Encoding::decode(const QByteArray &bytes) const
+{
+    return getCodec()->toUnicode(bytes);
+}
+
+QByteArray Encoding::encode(const QString &string) const
+{
+    return getCodec()->fromUnicode(string);
+}
+
+QString Encoding::getName() const
+{
+    // TODO Is it safe to assume UTF-8 here?
+    return QString::fromUtf8(getCodec()->name());
+}
+
+void Encoding::setEncoding(const QString &encoding)
+{
+    if (!encoding.isEmpty()) {
+        QTextCodec *codec = QTextCodec::codecForName(qPrintable(encoding));
+
+        if ((QTextCodec *)NULL != codec) {
+            m_codec = codec;
+        }
+    }
+}
+
+// private:
+QTextCodec *Encoding::getCodec() const
+{
+    QTextCodec *codec = m_codec;
+
+    if ((QTextCodec *)NULL == codec) {
+        codec = QTextCodec::codecForLocale();
+    }
+
+    return codec;
+}

--- a/src/encoding.h
+++ b/src/encoding.h
@@ -1,0 +1,54 @@
+/*
+  This file is part of the PhantomJS project from Ofi Labs.
+
+  Copyright (C) 2011 Ariya Hidayat <ariya.hidayat@gmail.com>
+  Copyright (C) 2011 execjosh, http://execjosh.blogspot.com
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef ENCODING_H
+#define ENCODING_H
+
+#include <QTextCodec>
+
+class Encoding
+{
+public:
+    Encoding();
+    ~Encoding();
+
+    QString decode(const QByteArray &bytes) const;
+    QByteArray encode(const QString &string) const;
+
+    QString getName() const;
+    void setEncoding(const QString &encoding);
+
+private:
+    QTextCodec *getCodec() const;
+
+    QTextCodec *m_codec;
+};
+
+#endif // ENCODING_H

--- a/src/encoding.h
+++ b/src/encoding.h
@@ -37,6 +37,7 @@ class Encoding
 {
 public:
     Encoding();
+    Encoding(const QString &encoding);
     ~Encoding();
 
     QString decode(const QByteArray &bytes) const;
@@ -44,6 +45,8 @@ public:
 
     QString getName() const;
     void setEncoding(const QString &encoding);
+
+    static const Encoding UTF8;
 
 private:
     QTextCodec *getCodec() const;

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -137,6 +137,10 @@ Phantom::Phantom(QObject *parent)
             Registry::terminal().setEncoding(arg.mid(18).trimmed());
             continue;
         }
+        if (arg.startsWith("--script-encoding=")) {
+            m_scriptFileEnc.setEncoding(arg.mid(18).trimmed());
+            continue;
+        }
         if (arg.startsWith("--")) {
             Registry::terminal().cerr(QString("Unknown option '%1'").arg(arg));
             m_terminated = true;
@@ -225,7 +229,7 @@ bool Phantom::execute()
     if (m_scriptFile.isEmpty())
         return false;
 
-    if (!Utils::injectJsInFrame(m_scriptFile, QDir::currentPath(), m_page->mainFrame(), true)) {
+    if (!Utils::injectJsInFrame(m_scriptFile, m_scriptFileEnc, QDir::currentPath(), m_page->mainFrame(), true)) {
         m_returnValue = -1;
         return false;
     }

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -133,6 +133,10 @@ Phantom::Phantom(QObject *parent)
             cookieFile = arg.mid(10).trimmed();
             continue;
         }
+        if (arg.startsWith("--output-encoding=")) {
+            Registry::terminal().setEncoding(arg.mid(18).trimmed());
+            continue;
+        }
         if (arg.startsWith("--")) {
             Registry::terminal().cerr(QString("Unknown option '%1'").arg(arg));
             m_terminated = true;

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -30,8 +30,6 @@
 
 #include "phantom.h"
 
-#include <iostream>
-
 #include <QtGui>
 #include <QtWebKit>
 #include <QDir>
@@ -41,6 +39,8 @@
 #include "consts.h"
 #include "utils.h"
 #include "webpage.h"
+
+#include "registry.h"
 
 // public:
 Phantom::Phantom(QObject *parent)
@@ -74,7 +74,7 @@ Phantom::Phantom(QObject *parent)
         const QString &arg = argIterator.next();
         if (arg == "--version") {
             m_terminated = true;
-            std::cout << PHANTOMJS_VERSION_STRING << " (development)" << std::endl;
+            Registry::terminal().cout(QString("%1 (development)").arg(PHANTOMJS_VERSION_STRING));
             return;
         }
         if (arg == "--load-images=yes") {
@@ -134,7 +134,7 @@ Phantom::Phantom(QObject *parent)
             continue;
         }
         if (arg.startsWith("--")) {
-            std::cerr << "Unknown option '" << qPrintable(arg) << "'" << std::endl;
+            Registry::terminal().cerr(QString("Unknown option '%1'").arg(arg));
             m_terminated = true;
             return;
         } else {
@@ -181,13 +181,13 @@ Phantom::Phantom(QObject *parent)
 
     QFile file(":/bootstrap.js");
     if (!file.open(QFile::ReadOnly)) {
-        std::cerr << "Can not bootstrap!" << std::endl;
+        Registry::terminal().cerr("Can not bootstrap!");
         exit(1);
     }
     QString bootstrapper = QString::fromUtf8(file.readAll());
     file.close();
     if (bootstrapper.isEmpty()) {
-        std::cerr << "Can not bootstrap!" << std::endl;
+        Registry::terminal().cerr("Can not bootstrap!");
         exit(1);
     }
     m_page->mainFrame()->evaluateJavaScript(bootstrapper);
@@ -284,5 +284,5 @@ void Phantom::printConsoleMessage(const QString &message, int lineNumber, const 
     QString msg = message;
     if (!source.isEmpty())
         msg = source + ":" + QString::number(lineNumber) + " " + msg;
-    std::cout << qPrintable(msg) << std::endl;
+    Registry::terminal().cout(msg);
 }

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -211,12 +211,12 @@ QVariantMap Phantom::defaultPageSettings() const
     return m_defaultPageSettings;
 }
 
-QString Phantom::encoding() const
+QString Phantom::outputEncoding() const
 {
     return Registry::terminal().getEncoding();
 }
 
-void Phantom::setEncoding(const QString &encoding)
+void Phantom::setOutputEncoding(const QString &encoding)
 {
     Registry::terminal().setEncoding(encoding);
 }

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -203,6 +203,16 @@ QVariantMap Phantom::defaultPageSettings() const
     return m_defaultPageSettings;
 }
 
+QString Phantom::encoding() const
+{
+    return Registry::terminal().getEncoding();
+}
+
+void Phantom::setEncoding(const QString &encoding)
+{
+    Registry::terminal().setEncoding(encoding);
+}
+
 bool Phantom::execute()
 {
     if (m_terminated)

--- a/src/phantom.h
+++ b/src/phantom.h
@@ -44,8 +44,8 @@ class Phantom: public QObject
     Q_OBJECT
     Q_PROPERTY(QStringList args READ args)
     Q_PROPERTY(QVariantMap defaultPageSettings READ defaultPageSettings)
-    Q_PROPERTY(QString encoding READ encoding WRITE setEncoding)
     Q_PROPERTY(QString libraryPath READ libraryPath WRITE setLibraryPath)
+    Q_PROPERTY(QString outputEncoding READ outputEncoding WRITE setOutputEncoding)
     Q_PROPERTY(QString scriptName READ scriptName)
     Q_PROPERTY(QVariantMap version READ version)
 
@@ -56,8 +56,8 @@ public:
 
     QVariantMap defaultPageSettings() const;
 
-    QString encoding() const;
-    void setEncoding(const QString &encoding);
+    QString outputEncoding() const;
+    void setOutputEncoding(const QString &encoding);
 
     bool execute();
     int returnValue() const;

--- a/src/phantom.h
+++ b/src/phantom.h
@@ -37,6 +37,7 @@ class WebPage;
 #include "csconverter.h"
 #include "networkaccessmanager.h"
 #include "filesystem.h"
+#include "encoding.h"
 
 class Phantom: public QObject
 {
@@ -79,6 +80,7 @@ private slots:
 
 private:
     QString m_scriptFile;
+    Encoding m_scriptFileEnc;
     QStringList m_args;
     WebPage *m_page;
     bool m_terminated;

--- a/src/phantom.h
+++ b/src/phantom.h
@@ -43,6 +43,7 @@ class Phantom: public QObject
     Q_OBJECT
     Q_PROPERTY(QStringList args READ args)
     Q_PROPERTY(QVariantMap defaultPageSettings READ defaultPageSettings)
+    Q_PROPERTY(QString encoding READ encoding WRITE setEncoding)
     Q_PROPERTY(QString libraryPath READ libraryPath WRITE setLibraryPath)
     Q_PROPERTY(QString scriptName READ scriptName)
     Q_PROPERTY(QVariantMap version READ version)
@@ -53,6 +54,9 @@ public:
     QStringList args() const;
 
     QVariantMap defaultPageSettings() const;
+
+    QString encoding() const;
+    void setEncoding(const QString &encoding);
 
     bool execute();
     int returnValue() const;

--- a/src/phantomjs.pro
+++ b/src/phantomjs.pro
@@ -19,6 +19,7 @@ HEADERS += csconverter.h \
     cookiejar.h \
     filesystem.h \
     terminal.h \
+    registry.h \
     encoding.h
 SOURCES += phantom.cpp \
     webpage.cpp \
@@ -29,6 +30,7 @@ SOURCES += phantom.cpp \
     cookiejar.cpp \
     filesystem.cpp \
     terminal.cpp \
+    registry.cpp \
     encoding.cpp
 
 OTHER_FILES = bootstrap.js

--- a/src/phantomjs.pro
+++ b/src/phantomjs.pro
@@ -18,6 +18,7 @@ HEADERS += csconverter.h \
     networkaccessmanager.h \
     cookiejar.h \
     filesystem.h \
+    terminal.h \
     encoding.h
 SOURCES += phantom.cpp \
     webpage.cpp \
@@ -27,6 +28,7 @@ SOURCES += phantom.cpp \
     networkaccessmanager.cpp \
     cookiejar.cpp \
     filesystem.cpp \
+    terminal.cpp \
     encoding.cpp
 
 OTHER_FILES = bootstrap.js

--- a/src/phantomjs.pro
+++ b/src/phantomjs.pro
@@ -17,7 +17,8 @@ HEADERS += csconverter.h \
     utils.h \
     networkaccessmanager.h \
     cookiejar.h \
-    filesystem.h
+    filesystem.h \
+    encoding.h
 SOURCES += phantom.cpp \
     webpage.cpp \
     main.cpp \
@@ -25,7 +26,8 @@ SOURCES += phantom.cpp \
     utils.cpp \
     networkaccessmanager.cpp \
     cookiejar.cpp \
-    filesystem.cpp
+    filesystem.cpp \
+    encoding.cpp
 
 OTHER_FILES = bootstrap.js
 

--- a/src/registry.cpp
+++ b/src/registry.cpp
@@ -1,0 +1,43 @@
+/*
+  This file is part of the PhantomJS project from Ofi Labs.
+
+  Copyright (C) 2011 Ariya Hidayat <ariya.hidayat@gmail.com>
+  Copyright (C) 2011 execjosh, http://execjosh.blogspot.com
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "registry.h"
+
+// public:
+Terminal &Registry::terminal() {
+    return INSTANCE.m_terminal;
+}
+
+// private:
+Registry::Registry()
+{
+}
+
+Registry Registry::INSTANCE;

--- a/src/registry.h
+++ b/src/registry.h
@@ -1,0 +1,50 @@
+/*
+  This file is part of the PhantomJS project from Ofi Labs.
+
+  Copyright (C) 2011 Ariya Hidayat <ariya.hidayat@gmail.com>
+  Copyright (C) 2011 execjosh, http://execjosh.blogspot.com
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef REGISTRY_H
+#define REGISTRY_H
+
+#include "terminal.h"
+
+class Registry
+{
+public:
+    static Terminal &terminal();
+
+private:
+    static Registry INSTANCE;
+
+private:
+    Registry();
+
+    Terminal m_terminal;
+};
+
+#endif // REGISTRY_H

--- a/src/terminal.cpp
+++ b/src/terminal.cpp
@@ -1,0 +1,71 @@
+/*
+  This file is part of the PhantomJS project from Ofi Labs.
+
+  Copyright (C) 2011 Ariya Hidayat <ariya.hidayat@gmail.com>
+  Copyright (C) 2011 execjosh, http://execjosh.blogspot.com
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "terminal.h"
+
+#include <iostream>
+
+Terminal::Terminal()
+{
+}
+
+Terminal::~Terminal()
+{
+}
+
+QString Terminal::getEncoding() const
+{
+    return m_encoding.getName();
+}
+
+void Terminal::setEncoding(const QString &encoding)
+{
+    m_encoding.setEncoding(encoding);
+}
+
+void Terminal::cout(const QString &string, const bool newline) const
+{
+    output(std::cout, string, newline);
+}
+
+void Terminal::cerr(const QString &string, const bool newline) const
+{
+    output(std::cerr, string, newline);
+}
+
+// private
+void Terminal::output(std::ostream &out, const QString &string, const bool newline) const
+{
+    out << m_encoding.encode(string).constData();
+    if (newline) {
+        out << std::endl;
+    }
+    out << std::flush;
+}

--- a/src/terminal.h
+++ b/src/terminal.h
@@ -1,0 +1,58 @@
+/*
+  This file is part of the PhantomJS project from Ofi Labs.
+
+  Copyright (C) 2011 Ariya Hidayat <ariya.hidayat@gmail.com>
+  Copyright (C) 2011 execjosh, http://execjosh.blogspot.com
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef CONSOLE_H
+#define CONSOLE_H
+
+#include <QString>
+#include <ostream>
+
+#include "encoding.h"
+
+class Terminal
+{
+public:
+    Terminal();
+    ~Terminal();
+
+    QString getEncoding() const;
+    void setEncoding(const QString &encoding);
+
+    void cout(const QString &string, const bool newline = true) const;
+    void cerr(const QString &string, const bool newline = true) const;
+
+private:
+    void output(std::ostream &out, const QString &string, const bool newline) const;
+
+private:
+    Encoding m_encoding;
+};
+
+#endif // CONSOLE_H

--- a/src/usage.txt
+++ b/src/usage.txt
@@ -10,3 +10,4 @@ Options:
     --ignore-ssl-errors=[yes|no]       Ignores SSL errors (i.e. expired or self-signed certificate errors).
     --local-access-remote=[yes|no]     Local content can access remote URL (default is 'no').
     --output-encoding                  Sets (if available) the encoding used for terminal output (default is 'utf8').
+    --script-encoding                  Sets (if available) the encoding used for the starting script (default is 'utf8').

--- a/src/usage.txt
+++ b/src/usage.txt
@@ -9,3 +9,4 @@ Options:
     --disk-cache=[yes|no]              Enables disk cache (at desktop services cache storage location, default is 'no').
     --ignore-ssl-errors=[yes|no]       Ignores SSL errors (i.e. expired or self-signed certificate errors).
     --local-access-remote=[yes|no]     Local content can access remote URL (default is 'no').
+    --output-encoding                  Sets (if available) the encoding used for terminal output (default is 'utf8').

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -27,7 +27,6 @@
   THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <iostream>
 #include <QFile>
 #include <QDebug>
 #include <QDateTime>
@@ -36,16 +35,18 @@
 #include "consts.h"
 #include "utils.h"
 
+#include "registry.h"
+
 // public:
 void Utils::showUsage()
 {
     QFile file;
     file.setFileName(":/usage.txt");
     if ( !file.open(QFile::ReadOnly) ) {
-        std::cerr << "Unable to print the usage message" << std::endl;
+        Registry::terminal().cerr("Unable to print the usage message");
         exit(1);
     }
-    std::cout << qPrintable(QString::fromUtf8(file.readAll()));
+    Registry::terminal().cout(QString::fromUtf8(file.readAll()));
     file.close();
 }
 
@@ -104,7 +105,7 @@ bool Utils::injectJsInFrame(const QString &jsFilePath, const QString &libraryPat
                 QVariant result = Utils::coffee2js(scriptBody);
                 if (result.toStringList().at(0) == "false") {
                     if (startingScript) {
-                        std::cerr << qPrintable(result.toStringList().at(1)) << std::endl;
+                        Registry::terminal().cerr(result.toStringList().at(1));
                         exit(1);
                     } else {
                         qWarning() << qPrintable(result.toStringList().at(1));
@@ -121,7 +122,7 @@ bool Utils::injectJsInFrame(const QString &jsFilePath, const QString &libraryPat
             return true;
         } else {
             if (startingScript) {
-                std::cerr << "Can't open '" << qPrintable(jsFilePath) << "'" << std::endl;
+                Registry::terminal().cerr(QString("Can't open '%1'").arg(jsFilePath));
             } else {
                 qWarning("Can't open '%s'", qPrintable(jsFilePath));
             }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -83,6 +83,11 @@ QVariant Utils::coffee2js(const QString &script)
 
 bool Utils::injectJsInFrame(const QString &jsFilePath, const QString &libraryPath, QWebFrame *targetFrame, const bool startingScript)
 {
+    return injectJsInFrame(jsFilePath, Encoding::UTF8, libraryPath, targetFrame, startingScript);
+}
+
+bool Utils::injectJsInFrame(const QString &jsFilePath, const Encoding &jsFileEnc, const QString &libraryPath, QWebFrame *targetFrame, const bool startingScript)
+{
     // Don't do anything if an empty string is passed
     if (!jsFilePath.isEmpty()) {
         QFile jsFile;
@@ -95,7 +100,7 @@ bool Utils::injectJsInFrame(const QString &jsFilePath, const QString &libraryPat
         }
 
         if ( jsFile.open(QFile::ReadOnly) ) {
-            QString scriptBody = QString::fromUtf8(jsFile.readAll());
+            QString scriptBody = jsFileEnc.decode(jsFile.readAll());
             // Remove CLI script heading
             if (scriptBody.startsWith("#!") && !jsFile.fileName().endsWith(COFFEE_SCRIPT_EXTENSION)) {
                 scriptBody.prepend("//");

--- a/src/utils.h
+++ b/src/utils.h
@@ -34,6 +34,7 @@
 #include <QWebFrame>
 
 #include "csconverter.h"
+#include "encoding.h"
 
 /**
  * Aggregate common utility functions.
@@ -47,6 +48,7 @@ public:
     static void messageHandler(QtMsgType type, const char *msg);
     static QVariant coffee2js(const QString &script);
     static bool injectJsInFrame(const QString &jsFilePath, const QString &libraryPath, QWebFrame *targetFrame, const bool startingScript = false);
+    static bool injectJsInFrame(const QString &jsFilePath, const Encoding &jsFileEnc, const QString &libraryPath, QWebFrame *targetFrame, const bool startingScript = false);
 
 private:
     Utils(); //< This class shouldn't be instantiated


### PR DESCRIPTION
Here is my implementation for the script and terminal encoding issue.

I added two new command-line options:
- `--output-encoding`;
- and, `--script-encoding`.

I also added the ability to set the output encoding on-the-fly from within the starting script.

``` javascript
// For example, start with UTF-8
phantom.outputEncoding = "utf8";
// ...
// Then, some time later switch to Shift-JIS
phantom.outputEncoding = "sjis";
```
