### PR TITLE
Env vars for encodings

### DIFF
--- a/src/consts.h
+++ b/src/consts.h
@@ -55,4 +55,7 @@
 #define PAGE_SETTINGS_USER_AGENT            "userAgent"
 #define PAGE_SETTINGS_LOCAL_ACCESS_REMOTE   "localAccessRemote"
 
+#define ENVVAR_OUTPUT_ENCODING              "PHANTOMJS_OUTPUT_ENCODING"
+#define ENVVAR_SCRIPT_ENCODING              "PHANTOMJS_SCRIPT_ENCODING"
+
 #endif // CONSTS_H

--- a/src/consts.h
+++ b/src/consts.h
@@ -55,7 +55,4 @@
 #define PAGE_SETTINGS_USER_AGENT            "userAgent"
 #define PAGE_SETTINGS_LOCAL_ACCESS_REMOTE   "localAccessRemote"
 
-#define ENVVAR_OUTPUT_ENCODING              "PHANTOMJS_OUTPUT_ENCODING"
-#define ENVVAR_SCRIPT_ENCODING              "PHANTOMJS_SCRIPT_ENCODING"
-
 #endif // CONSTS_H

--- a/src/envvars.h
+++ b/src/envvars.h
@@ -1,0 +1,9 @@
+#ifndef ENVVARS_H
+#define ENVVARS_H
+
+#define ENVVAR(x)                           (getenv("PHANTOMJS_" x))
+
+#define ENVVAR_OUTPUT_ENCODING              ENVVAR("OUTPUT_ENCODING")
+#define ENVVAR_SCRIPT_ENCODING              ENVVAR("SCRIPT_ENCODING")
+
+#endif // ENVVARS_H

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -61,6 +61,9 @@ Phantom::Phantom(QObject *parent)
     bool ignoreSslErrors = false;
     bool localAccessRemote = false;
 
+    // Pull defaults from environment variables
+    processEnvVars();
+
     // second argument: script name
     QStringList args = QApplication::arguments();
 
@@ -302,6 +305,11 @@ void Phantom::printConsoleMessage(const QString &message, int lineNumber, const 
 }
 
 // private:
+void Phantom::processEnvVars() {
+    setOutputEncoding(getenv(ENVVAR_OUTPUT_ENCODING));
+    setScriptEncoding(getenv(ENVVAR_SCRIPT_ENCODING));
+}
+
 void Phantom::setScriptEncoding(const QString &encoding) {
     m_scriptFileEnc.setEncoding(encoding);
 }

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -40,6 +40,7 @@
 #include "terminal.h"
 #include "utils.h"
 #include "webpage.h"
+#include "envvars.h"
 
 
 // public:
@@ -306,8 +307,8 @@ void Phantom::printConsoleMessage(const QString &message, int lineNumber, const 
 
 // private:
 void Phantom::processEnvVars() {
-    setOutputEncoding(getenv(ENVVAR_OUTPUT_ENCODING));
-    setScriptEncoding(getenv(ENVVAR_SCRIPT_ENCODING));
+    setOutputEncoding(ENVVAR_OUTPUT_ENCODING);
+    setScriptEncoding(ENVVAR_SCRIPT_ENCODING);
 }
 
 void Phantom::setScriptEncoding(const QString &encoding) {

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -133,11 +133,11 @@ Phantom::Phantom(QObject *parent)
             continue;
         }
         if (arg.startsWith("--output-encoding=")) {
-            Terminal::instance()->setEncoding(arg.mid(18).trimmed());
+            setOutputEncoding(arg.mid(18).trimmed());
             continue;
         }
         if (arg.startsWith("--script-encoding=")) {
-            m_scriptFileEnc.setEncoding(arg.mid(18).trimmed());
+            setScriptEncoding(arg.mid(18).trimmed());
             continue;
         }
         if (arg.startsWith("--")) {
@@ -299,4 +299,9 @@ void Phantom::printConsoleMessage(const QString &message, int lineNumber, const 
     if (!source.isEmpty())
         msg = source + ":" + QString::number(lineNumber) + " " + msg;
     Terminal::instance()->cout(msg);
+}
+
+// private:
+void Phantom::setScriptEncoding(const QString &encoding) {
+    m_scriptFileEnc.setEncoding(encoding);
 }

--- a/src/phantom.h
+++ b/src/phantom.h
@@ -78,6 +78,8 @@ private slots:
     void printConsoleMessage(const QString &msg, int lineNumber, const QString &source);
 
 private:
+    void setScriptEncoding(const QString &encoding);
+
     QString m_scriptFile;
     Encoding m_scriptFileEnc;
     QStringList m_args;

--- a/src/phantom.h
+++ b/src/phantom.h
@@ -78,6 +78,7 @@ private slots:
     void printConsoleMessage(const QString &msg, int lineNumber, const QString &source);
 
 private:
+    void processEnvVars();
     void setScriptEncoding(const QString &encoding);
 
     QString m_scriptFile;

--- a/src/phantomjs.pro
+++ b/src/phantomjs.pro
@@ -20,7 +20,8 @@ HEADERS += csconverter.h \
     cookiejar.h \
     filesystem.h \
     terminal.h \
-    encoding.h
+    encoding.h \
+    envvars.h
 SOURCES += phantom.cpp \
     webpage.cpp \
     main.cpp \


### PR DESCRIPTION
I added two environment variables, namely _PHANTOMJS_OUTPUT_ENCODING_ and _PHANTOMJS_SCRIPT_ENCODING_. They are useful for setting defaults, which can then be overridden via the command-line options.
