### PR TITLE
[BUGFIX] issue 194: make default encoding UTF-8

### DIFF
--- a/src/encoding.cpp
+++ b/src/encoding.cpp
@@ -32,7 +32,14 @@
 
 Encoding::Encoding()
 {
-    m_codec = QTextCodec::codecForLocale();
+    QTextCodec *codec = QTextCodec::codecForName(DEFAULT_CODEC_NAME);
+
+    // Fall back to locale codec
+    if ((QTextCodec *)NULL == codec) {
+        codec = QTextCodec::codecForLocale();
+    }
+
+    m_codec = codec;
 }
 
 Encoding::Encoding(const QString &encoding)
@@ -85,3 +92,5 @@ QTextCodec *Encoding::getCodec() const
 
     return codec;
 }
+
+const QByteArray Encoding::DEFAULT_CODEC_NAME = "UTF-8";

--- a/src/encoding.h
+++ b/src/encoding.h
@@ -52,6 +52,7 @@ private:
     QTextCodec *getCodec() const;
 
     QTextCodec *m_codec;
+    static const QByteArray DEFAULT_CODEC_NAME;
 };
 
 #endif // ENCODING_H

--- a/test/phantom-spec.js
+++ b/test/phantom-spec.js
@@ -40,8 +40,8 @@ describe("phantom global object", function() {
         expect(phantom.hasOwnProperty('outputEncoding')).toBeTruthy();
     });
 
-    it("should have the default outputEncoding to System", function() {
-        expect(phantom.outputEncoding).toEqual('System');
+    it("should have the default outputEncoding of UTF-8", function() {
+        expect(phantom.outputEncoding).toEqual('UTF-8');
     });
 
     it("should have version property", function() {


### PR DESCRIPTION
Fix for bug identified by [issue 194](http://code.google.com/p/phantomjs/issues/detail?id=194).
