### PR TITLE
Charset option for `fs.{open,read,write}`

### DIFF
--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -274,11 +274,20 @@ QString FileSystem::absolute(const QString &relativePath) const
 }
 
 // Files
-QObject *FileSystem::_open(const QString &path, const QString &mode) const
+QObject *FileSystem::_open(const QString &path, const QVariantMap &opts) const
 {
     File *f = NULL;
     QFile *_f = new QFile(path);
     QFile::OpenMode modeCode = QFile::NotOpen;
+    QVariant modeVar = opts["mode"];
+
+    // Ensure only strings
+    if (modeVar.type() != QVariant::String) {
+        qDebug() << "FileSystem::open - " << "Mode must be a string!" << modeVar;
+        return NULL;
+    }
+
+    QString mode = modeVar.toString();
 
     // Ensure only one "mode character" has been selected
     if ( mode.length() != 1) {

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -33,6 +33,7 @@
 #include <QObject>
 #include <QStringList>
 #include <QFile>
+#include <QTextCodec>
 #include <QTextStream>
 #include <QVariant>
 
@@ -41,7 +42,7 @@ class File : public QObject
     Q_OBJECT
 
 public:
-    File(QFile *openfile, QObject *parent = 0);
+    File(QFile *openfile, QTextCodec *codec, QObject *parent = 0);
     virtual ~File();
 
 public slots:

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -87,10 +87,10 @@ public slots:
     bool _removeTree(const QString &path) const;
 
     // Files
-    // 'open(path, mode)' implemented in "filesystem-shim.js" using '_open(path, mode)'
-    QObject *_open(const QString &path, const QString &mode) const;
-    // 'read(path)' implemented in "filesystem-shim.js"
-    // 'write(path, mode)' implemented in the "filesystem-shim.js"
+    // 'open(path, mode|options)' implemented in "filesystem-shim.js" using '_open(path, opts)'
+    QObject *_open(const QString &path, const QVariantMap &opts) const;
+    // 'read(path, options)' implemented in "filesystem-shim.js"
+    // 'write(path, mode|options)' implemented in the "filesystem-shim.js"
     // 'remove(path)' implemented in "filesystem-shim.js" using '_remove(path)'
     bool _remove(const QString &path) const;
     // 'copy(source, destination)' implemented in "filesystem-shim.js" using '_copy(source, destination)'

--- a/src/modules/fs.js
+++ b/src/modules/fs.js
@@ -40,6 +40,7 @@
  *  mode: Open Mode. A string made of 'r', 'w', 'a/+' characters.
  *  opts: Options.
  *          - mode (see Open Mode above)
+ *          - charset An IANA, case insensitive, charset name.
  * @return "file" object
  */
 exports.open = function (path, modeOrOpts) {
@@ -70,6 +71,7 @@ exports.open = function (path, modeOrOpts) {
  *
  * @param path Path of the file to read from
  * @param opts Options.
+ *               - charset An IANA, case insensitive, charset name.
  * @return file content
  */
 exports.read = function (path, opts) {
@@ -93,6 +95,7 @@ exports.read = function (path, opts) {
  *  mode: Open Mode. A string made of 'r', 'w', 'a/+' characters.
  *  opts: Options.
  *          - mode (see Open Mode above)
+ *          - charset An IANA, case insensitive, charset name.
  */
 exports.write = function (path, content, modeOrOpts) {
     if (modeOrOpts == null) {

--- a/src/modules/fs.js
+++ b/src/modules/fs.js
@@ -36,11 +36,29 @@
  * It will throw exception if it fails.
  *
  * @param path Path of the file to open
- * @param mode Open Mode. A string made of 'r', 'w', 'a/+' characters.
+ * @param modeOrOpts
+ *  mode: Open Mode. A string made of 'r', 'w', 'a/+' characters.
+ *  opts: Options.
+ *          - mode (see Open Mode above)
  * @return "file" object
  */
-exports.open = function (path, mode) {
-    var file = exports._open(path, mode);
+exports.open = function (path, modeOrOpts) {
+    var file, opts;
+
+    // Extract charset from opts
+    if (modeOrOpts == null) {
+        // Empty options
+        opts = {};
+    } else if (typeof modeOrOpts !== 'object') {
+        opts = {
+            mode: modeOrOpts
+        };
+    } else {
+        opts = modeOrOpts;
+    }
+
+    // Open file
+    file = exports._open(path, opts);
     if (file) {
         return file;
     }
@@ -51,10 +69,15 @@ exports.open = function (path, mode) {
  * It will throw an exception if it fails.
  *
  * @param path Path of the file to read from
+ * @param opts Options.
  * @return file content
  */
-exports.read = function (path) {
-    var f = exports.open(path, 'r'),
+exports.read = function (path, opts) {
+    if (opts == null || typeof opts !== 'object') {
+        opts = {};
+    }
+    opts.mode = 'r';
+    var f = exports.open(path, opts),
         content = f.read();
 
     f.close();
@@ -66,10 +89,16 @@ exports.read = function (path) {
  *
  * @param path Path of the file to read from
  * @param content Content to write to the file
- * @param mode Open Mode. A string made of 'w' or 'a / +' characters.
+ * @param modeOrOpts
+ *  mode: Open Mode. A string made of 'r', 'w', 'a/+' characters.
+ *  opts: Options.
+ *          - mode (see Open Mode above)
  */
-exports.write = function (path, content, mode) {
-    var f = exports.open(path, mode);
+exports.write = function (path, content, modeOrOpts) {
+    if (modeOrOpts == null) {
+        modeOrOpts = {};
+    }
+    var f = exports.open(path, modeOrOpts);
 
     f.write(content);
     f.close();

--- a/test/fs-spec-01.js
+++ b/test/fs-spec-01.js
@@ -3,6 +3,7 @@ describe("Basic Files API (read, write, remove, ...)", function() {
 		FILENAME_COPY = FILENAME + ".copy",
 		FILENAME_MOVED = FILENAME + ".moved",
 		FILENAME_EMPTY = FILENAME + ".empty",
+		FILENAME_ENC = FILENAME + ".enc",
         ABSENT = "absent-01.test";
     
     it("should be able to create and write a file", function() {
@@ -79,5 +80,21 @@ describe("Basic Files API (read, write, remove, ...)", function() {
 		expect(function(){
 			fs.copy(ABSENT, FILENAME_COPY);
 		}).toThrow("Unable to copy file '" + ABSENT + "' at '" + FILENAME_COPY + "'");
+	});
+
+	it("should be read/write utf8 text by default", function() {
+		var content, output = "ÄABCÖ";
+		try {
+			var f = fs.open(FILENAME_ENC, "w");
+			f.write(output);
+			f.close();
+
+			f = fs.open(FILENAME_ENC, "r");
+			content = f.read();
+			f.close();
+
+			fs.remove(FILENAME_ENC);
+		} catch (e) { }
+		expect(content).toEqual(output);
 	});
 });


### PR DESCRIPTION
This is a fix for [Issue 367](http://code.google.com/p/phantomjs/issues/detail?id=367).  The charset to be used by `fs.{open,read,write}` can now be passed as an option.  Additionally, instead of using the system default, will use _UTF-8_ when unspecified.  This allows for minimal effort across platforms, and is consistent with the command-line options `--{output,script}-encoding`.

Here's an example of converting _EUC-JP_ to _Shift-JIS_ (adapted from [comment 6](http://code.google.com/p/phantomjs/issues/detail?id=367#c6)).

Assuming a file, _test1.txt_, with _eucjp_-encoded text (`日本語\n`) in it, like so:

``` bash
$ od -An -tx1 test1.txt
 c6 fc cb dc b8 ec 0a
$ cat test1.txt | nkf -Ew
日本語
```

And a script, _test.coffee_, like so:

``` coffeescript
fs = require 'fs'
str = fs.read 'test1.txt', charset: 'eucjp'
console.log "Read: #{str}"
fs.write 'test2.txt', str, mode: 'w', charset: 'sjis'
phantom.exit 0
```

We would get a file, _text2.txt_, with _sjis_-encoded text, like so:

``` bash
$ echo $LANG
ja_JP.UTF8
$ phantomjs test.coffee
Read: 日本語

$ od -An -tx1 test2.txt
 93 fa 96 7b 8c ea 0a
$ cat test2.txt | nkf -Sw
日本語
```
