### PR TITLE
Change comment in run-jasmine example to be consistent with the way the c

### DIFF
--- a/examples/run-jasmine.js
+++ b/examples/run-jasmine.js
@@ -30,7 +30,7 @@ function waitFor(testFx, onReady, timeOutMillis) {
                     clearInterval(interval); //< Stop this interval
                 }
             }
-        }, 100); //< repeat check every 250ms
+        }, 100); //< repeat check every 100ms
 };
 
 


### PR DESCRIPTION
Change comment in run-jasmine example to be consistent with the way the code is written
