### PR TITLE
make it possible to read/write raw/binary files

### DIFF
--- a/examples/echoToFile.js
+++ b/examples/echoToFile.js
@@ -14,6 +14,7 @@ if (phantom.args.length < 2) {
     try {
         f = fs.open(phantom.args[0], "w");
         f.writeLine(content);
+        f.close();
     } catch (e) {
         console.log(e);
     }

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -92,10 +92,28 @@ bool File::writeLine(const QString &data)
     return false;
 }
 
+QByteArray File::readRaw()
+{
+    if ( m_file->isReadable() ) {
+        return m_file->readAll();
+    }
+    qDebug() << "File::readRaw - " << "Couldn't read:" << m_file->fileName();
+    return QByteArray();
+}
+
+bool File::writeRaw(const QByteArray &data)
+{
+    if ( m_file->isWritable() ) {
+        return m_file->write(data);
+    }
+    qDebug() << "File::writeRaw - " << "Couldn't write:" << m_file->fileName();
+    return false;
+}
+
 bool File::atEnd() const
 {
     if ( m_file->isReadable() ) {
-        return m_fileStream.atEnd();
+        return m_file->atEnd();
     }
     qDebug() << "File::atEnd - " << "Couldn't read:" << m_file->fileName();
     return false;

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -92,19 +92,31 @@ bool File::writeLine(const QString &data)
     return false;
 }
 
-QByteArray File::readRaw()
+//NOTE: we want to use QString instead of QByteArray as the latter is not really
+//      useable in javascript and e.g. window.btoa expects a string
+//NOTE: special code required since fromAsci() would stop as soon as it encounters \0
+QString File::readRaw()
 {
     if ( m_file->isReadable() ) {
-        return m_file->readAll();
+        const QByteArray data = m_file->readAll();
+        QString ret(data.size());
+        for(int i = 0; i < data.size(); ++i) {
+            ret[i] = data.at(i);
+        }
+        return ret;
     }
     qDebug() << "File::readRaw - " << "Couldn't read:" << m_file->fileName();
-    return QByteArray();
+    return QString();
 }
 
-bool File::writeRaw(const QByteArray &data)
+bool File::writeRaw(const QString &data)
 {
     if ( m_file->isWritable() ) {
-        return m_file->write(data);
+        QByteArray bytes(data.size(), Qt::Uninitialized);
+        for(int i = 0; i < data.size(); ++i) {
+            bytes[i] = data.at(i).toAscii();
+        }
+        return m_file->write(bytes);
     }
     qDebug() << "File::writeRaw - " << "Couldn't write:" << m_file->fileName();
     return false;

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -42,15 +42,14 @@ class File : public QObject
     Q_OBJECT
 
 public:
+    // handle a textfile with given codec
+    // if @p codec is null, the file is considered to be binary
     File(QFile *openfile, QTextCodec *codec, QObject *parent = 0);
     virtual ~File();
 
 public slots:
     QString read();
     bool write(const QString &data);
-
-    QString readRaw();
-    bool writeRaw(const QString &data);
 
     QString readLine();
     bool writeLine(const QString &data);
@@ -61,7 +60,7 @@ public slots:
 
 private:
     QFile *m_file;
-    QTextStream m_fileStream;
+    QTextStream *m_fileStream;
 };
 
 

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -49,8 +49,8 @@ public slots:
     QString read();
     bool write(const QString &data);
 
-    QByteArray readRaw();
-    bool writeRaw(const QByteArray &data);
+    QString readRaw();
+    bool writeRaw(const QString &data);
 
     QString readLine();
     bool writeLine(const QString &data);

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -49,6 +49,9 @@ public slots:
     QString read();
     bool write(const QString &data);
 
+    QByteArray readRaw();
+    bool writeRaw(const QByteArray &data);
+
     QString readLine();
     bool writeLine(const QString &data);
 
@@ -91,7 +94,9 @@ public slots:
     // 'open(path, mode|options)' implemented in "filesystem-shim.js" using '_open(path, opts)'
     QObject *_open(const QString &path, const QVariantMap &opts) const;
     // 'read(path, options)' implemented in "filesystem-shim.js"
+    // 'readRaw(path, options)' implemented in "filesystem-shim.js"
     // 'write(path, mode|options)' implemented in the "filesystem-shim.js"
+    // 'writeRaw(path, mode|options)' implemented in the "filesystem-shim.js"
     // 'remove(path)' implemented in "filesystem-shim.js" using '_remove(path)'
     bool _remove(const QString &path) const;
     // 'copy(source, destination)' implemented in "filesystem-shim.js" using '_copy(source, destination)'

--- a/src/modules/fs.js
+++ b/src/modules/fs.js
@@ -66,8 +66,10 @@ exports.open = function (path, modeOrOpts) {
     throw "Unable to open file '" + path + "'";
 };
 
