### PR TITLE
Add examples for phantom.outputEncoding

### DIFF
--- a/examples/outputEncoding.coffee
+++ b/examples/outputEncoding.coffee
@@ -1,0 +1,12 @@
+helloWorld = () -> console.log phantom.outputEncoding + ": こんにちは、世界！"
+
+console.log "Using default encoding..."
+helloWorld()
+
+console.log "\nUsing other encodings..."
+for enc in ["euc-jp", "sjis", "utf8", "System"]
+  do (enc) ->
+    phantom.outputEncoding = enc
+    helloWorld()
+
+phantom.exit()

--- a/examples/outputEncoding.js
+++ b/examples/outputEncoding.js
@@ -1,0 +1,16 @@
+function helloWorld() {
+	console.log(phantom.outputEncoding + ": こんにちは、世界！");
+}
+
+console.log("Using default encoding...");
+helloWorld();
+
+console.log("\nUsing other encodings...");
+
+var encodings = ["euc-jp", "sjis", "utf8", "System"];
+for (var i = 0; i < encodings.length; i++) {
+    phantom.outputEncoding = encodings[i];
+    helloWorld();
+}
+
+phantom.exit()


### PR DESCRIPTION
I added examples for phantom.outputEncoding as had been requested in [issue186](http://code.google.com/p/phantomjs/issues/detail?id=186#c10).
