### PR TITLE
disable web security

### DIFF
--- a/deploy/build-helper.sh
+++ b/deploy/build-helper.sh
@@ -148,6 +148,7 @@ patch_qt() {
         patch -p1 < ../qt48_fix_inspector.patch
         patch -p1 < ../qt48_headless_and_pdf_fixes.patch
         patch -p1 < ../qt48_enable_file_input_click.patch
+        patch -p1 < ../qt48_disable_web_security.patch
 
         # Build in lighthose mode for an x-less build
         if [ $QT_HEADLESS -eq 1 -a $DISABLE_HEADLESS -eq 0 ] ; then

--- a/deploy/qt48_disable_web_security.patch
+++ b/deploy/qt48_disable_web_security.patch
@@ -1,0 +1,35 @@
+diff -ruN qt-everywhere-opensource-src-4.8.0/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebsettings.cpp qt-everywhere-opensource-src-4.8.0.patched/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebsettings.cpp
+--- qt-everywhere-opensource-src-4.8.0/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebsettings.cpp	2011-12-08 13:06:03.000000000 +0800
++++ qt-everywhere-opensource-src-4.8.0.patched/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebsettings.cpp	2012-03-03 16:24:01.000000000 +0800
+@@ -278,6 +278,10 @@
+         settings->setPasswordEchoEnabled(true);
+         settings->setPasswordEchoDurationInSeconds(1);
+ #endif
++
++        value = attributes.value(QWebSettings::WebSecurityEnabled,
++                                      global->attributes.value(QWebSettings::WebSecurityEnabled));
++        settings->setWebSecurityEnabled(value);
+     } else {
+         QList<QWebSettingsPrivate*> settings = *::allSettings();
+         for (int i = 0; i < settings.count(); ++i)
+@@ -515,6 +519,7 @@
+     d->attributes.insert(QWebSettings::TiledBackingStoreEnabled, false);
+     d->attributes.insert(QWebSettings::FrameFlatteningEnabled, false);
+     d->attributes.insert(QWebSettings::SiteSpecificQuirksEnabled, true);
++    d->attributes.insert(QWebSettings::WebSecurityEnabled, true);
+     d->offlineStorageDefaultQuota = 5 * 1024 * 1024;
+     d->defaultTextEncoding = QLatin1String("iso-8859-1");
+ }
+diff -ruN qt-everywhere-opensource-src-4.8.0/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebsettings.h qt-everywhere-opensource-src-4.8.0.patched/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebsettings.h
+--- qt-everywhere-opensource-src-4.8.0/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebsettings.h	2011-12-08 13:06:03.000000000 +0800
++++ qt-everywhere-opensource-src-4.8.0.patched/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebsettings.h	2012-03-03 16:24:01.000000000 +0800
+@@ -77,7 +77,8 @@
+         SiteSpecificQuirksEnabled,
+         JavascriptCanCloseWindows,
+         WebGLEnabled,
+-        HyperlinkAuditingEnabled
++        HyperlinkAuditingEnabled,
++        WebSecurityEnabled
+     };
+     enum WebGraphic {
+         MissingImageGraphic,

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -148,6 +148,14 @@ void Config::processArgs(const QStringList &args)
             setRemoteDebugAutorun(false);
             continue;
         }
+        if (arg == "--web-security=yes") {
+            setWebSecurityEnabled(true);
+            continue;
+        }
+        if (arg == "--web-security=no") {
+            setWebSecurityEnabled(false);
+            continue;
+        }
         if (arg.startsWith("--")) {
             setUnknownOption(QString("Unknown option '%1'").arg(arg));
             return;
@@ -412,6 +420,16 @@ void Config::setRemoteDebugAutorun(const bool value)
     m_remoteDebugAutorun = value;
 }
 
+bool Config::webSecurityEnabled() const
+{
+    return m_webSecurityEnabled;
+}
+
+void Config::setWebSecurityEnabled(const bool value)
+{
+    m_webSecurityEnabled = value;
+}
+
 // private:
 void Config::resetToDefaults()
 {
@@ -434,6 +452,7 @@ void Config::resetToDefaults()
     m_debug = false;
     m_remoteDebugPort = -1;
     m_remoteDebugAutorun = false;
+    m_webSecurityEnabled = true;
     m_helpFlag = false;
 }
 