-/** Open, read and return content of a file.
+/** Open, read and return text content of a file.
  * It will throw an exception if it fails.
+ *
+ * NOTE: do not use this for binary files.
  *
  * @param path Path of the file to read from
  * @param opts Options.
@@ -86,7 +88,22 @@ exports.read = function (path, opts) {
     return content;
 };
 
-/** Open and write content to a file
+/** Open, read and return raw binary content of a file.
+ * It will throw an exception if it fails.
+ *
+ * @param path Path of the file to read from
+ * @return file content
+ */
+exports.readRaw = function (path, opts) {
+    var opts = {'mode': 'r'};
+    var f = exports.open(path, opts),
+        content = f.readRaw();
+
+    f.close();
+    return content;
+};
+
+/** Open and write text content to a file
  * It will throw an exception if it fails.
  *
  * @param path Path of the file to read from
@@ -104,6 +121,26 @@ exports.write = function (path, content, modeOrOpts) {
     var f = exports.open(path, modeOrOpts);
 
     f.write(content);
+    f.close();
+};
+
+/** Open and write raw binary content to a file
+ * It will throw an exception if it fails.
+ *
+ * @param path Path of the file to read from
+ * @param content Content to write to the file
+ * @param modeOrOpts
+ *  mode: Open Mode. A string made of 'r', 'w', 'a/+' characters.
+ *  opts: Options.
+ *          - mode (see Open Mode above)
+ */
+exports.writeRaw = function (path, content, modeOrOpts) {
+    if (modeOrOpts == null) {
+        modeOrOpts = {};
+    }
+    var f = exports.open(path, modeOrOpts);
+
+    f.writeRaw(content);
     f.close();
 };
 

--- a/test/fs-spec-01.js
+++ b/test/fs-spec-01.js
@@ -4,6 +4,7 @@ describe("Basic Files API (read, write, remove, ...)", function() {
 		FILENAME_MOVED = FILENAME + ".moved",
 		FILENAME_EMPTY = FILENAME + ".empty",
 		FILENAME_ENC = FILENAME + ".enc",
+        FILENAME_BIN = FILENAME + ".bin",
         ABSENT = "absent-01.test";
     
     it("should be able to create and write a file", function() {
@@ -97,4 +98,20 @@ describe("Basic Files API (read, write, remove, ...)", function() {
 		} catch (e) { }
 		expect(content).toEqual(output);
 	});
+
+    it("should be read/write binary data", function() {
+        var content, output = String.fromCharCode(0, 1, 2, 3, 4, 5);
+        try {
+            var f = fs.open(FILENAME_BIN, "w");
+            f.writeRaw(output);
+            f.close();
+
+            f = fs.open(FILENAME_BIN, "r");
+            content = f.readRaw();
+            f.close();
+
+            fs.remove(FILENAME_BIN);
+        } catch (e) { }
+        expect(content).toEqual(output);
+    });
 });

--- a/test/fs-spec-01.js
+++ b/test/fs-spec-01.js
@@ -37,6 +37,19 @@ describe("Basic Files API (read, write, remove, ...)", function() {
         expect(content).toEqual("hello\nworld\n");
     });
     
+    it("should be able to read/write/append content from a file", function() {
+        var content = "";
+        try{
+            var f = fs.open(FILENAME, "rw+");
+            console.log(f.read().length);
+            f.writeLine("asdf");
+            content = f.read();
+            console.log(content.length);
+            f.close();
+        } catch (e) { }
+        expect(content).toEqual("hello\nworld\nasdf\n");
+    });
+    
 	it("should be able to copy a file", function() {
 		expect(fs.exists(FILENAME_COPY)).toBeFalsy();
 		fs.copy(FILENAME, FILENAME_COPY);
@@ -102,13 +115,25 @@ describe("Basic Files API (read, write, remove, ...)", function() {
     it("should be read/write binary data", function() {
         var content, output = String.fromCharCode(0, 1, 2, 3, 4, 5);
         try {
-            var f = fs.open(FILENAME_BIN, "w");
-            f.writeRaw(output);
+            var f = fs.open(FILENAME_BIN, "wb");
+            f.write(output);
             f.close();
 
-            f = fs.open(FILENAME_BIN, "r");
-            content = f.readRaw();
+            f = fs.open(FILENAME_BIN, "rb");
+            content = f.read();
             f.close();
+
+            fs.remove(FILENAME_BIN);
+        } catch (e) { }
+        expect(content).toEqual(output);
+    });
+
+    it("should be read/write binary data (shortcuts)", function() {
+        var content, output = String.fromCharCode(0, 1, 2, 3, 4, 5);
+        try {
+            fs.write(FILENAME_BIN, output, "b");
+
+            content = fs.read(FILENAME_BIN, "b");
 
             fs.remove(FILENAME_BIN);
         } catch (e) { }


### PR DESCRIPTION
this adds File::readRaw and File::writeRaw functions,
as well as 'shimmed' versions FS::readRaw and FS::writeRaw

these functions directly use QFile and QByteArray instead of
QTextStream and QString, making it possible to read and write
binary data, e.g. images and such.

I wonder how to write a test for this, as ::writeRaw is not really useable without a prior readRaw on a binary file... At least I don't see a way to directly "create" a QByteArray in javascript and then write random data to it. If I'd use a javascript string then there is no way to ensure that the data is actually read "raw" (as it's a string...). And there doesn't seem to be a bridge for ArrayBuffer -> QByteArray or something like that...

Anyhow, the above is still required if you want to do something like this e.g.:
page.render("foo.png");
var content = fs.readRaw("foo.png");
// now base64 the data, using e.g. an adapted version of base64encode as can be found here: 
// http://jsfiddle.net/3kUXy/ just replace str.charCodeAt(...) with str[...]
response.write(base64encode(content));
response.close();
