### PR TITLE
Added HTTP Basic authentication support

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -104,6 +104,15 @@ void Config::processArgs(const QStringList &args)
             setProxy(arg.mid(8).trimmed());
             continue;
         }
+        if (arg.startsWith("--auth=")) {
+            QString credentials = arg.mid(7).trimmed();
+            if (credentials.startsWith('"') && credentials.endsWith('"'))
+            {
+               QString credentials = credentials.mid(1, credentials.length()-2);
+            }
+            setAuth(credentials);
+            continue;
+        }
         if (arg.startsWith("--cookies=")) {
             setCookieFile(arg.mid(10).trimmed());
             continue;
@@ -276,6 +285,35 @@ int Config::proxyPort() const
     return m_proxyPort;
 }
 
+QString Config::auth() const
+{
+    return authUser() + ":" + authPass();
+}
+
+void Config::setAuth(const QString &value)
+{
+    QString authUser = value;
+    QString authPass = "";
+
+    if (authUser.lastIndexOf(':') > 0) {
+        authPass = authUser.mid(authUser.lastIndexOf(':') + 1).trimmed();
+        authUser = authUser.left(authUser.lastIndexOf(':')).trimmed();
+    }
+
+    setAuthUser(authUser);
+    setAuthPass(authPass);
+}
+
+QString Config::authUser() const
+{
+    return m_authUser;
+}
+
+QString Config::authPass() const
+{
+    return m_authPass;
+}
+
 QStringList Config::scriptArgs() const
 {
     return m_scriptArgs;
@@ -352,6 +390,8 @@ void Config::resetToDefaults()
     m_scriptFile.clear();
     m_unknownOption.clear();
     m_versionFlag = false;
+    m_authUser.clear();
+    m_authPass.clear();
 }
 
 void Config::setProxyHost(const QString &value)
@@ -362,6 +402,16 @@ void Config::setProxyHost(const QString &value)
 void Config::setProxyPort(const int value)
 {
     m_proxyPort = value;
+}
+
+void Config::setAuthUser(const QString &value)
+{
+    m_authUser = value;
+}
+
+void Config::setAuthPass(const QString &value)
+{
+    m_authPass = value;
 }
 
 // private: (static)

--- a/src/config.h
+++ b/src/config.h
@@ -44,6 +44,7 @@ class Config: QObject
     Q_PROPERTY(QString outputEncoding READ outputEncoding WRITE setOutputEncoding)
     Q_PROPERTY(bool pluginsEnabled READ pluginsEnabled WRITE setPluginsEnabled)
     Q_PROPERTY(QString proxy READ proxy WRITE setProxy)
+    Q_PROPERTY(QString auth READ auth WRITE setAuth)
     Q_PROPERTY(QString scriptEncoding READ scriptEncoding WRITE setScriptEncoding)
 
 public:
@@ -79,6 +80,11 @@ public:
     QString proxyHost() const;
     int proxyPort() const;
 
+    QString auth() const;
+    void setAuth(const QString &value);
+    QString authUser() const;
+    QString authPass() const;
+
     QStringList scriptArgs() const;
     void setScriptArgs(const QStringList &value);
 
@@ -98,6 +104,8 @@ private:
     void resetToDefaults();
     void setProxyHost(const QString &value);
     void setProxyPort(const int value);
+    void setAuthUser(const QString &value);
+    void setAuthPass(const QString &value);
 
     bool m_autoLoadImages;
     QString m_cookieFile;
@@ -113,6 +121,8 @@ private:
     QString m_scriptFile;
     QString m_unknownOption;
     bool m_versionFlag;
+    QString m_authUser;
+    QString m_authPass;
 
 private:
     static QString normalisePath(const QString &path);

--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -40,7 +40,6 @@
 #include "networkreplyproxy.h"
 #include "cookiejar.h"
 
