### PR TITLE
Add conventional "--help" option

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -58,6 +58,10 @@ void Config::processArgs(const QStringList &args)
     while (it.hasNext()) {
         const QString &arg = it.next();
 
+        if (arg == "--help") {
+            setHelpFlag(true);
+            return;
+        }
         if (arg == "--version") {
             setVersionFlag(true);
             return;
@@ -411,6 +415,7 @@ void Config::resetToDefaults()
     m_versionFlag = false;
     m_debug = false;
     m_remoteDebugPort = -1;
+    m_helpFlag = false;
 }
 
 void Config::setProxyHost(const QString &value)
@@ -421,4 +426,14 @@ void Config::setProxyHost(const QString &value)
 void Config::setProxyPort(const int value)
 {
     m_proxyPort = value;
+}
+
+bool Config::helpFlag() const
+{
+    return m_helpFlag;
+}
+
+void Config::setHelpFlag(const bool value)
+{
+    m_helpFlag = value;
 }

--- a/src/config.h
+++ b/src/config.h
@@ -108,6 +108,10 @@ public:
 
     void setRemoteDebugPort(const int port);
     int remoteDebugPort() const;
+
+    bool helpFlag() const;
+    void setHelpFlag(const bool value);
+
 private:
     void resetToDefaults();
     void setProxyHost(const QString &value);
@@ -135,6 +139,7 @@ private:
     QString m_authPass;
     bool m_debug;
     int m_remoteDebugPort;
+    bool m_helpFlag;
 };
 
 #endif // CONFIG_H

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -58,6 +58,12 @@ Phantom::Phantom(QObject *parent)
 
     m_config.init(&args);
 
+    if (m_config.helpFlag()) {
+        m_terminated = true;
+        Utils::showUsage();
+        return;
+    }
+
     if (m_config.versionFlag()) {
         m_terminated = true;
         Terminal::instance()->cout(QString("%1 (development)").arg(PHANTOMJS_VERSION_STRING));

--- a/src/usage.txt
+++ b/src/usage.txt
@@ -6,6 +6,7 @@ Options:
 --cookies-file=/path/to/cookies.txt    Sets the file name to store the persistent cookies
 --config=/path/to/config               Specifies path to a JSON-formatted config file
 --disk-cache=[yes|no]                  Enables disk cache (at desktop services cache storage location, default is 'no')
+--help                                 Shows this message and quits
 --ignore-ssl-errors=[yes|no]           Ignores SSL errors (i.e. expired or self-signed certificate errors)
 --load-images=[yes|no]                 Loads all inlined images (default is 'yes')
 --load-plugins=[yes|no]                Loads all plugins (i.e. 'Flash', 'Silverlight', ...) (default is 'no')


### PR DESCRIPTION
Most command-line programs provide an option to display the usage
message.  Currently, this is achieved by passing no options at all.
This change allows for a more intuitive way for users to check the
list of available options.
