### PR TITLE
used QUrl::fromEncoded() and QUrl::toEncoded() instead of QUrl(string) and QUrl::toString() when converting QUrl from/to string

### DIFF
--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -120,7 +120,7 @@ QNetworkReply *NetworkAccessManager::createRequest(Operation op, const QNetworkR
 
     QVariantMap data;
     data["id"] = m_idCounter;
-    data["url"] = req.url().toString();
+    data["url"] = req.url().toEncoded().data();
     data["method"] = toString(op);
     data["headers"] = headers;
     data["time"] = QDateTime::currentDateTime();
@@ -152,7 +152,7 @@ void NetworkAccessManager::handleStarted()
     QVariantMap data;
     data["stage"] = "start";
     data["id"] = m_ids.value(reply);
-    data["url"] = reply->url().toString();
+    data["url"] = reply->url().toEncoded().data();
     data["status"] = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute);
     data["statusText"] = reply->attribute(QNetworkRequest::HttpReasonPhraseAttribute);
     data["contentType"] = reply->header(QNetworkRequest::ContentTypeHeader);
@@ -177,7 +177,7 @@ void NetworkAccessManager::handleFinished(QNetworkReply *reply)
     QVariantMap data;
     data["stage"] = "end";
     data["id"] = m_ids.value(reply);
-    data["url"] = reply->url().toString();
+    data["url"] = reply->url().toEncoded().data();
     data["status"] = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute);
     data["statusText"] = reply->attribute(QNetworkRequest::HttpReasonPhraseAttribute);
     data["contentType"] = reply->header(QNetworkRequest::ContentTypeHeader);

--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -120,7 +120,7 @@ QNetworkReply *NetworkAccessManager::createRequest(Operation op, const QNetworkR
 
     QVariantMap data;
     data["id"] = m_idCounter;
-    data["url"] = req.url().toEncoded().data();
+    data["url"] = req.url().toString();
     data["method"] = toString(op);
     data["headers"] = headers;
     data["time"] = QDateTime::currentDateTime();
@@ -152,7 +152,7 @@ void NetworkAccessManager::handleStarted()
     QVariantMap data;
     data["stage"] = "start";
     data["id"] = m_ids.value(reply);
-    data["url"] = reply->url().toEncoded().data();
+    data["url"] = reply->url().toString();
     data["status"] = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute);
     data["statusText"] = reply->attribute(QNetworkRequest::HttpReasonPhraseAttribute);
     data["contentType"] = reply->header(QNetworkRequest::ContentTypeHeader);
@@ -177,7 +177,7 @@ void NetworkAccessManager::handleFinished(QNetworkReply *reply)
     QVariantMap data;
     data["stage"] = "end";
     data["id"] = m_ids.value(reply);
-    data["url"] = reply->url().toEncoded().data();
+    data["url"] = reply->url().toString();
     data["status"] = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute);
     data["statusText"] = reply->attribute(QNetworkRequest::HttpReasonPhraseAttribute);
     data["contentType"] = reply->header(QNetworkRequest::ContentTypeHeader);

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -343,7 +343,8 @@ void WebPage::openUrl(const QString &address, const QVariant &op, const QVariant
     if (address == "about:blank") {
         m_mainFrame->setHtml(BLANK_HTML);
     } else {
-        m_mainFrame->load(QNetworkRequest(QUrl(address)), networkOp, body);
+        QUrl url = QUrl::fromEncoded(QByteArray(address.toAscii()));
+        m_mainFrame->load(QNetworkRequest(url), networkOp, body);
     }
 }
 


### PR DESCRIPTION
test code:

``` javascript
var url = 'http://twitter.com/';
var page = require('webpage').create();
page.onLoadFinished = phantom.exit;
page.onResourceRequested = function(e) {
    /scribe.twitter.com/.test(e.url) && console.log(e.url);
}
page.open(url);
```

the correct output should be:
http://scribe.twitter.com/scribe?category=client_event&log=%7B%22context%22%3A%22front%22%2C%22event_name%22%3A%22web%3Afront%3A%3A%3Aimpression%22%7D&ts=1322214294414

current output is human-readable but not correct for further use: 
http://scribe.twitter.com/scribe?category=client_event&log={"context":"front","event_name":"web:front:::impression"}&ts=1322214294414

the modifications fixed this bug.
