### PR TITLE
WebServer: Data access (POST/PUT)

### DIFF
--- a/examples/postserver.js
+++ b/examples/postserver.js
@@ -1,0 +1,33 @@
+// Example using HTTP POST operation
+
+var page = require('webpage').create(),
+    server = require('webserver').create(),
+    data = 'universe=expanding&answer=42';
+
+if (phantom.args.length !== 1) {
+    console.log('Usage: postserver.js <portnumber>');
+    phantom.exit();
+}
+
+var port = phantom.args[0];
+
+service = server.listen(port, function (request, response) {
+    console.log('Request received at ' + new Date());
+
+    response.statusCode = 200;
+    response.headers = {
+        'Cache': 'no-cache',
+        'Content-Type': 'text/plain;charset=utf-8'
+    };
+    response.write(JSON.stringify(request, null, 4));
+    response.close();
+});
+
+page.open('http://localhost:' + port + '/', 'post', data, function (status) {
+    if (status !== 'success') {
+        console.log('Unable to post!');
+    } else {
+        console.log(page.plainText);
+    }
+    phantom.exit();
+});

--- a/examples/server.js
+++ b/examples/server.js
@@ -9,20 +9,7 @@ if (phantom.args.length !== 1) {
     port = phantom.args[0];
     var listening = server.listen(port, function (request, response) {
         console.log("GOT HTTP REQUEST");
-        console.log("request.url = " + request.url);
-        console.log("request.queryString = " + request.queryString);
-        console.log("request.method = " + request.method);
-        console.log("request.httpVersion = " + request.httpVersion);
-        console.log("request.statusCode = " + request.statusCode);
-        console.log("request.isSSL = " + request.isSSL);
-        console.log("request.remoteIP = " + request.remoteIP);
-        console.log("request.remotePort = " + request.remotePort);
-        console.log("request.remoteUser = " + request.remoteUser);
-        console.log("request.headers = " + request.headers);
-        for(var i = 0; i < request.headers; ++i) {
-            console.log("request.headerName(" + i + ") = " + request.headerName(i));
-            console.log("request.headerValue(" + i + ") = " + request.headerValue(i));
-        }
+        console.log(JSON.stringify(request, null, 4));
 
         // we set the headers here
         response.statusCode = 200;
@@ -41,11 +28,13 @@ if (phantom.args.length !== 1) {
         phantom.exit();
     }
     var url = "http://localhost:" + port + "/foo/bar.php?asdf=true";
+    console.log("SENDING REQUEST TO:");
     console.log(url);
     page.open(url, function (status) {
         if (status !== 'success') {
             console.log('FAIL to load the address');
         } else {
+            console.log("GOT REPLY FROM SERVER:");
             console.log(page.content);
         }
         phantom.exit();

--- a/examples/server.js
+++ b/examples/server.js
@@ -34,6 +34,7 @@ if (phantom.args.length !== 1) {
         response.write("<html><head><title>YES!</title></head>");
         // note: writeBody can be called multiple times
         response.write("<body><p>pretty cool :)</body></html>");
+        response.close();
     });
     if (!listening) {
         console.log("could not create web server listening on port " + port);

--- a/examples/simpleserver.coffee
+++ b/examples/simpleserver.coffee
@@ -27,6 +27,7 @@ else
     response.write "</pre>"
     response.write "</body>"
     response.write "</html>"
+    response.close
   )
   if service
     console.log "Web server running on port " + port

--- a/examples/simpleserver.js
+++ b/examples/simpleserver.js
@@ -29,6 +29,7 @@ if (phantom.args.length !== 1) {
         response.write('</pre>');
         response.write('</body>');
         response.write('</html>');
+        response.close();
     });
 
     if (service) {

--- a/src/mongoose/mongoose.h
+++ b/src/mongoose/mongoose.h
@@ -21,8 +21,6 @@
 #ifndef MONGOOSE_HEADER_INCLUDED
 #define  MONGOOSE_HEADER_INCLUDED
 
-#include <stddef.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -56,7 +54,7 @@ enum mg_event {
   MG_NEW_REQUEST,   // New HTTP request has arrived from the client
   MG_HTTP_ERROR,    // HTTP error must be returned to the client
   MG_EVENT_LOG,     // Mongoose logs an event, request_info.log_message
-  MG_INIT_SSL       // Mongoose initializes SSL. Instead of mg_connection *,
+  MG_INIT_SSL,      // Mongoose initializes SSL. Instead of mg_connection *,
                     // SSL context is passed to the callback function.
 };
 
@@ -94,7 +92,7 @@ typedef void * (*mg_callback_t)(enum mg_event event,
 //     "listening_ports", "80,443s",
 //     NULL
 //   };
-//   struct mg_context *ctx = mg_start(&my_func, NULL, options);
+//   struct mg_context *ctx = mg_start(&my_func, options);
 //
 // Please refer to http://code.google.com/p/mongoose/wiki/MongooseManual
 // for the list of valid option and their possible values.
@@ -140,10 +138,8 @@ const char **mg_get_valid_option_names(void);
 //
 // Return:
 //   1 on success, 0 on error.
-int mg_modify_passwords_file(const char *passwords_file_name,
-                             const char *domain,
-                             const char *user,
-                             const char *password);
+int mg_modify_passwords_file(struct mg_context *ctx,
+    const char *passwords_file_name, const char *user, const char *password);
 
 // Send data to the client.
 int mg_write(struct mg_connection *, const void *buf, size_t len);
@@ -160,6 +156,16 @@ int mg_printf(struct mg_connection *, const char *fmt, ...);
 
 // Read data from the remote end, return number of bytes read.
 int mg_read(struct mg_connection *, void *buf, size_t len);
+
+
+// Allow a user_callback to handle a request on its own thread, in its
+// own time.  Useful, for example, for doing long pull requests without
+// needing a dedicated thread for each.
+void mg_detach(struct mg_connection *, int);
+
+
+// Release the resources associated with this connection.
+void mg_close_detached_connection(struct mg_connection *conn);
 
 
 // Get the value of particular HTTP header.

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -161,6 +161,10 @@ void WebPage::setContent(const QString &content)
     m_mainFrame->setHtml(content);
 }
 
+QString WebPage::plainText() const
+{
+    return m_mainFrame->toPlainText();
+}
 
 QString WebPage::libraryPath() const
 {

--- a/src/webpage.h
+++ b/src/webpage.h
@@ -45,6 +45,7 @@ class WebPage: public QObject
 {
     Q_OBJECT
     Q_PROPERTY(QString content READ content WRITE setContent)
+    Q_PROPERTY(QString plainText READ plainText)
     Q_PROPERTY(QString libraryPath READ libraryPath WRITE setLibraryPath)
     Q_PROPERTY(QVariantMap viewportSize READ viewportSize WRITE setViewportSize)
     Q_PROPERTY(QVariantMap paperSize READ paperSize WRITE setPaperSize)
@@ -58,6 +59,8 @@ public:
 
     QString content() const;
     void setContent(const QString &content);
+
+    QString plainText() const;
 
     QString libraryPath() const;
     void setLibraryPath(const QString &dirPath);

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -30,7 +30,7 @@
 
 #include "webserver.h"
 
-#include "mongoose.h"
+#include "mongoose/mongoose.h"
 
 #include <QByteArray>
 #include <QHostAddress>
@@ -117,7 +117,7 @@ void WebServer::handleRequest(mg_event event, mg_connection *conn, const mg_requ
 {
     Q_ASSERT(QThread::currentThread() == thread());
     if (event == MG_NEW_REQUEST) {
-        WebServerResponse responseObj(conn);
+        WebServerResponse* responseObj = new WebServerResponse(conn);
 
         // Modelled after http://nodejs.org/docs/latest/api/http.html#http.ServerRequest
         QVariantMap requestObject;
@@ -155,7 +155,7 @@ void WebServer::handleRequest(mg_event event, mg_connection *conn, const mg_requ
         }
         requestObject["headers"] = headersObject;
 
-        emit newRequest(requestObject, &responseObj);
+        emit newRequest(requestObject, responseObj);
         *handled = true;
         return;
     }
@@ -166,12 +166,14 @@ void WebServer::handleRequest(mg_event event, mg_connection *conn, const mg_requ
 //BEGIN WebServerResponse
 
 WebServerResponse::WebServerResponse(mg_connection *conn)
-    : m_conn(conn)
+    : QObject()
+    , m_conn(conn)
     , m_statusCode(200)
     , m_headersSent(false)
 {
-
+    mg_detach(m_conn, 1);
 }
+
 
 const char* responseCodeString(int code)
 {
@@ -288,6 +290,14 @@ void WebServerResponse::write(const QString &body)
     const QByteArray data = body.toLocal8Bit();
     mg_write(m_conn, data.constData(), data.size());
 }
+
+
+void WebServerResponse::close()
+{
+    mg_close_detached_connection(m_conn);
+    deleteLater();
+}
+
 
 int WebServerResponse::statusCode() const
 {

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -112,6 +112,43 @@ void WebServer::close()
     }
 }
 
+namespace UrlEncodedParser {
+
+QString unescape(QByteArray in)
+{
+    // first step: decode '+' to spaces
+    for(int i = 0; i < in.length(); ++i) {
+        QByteRef c = in[i];
+        if (c == '+') {
+            c = ' ';
+        }
+    }
+    // now decode as usual
+    return QUrl::fromPercentEncoding(in);
+};
+
+// Parse a application/x-www-form-urlencoded data string
+QVariantMap parse(const QByteArray &data) {
+    QVariantMap ret;
+    if (data.isEmpty()) {
+        return ret;
+    }
+    foreach(const QByteArray &part, data.split('&')) {
+        const int eqPos = part.indexOf('=');
+        if (eqPos == -1) {
+            ret[unescape(part)] = "";
+        } else {
+            const QByteArray key = part.mid(0, eqPos);
+            const QByteArray value = part.mid(eqPos + 1);
+            ret[unescape(key)] = unescape(value);
+        }
+    }
+
+    return ret;
+}
+
+}
+
 void WebServer::handleRequest(mg_event event, mg_connection *conn, const mg_request_info *request,
                               bool *handled)
 {
@@ -154,6 +191,23 @@ void WebServer::handleRequest(mg_event event, mg_connection *conn, const mg_requ
             headersObject[key] = value;
         }
         requestObject["headers"] = headersObject;
+
+        if ((requestObject["method"] == "POST" || requestObject["method"] == "PUT")
+            && headersObject.contains("Content-Length"))
+        {
+            bool ok = false;
+            uint contentLength = headersObject["Content-Length"].toUInt(&ok);
+            if (ok) {
+                contentLength += 1; // allow \0 at end
+                char * data = new char[contentLength];
+                int read = mg_read(conn, data, contentLength);
+                QByteArray rawData(data, read);
+                requestObject["rawData"] = rawData;
+                if (headersObject["Content-Type"] == "application/x-www-form-urlencoded") {
+                    requestObject["post"] = UrlEncodedParser::parse(rawData);
+                }
+            }
+        }
 
         emit newRequest(requestObject, responseObj);
         *handled = true;

--- a/src/webserver.h
+++ b/src/webserver.h
@@ -110,6 +110,16 @@ public slots:
     /// sends @p data to client and makes sure the headers are send beforehand
     void write(const QString &data);
 
+    /**
+     * Closes the request once all writing if finished
+     * This MUST be called when done with a request!
+     *
+     * NOTE: After calling close(), this request object
+     *       is no longer valid. Any further calls are
+     *       undefined and may crash.
+     */
+    void close();
+
     /// get the currently set status code, 200 is the default
     int statusCode() const;
     /// set the status code to @p code

--- a/test/webpage-spec.js
+++ b/test/webpage-spec.js
@@ -55,6 +55,7 @@ describe("WebPage object", function() {
     checkClipRect(page, {height:0,left:0,top:0,width:0});
 
     expectHasPropertyString(page, 'content');
+    expectHasPropertyString(page, 'plainText');
 
     expectHasPropertyString(page, 'libraryPath');
 


### PR DESCRIPTION
```
For POST and PUT request we now read all data as defined by
the Content-Length header into request.rawData property.
This property is a QByteArray which neatly maps to an array
in javascript.

For POST requests with Content-Type = applicaiton/x-www-form-urlencoded
we furthermore provide a parsed, easy-to-use request.post property.
This one is a QVariantMap of the decoded form data.

There is a new postserver.js example that shows the usage.

The unit test is extended to test the new (and old) features
of the server.

TODO: test that verifies proper decoding of UTF8 data, which
is not yet possible since I see no way to do a post-request
using phantomjs with an explicitly defined charset

ISSUE: 340 (http://code.google.com/p/phantomjs/issues/detail?id=340)
```

NOTE: I have no idea how to exclude the commit from https://github.com/ariya/phantomjs/pull/202 from this pull request, I'm sorry.

NOTE2: I finally figured out the webserver-spec issue, apparently one must not nest it() tests, which is done if one uses expectHasFunction or expectHasProperty (which I did in the webserver callback). Anyhow, now the test works as one would expect, nice!
