### PR TITLE
1.4 windows link fix

### DIFF
--- a/src/mongoose/mongoose.pri
+++ b/src/mongoose/mongoose.pri
@@ -4,3 +4,4 @@ INCLUDEPATH += $$PWD
 SOURCES += mongoose.c
 HEADERS += mongoose.h
 unix:LIBS += -ldl
+win32:LIBS += -lWs2_32


### PR DESCRIPTION
mongoose needs symbols from Ws2_32.lib
