### PR TITLE
Maximum disk cache size parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ debian/*.substvars
 debian/*/
 python/build/
 python/*.egg-info/
+/nbproject/private/
+/nbproject/
+.gitignore

--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -65,7 +65,7 @@ static const char *toString(QNetworkAccessManager::Operation op)
 }
 
 // public:
-NetworkAccessManager::NetworkAccessManager(QObject *parent, bool diskCacheEnabled, QString cookieFile, bool ignoreSslErrors)
+NetworkAccessManager::NetworkAccessManager(QObject *parent, bool diskCacheEnabled, QString cookieFile, bool ignoreSslErrors, qint64 maxCacheSize)
     : QNetworkAccessManager(parent)
     , m_networkDiskCache(0)
     , m_ignoreSslErrors(ignoreSslErrors)
@@ -78,6 +78,7 @@ NetworkAccessManager::NetworkAccessManager(QObject *parent, bool diskCacheEnable
     if (diskCacheEnabled) {
         m_networkDiskCache = new QNetworkDiskCache();
         m_networkDiskCache->setCacheDirectory(QDesktopServices::storageLocation(QDesktopServices::CacheLocation));
+        m_networkDiskCache->setMaximumCacheSize(maxCacheSize);
         setCache(m_networkDiskCache);
     }
     connect(this, SIGNAL(finished(QNetworkReply*)), SLOT(handleFinished(QNetworkReply*)));

--- a/src/networkaccessmanager.h
+++ b/src/networkaccessmanager.h
@@ -42,7 +42,7 @@ class NetworkAccessManager : public QNetworkAccessManager
     Q_OBJECT
     QNetworkDiskCache* m_networkDiskCache;
 public:
-    NetworkAccessManager(QObject *parent = 0, bool diskCacheEnabled = false, QString cookieFile = "", bool ignoreSslErrors = false);
+    NetworkAccessManager(QObject *parent = 0, bool diskCacheEnabled = false, QString cookieFile = "", bool ignoreSslErrors = false, qint64 maxCacheSize = (qint64)104857600);
     virtual ~NetworkAccessManager();
 
 protected:

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -60,6 +60,7 @@ Phantom::Phantom(QObject *parent)
     bool diskCacheEnabled = false;
     bool ignoreSslErrors = false;
     bool localAccessRemote = false;
+    qint64 maxCacheSize = 104857600;
 
     // second argument: script name
     QStringList args = QApplication::arguments();
@@ -98,6 +99,10 @@ Phantom::Phantom(QObject *parent)
         }
         if (arg == "--disk-cache=no") {
             diskCacheEnabled = false;
+            continue;
+        }
+        if (arg.startsWith("--max-disk-cache-size=")) {
+            maxCacheSize = arg.mid(arg.indexOf("=") + 1).trimmed().toLongLong();
             continue;
         }
         if (arg == "--ignore-ssl-errors=yes") {
@@ -169,7 +174,7 @@ Phantom::Phantom(QObject *parent)
     }
 
     // Provide WebPage with a non-standard Network Access Manager
-    m_netAccessMan = new NetworkAccessManager(this, diskCacheEnabled, cookieFile, ignoreSslErrors);
+    m_netAccessMan = new NetworkAccessManager(this, diskCacheEnabled, cookieFile, ignoreSslErrors, maxCacheSize);
     m_page->setNetworkAccessManager(m_netAccessMan);
 
     connect(m_page, SIGNAL(javaScriptConsoleMessageSent(QString, int, QString)),


### PR DESCRIPTION
Added --max-disk-cache-size=maxsize option. Useful if default disk cache limit is not acceptable.