--- a/src/config.h
+++ b/src/config.h
@@ -48,6 +48,7 @@ class Config: QObject
     Q_PROPERTY(QString proxyType READ proxyType WRITE setProxyType)
     Q_PROPERTY(QString proxy READ proxy WRITE setProxy)
     Q_PROPERTY(QString scriptEncoding READ scriptEncoding WRITE setScriptEncoding)
+    Q_PROPERTY(bool webSecurityEnabled READ webSecurityEnabled WRITE setWebSecurityEnabled)
 
 public:
     Config(QObject *parent = 0);
@@ -112,6 +113,9 @@ public:
     void setRemoteDebugAutorun(const bool value);
     bool remoteDebugAutorun() const;
 
+    bool webSecurityEnabled() const;
+    void setWebSecurityEnabled(const bool value);
+
     bool helpFlag() const;
     void setHelpFlag(const bool value);
 
@@ -143,6 +147,7 @@ private:
     bool m_debug;
     int m_remoteDebugPort;
     bool m_remoteDebugAutorun;
+    bool m_webSecurityEnabled;
     bool m_helpFlag;
 };
 

--- a/src/consts.h
+++ b/src/consts.h
@@ -59,5 +59,6 @@
 #define PAGE_SETTINGS_LOCAL_ACCESS_REMOTE   "localToRemoteUrlAccessEnabled"
 #define PAGE_SETTINGS_USERNAME              "userName"
 #define PAGE_SETTINGS_PASSWORD              "password"
+#define PAGE_SETTINGS_WEB_SECURITY_ENABLED  "webSecurityEnabled"
 
 #endif // CONSTS_H

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -115,6 +115,7 @@ Phantom::Phantom(QObject *parent)
     m_defaultPageSettings[PAGE_SETTINGS_XSS_AUDITING] = QVariant::fromValue(false);
     m_defaultPageSettings[PAGE_SETTINGS_USER_AGENT] = QVariant::fromValue(m_page->userAgent());
     m_defaultPageSettings[PAGE_SETTINGS_LOCAL_ACCESS_REMOTE] = QVariant::fromValue(m_config.localToRemoteUrlAccessEnabled());
+    m_defaultPageSettings[PAGE_SETTINGS_WEB_SECURITY_ENABLED] = QVariant::fromValue(m_config.webSecurityEnabled());
     m_page->applySettings(m_defaultPageSettings);
 
     setLibraryPath(QFileInfo(m_config.scriptFile()).dir().absolutePath());

--- a/src/usage.txt
+++ b/src/usage.txt
@@ -18,4 +18,5 @@ Options:
 --proxy=address:port                   Sets the network proxy (e.g. "--proxy=192.168.1.42:8080")
 --proxy-type=[http|socks5]             Sets the proxy type, either "http" (default) or "socks5"
 --script-encoding                      Sets the encoding used for the starting script (default is 'utf8')
+--web-security=[yes|no]                Enable web security (default is 'yes')
 --version                              Prints out PhantomJS version

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -200,6 +200,7 @@ void WebPage::applySettings(const QVariantMap &def)
     opt->setAttribute(QWebSettings::JavascriptEnabled, def[PAGE_SETTINGS_JS_ENABLED].toBool());
     opt->setAttribute(QWebSettings::XSSAuditingEnabled, def[PAGE_SETTINGS_XSS_AUDITING].toBool());
     opt->setAttribute(QWebSettings::LocalContentCanAccessRemoteUrls, def[PAGE_SETTINGS_LOCAL_ACCESS_REMOTE].toBool());
+    opt->setAttribute(QWebSettings::WebSecurityEnabled, def[PAGE_SETTINGS_WEB_SECURITY_ENABLED].toBool());
 
     if (def.contains(PAGE_SETTINGS_USER_AGENT))
         m_webPage->m_userAgent = def[PAGE_SETTINGS_USER_AGENT].toString();


### PR DESCRIPTION
added a patch to qt-4.8.0 and a new option --web-security to phantomjs
allow web security restrictions to be disabled
such as cross-domain XMLHttpRequest and iframe access are possible now

issue: http://code.google.com/p/phantomjs/issues/detail?id=28

i also wrote a demo test here: https://gist.github.com/1966848
