### PR TITLE
Passed test results failed count as exit code

### DIFF
--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -73,7 +73,7 @@ jasmineEnv.addReporter(new jasmine.ConsoleReporter(function(msg){
     console.log(msg.replace('\n', ''));
 }, function(reporter){
     // On complete
-    phantom.exit();
+    phantom.exit(reporter.results().failedCount);
 }, true));
 
 // Launch tests


### PR DESCRIPTION
I needed to automate the tests and I couldn't get a non-zero exit code from the run-tests.js in the event of a failure.
This way the number of failed tests is passed as an exit code.
If all tests pass the exit code will be 0, if not it will be the number of failed tests.
