### PR TITLE
Enable remote web inspector on sub-pages.

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -140,6 +140,14 @@ void Config::processArgs(const QStringList &args)
             setRemoteDebugPort(arg.mid(23).trimmed().toInt());
             continue;
         }
+        if (arg == "--remote-debugger-autorun=yes") {
+            setRemoteDebugAutorun(true);
+            continue;
+        }
+        if (arg == "--remote-debugger-autorun=no") {
+            setRemoteDebugAutorun(false);
+            continue;
+        }
         if (arg.startsWith("--")) {
             setUnknownOption(QString("Unknown option '%1'").arg(arg));
             return;
@@ -394,6 +402,16 @@ void Config::setRemoteDebugPort(const int port)
     m_remoteDebugPort = port;
 }
 
+bool Config::remoteDebugAutorun() const
+{
+    return m_remoteDebugAutorun;
+}
+
+void Config::setRemoteDebugAutorun(const bool value)
+{
+    m_remoteDebugAutorun = value;
+}
+
 // private:
 void Config::resetToDefaults()
 {
@@ -415,6 +433,7 @@ void Config::resetToDefaults()
     m_versionFlag = false;
     m_debug = false;
     m_remoteDebugPort = -1;
+    m_remoteDebugAutorun = false;
     m_helpFlag = false;
 }
 

--- a/src/config.h
+++ b/src/config.h
@@ -109,6 +109,9 @@ public:
     void setRemoteDebugPort(const int port);
     int remoteDebugPort() const;
 
+    void setRemoteDebugAutorun(const bool value);
+    bool remoteDebugAutorun() const;
+
     bool helpFlag() const;
     void setHelpFlag(const bool value);
 
@@ -139,6 +142,7 @@ private:
     QString m_authPass;
     bool m_debug;
     int m_remoteDebugPort;
+    bool m_remoteDebugAutorun;
     bool m_helpFlag;
 };
 

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -208,6 +208,11 @@ QObject *Phantom::createWebPage()
     m_pages.append(page);
     page->applySettings(m_defaultPageSettings);
     page->setLibraryPath(QFileInfo(m_config.scriptFile()).dir().absolutePath());
+
+    if (m_config.debug()) {
+      page->showInspector(m_config.remoteDebugPort());
+    }
+
     return page;
 }
 

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -157,7 +157,7 @@ bool Phantom::execute()
 
     if (m_config.debug())
     {
-        if (!Utils::loadJSForDebug(m_config.scriptFile(), m_scriptFileEnc, QDir::currentPath(), m_page->mainFrame())) {
+        if (!Utils::loadJSForDebug(m_config.scriptFile(), m_scriptFileEnc, QDir::currentPath(), m_page->mainFrame(), m_config.remoteDebugAutorun())) {
             m_returnValue = -1;
             return false;
         }

--- a/src/usage.txt
+++ b/src/usage.txt
@@ -14,6 +14,7 @@ Options:
 --max-disk-cache-size=size             Limits the size of disk cache (in KB)
 --output-encoding                      Sets the encoding used for terminal output (default is 'utf8')
 --remote-debugger-port=port            Starts the script in a debug harness and listens on the desired port.
+--remote-debugger-autorun=[yes|no]     Whether to run the script in the debugger immediately, or wait for the user to type __run() in the console. (default is 'no')
 --proxy=address:port                   Sets the network proxy (e.g. "--proxy=192.168.1.42:8080")
 --proxy-type=[http|socks5]             Sets the proxy type, either "http" (default) or "socks5"
 --script-encoding                      Sets the encoding used for the starting script (default is 'utf8')

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -98,12 +98,12 @@ bool Utils::injectJsInFrame(const QString &jsFilePath, const Encoding &jsFileEnc
     return true;
 }
 
-bool Utils::loadJSForDebug(const QString& jsFilePath, const QString& libraryPath, QWebFrame* targetFrame)
+bool Utils::loadJSForDebug(const QString& jsFilePath, const QString& libraryPath, QWebFrame* targetFrame, const bool autorun)
 {
-    return loadJSForDebug(jsFilePath, Encoding::UTF8, libraryPath, targetFrame);
+    return loadJSForDebug(jsFilePath, Encoding::UTF8, libraryPath, targetFrame, autorun);
 }
 
-bool Utils::loadJSForDebug(const QString& jsFilePath, const Encoding& jsFileEnc, const QString& libraryPath, QWebFrame* targetFrame)
+bool Utils::loadJSForDebug(const QString& jsFilePath, const Encoding& jsFileEnc, const QString& libraryPath, QWebFrame* targetFrame, const bool autorun)
 {
     QString scriptPath = findScript(jsFilePath, libraryPath);
     QString scriptBody = jsFromScriptFile(scriptPath, jsFileEnc);
@@ -111,6 +111,11 @@ bool Utils::loadJSForDebug(const QString& jsFilePath, const Encoding& jsFileEnc,
     QString remoteDebuggerHarnessSrc =  Utils::readResourceFileUtf8(":/remote_debugger_harness.html");
     remoteDebuggerHarnessSrc = remoteDebuggerHarnessSrc.arg(scriptBody);
     targetFrame->setHtml(remoteDebuggerHarnessSrc);
+
+    if (autorun) {
+        targetFrame->evaluateJavaScript("__run()");
+    }
+
     return true;
 }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -54,8 +54,8 @@ public:
     static bool injectJsInFrame(const QString &jsFilePath, const Encoding &jsFileEnc, const QString &libraryPath, QWebFrame *targetFrame, const bool startingScript = false);
     static QString readResourceFileUtf8(const QString &resourceFilePath);
 
-    static bool loadJSForDebug(const QString &jsFilePath, const Encoding &jsFileEnc, const QString &libraryPath, QWebFrame *targetFrame);
-    static bool loadJSForDebug(const QString &jsFilePath, const QString &libraryPath, QWebFrame *targetFrame);
+    static bool loadJSForDebug(const QString &jsFilePath, const Encoding &jsFileEnc, const QString &libraryPath, QWebFrame *targetFrame, const bool autorun = false);
+    static bool loadJSForDebug(const QString &jsFilePath, const QString &libraryPath, QWebFrame *targetFrame, const bool autorun = false);
     static void cleanupFromDebug();
 private:
     static QString findScript(const QString &jsFilePath, const QString& libraryPath);


### PR DESCRIPTION
Currently trying to use the remote debugger with sub-pages created in
the phantomjs session will result in a segfault inside QtWebKit. With
this patch, it works.
