### PR TITLE
Fix issue 128 and 193

### DIFF
--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -60,6 +60,7 @@ public:
         , m_webPage(parent)
     {
         m_userAgent = QWebPage::userAgentForUrl(QUrl());
+        setForwardUnsupportedContent(true);
     }
 
 public slots:


### PR DESCRIPTION
See:
http://code.google.com/p/phantomjs/issues/detail?id=128
http://code.google.com/p/phantomjs/issues/detail?id=193

Allows PhantomJS to read a page that doesn't return a Content-Type header.
