### PR TITLE
Fix jasmine example terminating too early against jasmine 1.1.0.

### DIFF
--- a/examples/run-jasmine.js
+++ b/examples/run-jasmine.js
@@ -53,7 +53,7 @@ page.open(phantom.args[0], function(status){
     } else {
         waitFor(function(){
             return page.evaluate(function(){
-                if (document.body.querySelector('.finished-at')) {
+                if (document.body.querySelector('.runner .description')) {
                     return true;
                 }
                 return false;


### PR DESCRIPTION
The .finished-at element that was being checked for is present all
the time during the test run, so the waitFor call ended too early.
