### PR TITLE
Fix fs module absolute path test on Windows

### DIFF
--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -357,6 +357,16 @@ QString FileSystem::absolute(const QString &relativePath) const
     return QFileInfo(relativePath).absoluteFilePath();
 }
 
+QString FileSystem::fromNativeSeparators(const QString &path) const
+{
+    return QDir::fromNativeSeparators(path);
+}
+
+QString FileSystem::toNativeSeparators(const QString &path) const
+{
+    return QDir::toNativeSeparators(path);
+}
+
 // Files
 QObject *FileSystem::_open(const QString &path, const QVariantMap &opts) const
 {
@@ -477,4 +487,6 @@ void FileSystem::initCompletions()
     addCompletion("copy");
     addCompletion("move");
     addCompletion("touch");
+    addCompletion("join");
+    addCompletion("split");
 }

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -115,6 +115,10 @@ public slots:
     QString workingDirectory() const;
     bool changeWorkingDirectory(const QString &path) const;
     QString absolute(const QString &relativePath) const;
+    // 'join(...)' implemented in "fs.js"
+    // 'split(path)' implemented in "fs.js"
+    QString fromNativeSeparators(const QString &path) const;
+    QString toNativeSeparators(const QString &path) const;
 
     // Links
     QString readLink(const QString &path) const;

--- a/src/modules/fs.js
+++ b/src/modules/fs.js
@@ -223,3 +223,46 @@ exports.removeTree = function (path) {
 exports.touch = function (path) {
     exports.write(path, "", 'a');
 };
+
+// Path stuff
+
+exports.join = function() {
+    var args = [];
+
+    if (0 < arguments.length) {
+        args = args.slice.call(arguments, 0)
+            // Make sure each part is a string and remove empty parts (except at begining)
+            .map(function (part, idx) {
+                if (null != part) {
+                    var str = part.toString();
+                    if ("" === str) {
+                        return 0 === idx ? "" : null;
+                    } else {
+                        return str;
+                    }
+                }
+            })
+            // Remove empty parts
+            .filter(function (part) {
+                return null != part;
+            });
+    }
+
+    var ret = args.join("/");
+
+    return 0 < ret.length ? ret : ".";
+};
+
+exports.split = function (path) {
+    if (typeof path !== "string") {
+        return [];
+    }
+
+    return exports.fromNativeSeparators(path)
+        // Collapse redundant separators
+        .replace(/\/+/g, "/")
+        // Remove separator at end
+        .replace(/\/$/, "")
+        // And split
+        .split("/")
+};

--- a/test/fs-spec-03.js
+++ b/test/fs-spec-03.js
@@ -10,7 +10,7 @@ describe("Files and Directories API", function() {
 
 	it("should create a file in the Current Working Directory and check it's absolute path", function() {
 		fs.write(TEST_FILE, TEST_FILE, "w");
-		var suffix = fs.separator + TEST_DIR + fs.separator +  TEST_FILE,
+		var suffix = fs.join("", TEST_DIR, TEST_FILE),
 			abs = fs.absolute(".." + suffix),
 			lastIndex = abs.lastIndexOf(suffix);
 		expect(lastIndex).toNotEqual(-1);

--- a/test/fs-spec-03.js
+++ b/test/fs-spec-03.js
@@ -35,4 +35,103 @@ describe("Files and Directories API", function() {
     });
 
     fs.removeTree(TEST_DIR);
+
+    describe("fs.join(...)", function() {
+      var parts, expected, actual;
+
+      it("empty parts", function() {
+        parts = [];
+        expected = ".";
+        actual = fs.join.apply(null, parts);
+        expect(actual).toEqual(expected);
+      });
+
+      it("one part (empty string)", function() {
+        parts = [""];
+        expected = ".";
+        actual = fs.join.apply(null, parts);
+        expect(actual).toEqual(expected);
+      });
+
+      it("one part (array)", function() {
+        parts = [[], null];
+        expected = ".";
+        actual = fs.join.apply(null, parts);
+        expect(actual).toEqual(expected);
+      });
+
+      it("empty string and one part", function() {
+        parts = ["", "a"];
+        expected = "/a";
+        actual = fs.join.apply(null, parts);
+        expect(actual).toEqual(expected);
+      });
+
+      it("empty string and multiple parts", function() {
+        parts = ["", "a", "b", "c"];
+        expected = "/a/b/c";
+        actual = fs.join.apply(null, parts);
+        expect(actual).toEqual(expected);
+      });
+
+      it("empty string and multiple parts with empty strings", function() {
+        parts = ["", "a", "", "b", "", "c"];
+        expected = "/a/b/c";
+        actual = fs.join.apply(null, parts);
+        expect(actual).toEqual(expected);
+      });
+
+      it("multiple parts", function() {
+        parts = ["a", "b", "c"];
+        expected = "a/b/c";
+        actual = fs.join.apply(null, parts);
+        expect(actual).toEqual(expected);
+      });
+
+      it("multiple parts with empty strings", function() {
+        parts = ["a", "", "b", "", "c"];
+        expected = "a/b/c";
+        actual = fs.join.apply(null, parts);
+        expect(actual).toEqual(expected);
+      });
+    });
+
+    describe("fs.split(path)", function() {
+      var path, expected, actual;
+
+      it("should split absolute path with trailing separator", function() {
+        path = fs.separator + "a" + fs.separator + "b" + fs.separator + "c" + fs.separator + "d" + fs.separator;
+        actual = fs.split(path);
+        expected = ["", "a", "b", "c", "d"];
+        expect(actual).toEqual(expected);
+      });
+
+      it("should split absolute path without trailing separator", function() {
+        path = fs.separator + "a" + fs.separator + "b" + fs.separator + "c" + fs.separator + "d";
+        actual = fs.split(path);
+        expected = ["", "a", "b", "c", "d"];
+        expect(actual).toEqual(expected);
+      });
+
+      it("should split non-absolute path with trailing separator", function() {
+        path = "a" + fs.separator + "b" + fs.separator + "c" + fs.separator + "d" + fs.separator;
+        actual = fs.split(path);
+        expected = ["a", "b", "c", "d"];
+        expect(actual).toEqual(expected);
+      });
+
+      it("should split non-absolute path without trailing separator", function() {
+        path = "a" + fs.separator + "b" + fs.separator + "c" + fs.separator + "d";
+        actual = fs.split(path);
+        expected = ["a", "b", "c", "d"];
+        expect(actual).toEqual(expected);
+      });
+
+      it("should split path with consecutive separators", function() {
+        path = "a" + fs.separator + fs.separator + fs.separator + "b" + fs.separator + "c" + fs.separator + fs.separator + "d" + fs.separator + fs.separator + fs.separator;
+        expected = ["a", "b", "c", "d"];
+        actual = fs.split(path);
+        expect(actual).toEqual(expected);
+      });
+    });
 });

--- a/test/fs-spec-04.js
+++ b/test/fs-spec-04.js
@@ -3,7 +3,7 @@ describe("Tests Files API", function() {
 		ABSENT_FILE = "absentfile04",
 		TEST_DIR = "testdir04",
 		TEST_FILE = "testfile04",
-		TEST_FILE_PATH = TEST_DIR + fs.separator + TEST_FILE,
+		TEST_FILE_PATH = fs.join(TEST_DIR, TEST_FILE),
 		TEST_CONTENT = "test content",
 		START_CWD = null;
 	


### PR DESCRIPTION
This pull request fixes #10361.

In addition, I also took the liberty to make `fs.workingDirectory` return with native separators.