-#include "terminal.h"
 static const char *toString(QNetworkAccessManager::Operation op)
 {
     const char *str = 0;

--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -34,11 +34,13 @@
 #include <QNetworkRequest>
 #include <QNetworkReply>
 #include <QNetworkDiskCache>
+#include <QAuthenticator>
 
 #include "networkaccessmanager.h"
 #include "networkreplyproxy.h"
 #include "cookiejar.h"
 
+#include "terminal.h"
 static const char *toString(QNetworkAccessManager::Operation op)
 {
     const char *str = 0;
@@ -66,10 +68,12 @@ static const char *toString(QNetworkAccessManager::Operation op)
 }
 
 // public:
-NetworkAccessManager::NetworkAccessManager(QObject *parent, bool diskCacheEnabled, QString cookieFile, bool ignoreSslErrors)
+NetworkAccessManager::NetworkAccessManager(QObject *parent, bool diskCacheEnabled, QString cookieFile, bool ignoreSslErrors, QString authUser, QString authPass)
     : QNetworkAccessManager(parent)
     , m_networkDiskCache(0)
     , m_ignoreSslErrors(ignoreSslErrors)
+    , m_authUser(authUser)
+    , m_authPass(authPass)
     , m_idCounter(0)
 {
     if (!cookieFile.isEmpty()) {
@@ -81,6 +85,8 @@ NetworkAccessManager::NetworkAccessManager(QObject *parent, bool diskCacheEnable
         m_networkDiskCache->setCacheDirectory(QDesktopServices::storageLocation(QDesktopServices::CacheLocation));
         setCache(m_networkDiskCache);
     }
+
+    connect(this, SIGNAL(authenticationRequired(QNetworkReply*,QAuthenticator*)), SLOT(provideAuthenication(QNetworkReply*,QAuthenticator*)));
     connect(this, SIGNAL(finished(QNetworkReply*)), SLOT(handleFinished(QNetworkReply*)));
 }
 
@@ -184,4 +190,10 @@ void NetworkAccessManager::handleFinished(QNetworkReply *reply)
     m_started.remove(reply);
 
     emit resourceReceived(data);
+}
+
+void NetworkAccessManager::provideAuthenication(QNetworkReply *reply, QAuthenticator *ator)
+{
+    ator->setUser(m_authUser);
+    ator->setPassword(m_authPass);
 }

--- a/src/networkaccessmanager.h
+++ b/src/networkaccessmanager.h
@@ -34,6 +34,7 @@
 #include <QHash>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
+#include <QAuthenticator>
 #include <QSet>
 
 class QNetworkDiskCache;
@@ -43,11 +44,13 @@ class NetworkAccessManager : public QNetworkAccessManager
     Q_OBJECT
     QNetworkDiskCache* m_networkDiskCache;
 public:
-    NetworkAccessManager(QObject *parent = 0, bool diskCacheEnabled = false, QString cookieFile = "", bool ignoreSslErrors = false);
+    NetworkAccessManager(QObject *parent = 0, bool diskCacheEnabled = false, QString cookieFile = "", bool ignoreSslErrors = false, QString authUser = "", QString authPass = "");
     virtual ~NetworkAccessManager();
 
 protected:
     bool m_ignoreSslErrors;
+    QString m_authUser;
+    QString m_authPass;
     QNetworkReply *createRequest(Operation op, const QNetworkRequest & req, QIODevice * outgoingData = 0);
 
 signals:
@@ -57,6 +60,7 @@ signals:
 private slots:
     void handleStarted();
     void handleFinished(QNetworkReply *reply);
+    void provideAuthenication(QNetworkReply *reply, QAuthenticator *ator);
 
 private:
     QHash<QNetworkReply*, int> m_ids;

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -91,7 +91,7 @@ Phantom::Phantom(QObject *parent)
     m_scriptFileEnc.setEncoding(m_config.scriptEncoding());
 
     // Provide WebPage with a non-standard Network Access Manager
-    m_netAccessMan = new NetworkAccessManager(this, m_config.diskCacheEnabled(), m_config.cookieFile(), m_config.ignoreSslErrors());
+    m_netAccessMan = new NetworkAccessManager(this, m_config.diskCacheEnabled(), m_config.cookieFile(), m_config.ignoreSslErrors(), m_config.authUser(), m_config.authPass());
     m_page->setNetworkAccessManager(m_netAccessMan);
 
     connect(m_page, SIGNAL(javaScriptConsoleMessageSent(QString, int, QString)),

--- a/src/usage.txt
+++ b/src/usage.txt
@@ -7,6 +7,7 @@ Options:
     --load-images=[yes|no]             Loads all inlined images (default is 'yes').
     --load-plugins=[yes|no]            Loads all plugins (i.e. 'Flash', 'Silverlight', ...) (default is 'no').
     --proxy=address:port               Sets the network proxy (e.g. "--proxy=http://192.168.1.42:8080").
+    --auth=username:password           Sets the authentication username and password (e.g. "--auth=username:password").
     --disk-cache=[yes|no]              Enables disk cache (at desktop services cache storage location, default is 'no').
     --ignore-ssl-errors=[yes|no]       Ignores SSL errors (i.e. expired or self-signed certificate errors).
     --local-access-remote=[yes|no]     Local content can access remote URL (default is 'no').


### PR DESCRIPTION
I've added http basic auth support to networkaccessmanager using the authenticationRequired signal. I also aded the ability to pass the auth credentials in from the command line with --auth=user:pass
