### PR TITLE
Proxy Authentication, fixes issue 105

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -114,6 +114,10 @@ void Config::processArgs(const QStringList &args)
             setProxyType(arg.mid(13).trimmed());
             continue;
         }
+        if (arg.startsWith("--proxy-auth=")){
+            setProxyAuth(arg.mid(13).trimmed());
+            continue;
+        }
         if (arg.startsWith("--proxy=")) {
             setProxy(arg.mid(8).trimmed());
             continue;
@@ -313,6 +317,34 @@ void Config::setProxy(const QString &value)
     setProxyPort(proxyPort);
 }
 
+void Config::setProxyAuth(const QString &value)
+{   
+    QString proxyUser = value;
+    QString proxyPass = "";
+
+    if (proxyUser.lastIndexOf(':') > 0) {
+        proxyPass = proxyUser.mid(proxyUser.lastIndexOf(':') + 1).trimmed();
+        proxyUser = proxyUser.left(proxyUser.lastIndexOf(':')).trimmed();
+        
+        setProxyAuthUser(proxyUser);
+        setProxyAuthPass(proxyPass);
+    }
+}
+
+QString Config::proxyAuth() const
+{
+    return proxyAuthUser() + ":" + proxyAuthPass();
+}
+QString Config::proxyAuthUser() const
+{
+    return m_proxyAuthUser;
+}
+
+QString Config::proxyAuthPass() const
+{
+    return m_proxyAuthPass;
+}
+
 QString Config::proxyHost() const
 {
     return m_proxyHost;
@@ -426,6 +458,8 @@ void Config::resetToDefaults()
     m_proxyType = "http";
     m_proxyHost.clear();
     m_proxyPort = 1080;
+    m_proxyAuthUser.clear();
+    m_proxyAuthPass.clear();
     m_scriptArgs.clear();
     m_scriptEncoding = "UTF-8";
     m_scriptFile.clear();
@@ -436,7 +470,14 @@ void Config::resetToDefaults()
     m_remoteDebugAutorun = false;
     m_helpFlag = false;
 }
-
+void Config::setProxyAuthPass(const QString &value)
+{
+    m_proxyAuthPass = value;
+}
+void Config::setProxyAuthUser(const QString &value)
+{
+    m_proxyAuthUser = value;
+}
 void Config::setProxyHost(const QString &value)
 {
     m_proxyHost = value;

--- a/src/config.h
+++ b/src/config.h
@@ -47,6 +47,7 @@ class Config: QObject
     Q_PROPERTY(bool pluginsEnabled READ pluginsEnabled WRITE setPluginsEnabled)
     Q_PROPERTY(QString proxyType READ proxyType WRITE setProxyType)
     Q_PROPERTY(QString proxy READ proxy WRITE setProxy)
+    Q_PROPERTY(QString proxyAuth READ proxyAuth WRITE setProxyAuth)
     Q_PROPERTY(QString scriptEncoding READ scriptEncoding WRITE setScriptEncoding)
 
 public:
@@ -87,6 +88,13 @@ public:
     void setProxy(const QString &value);
     QString proxyHost() const;
     int proxyPort() const;
+
+    QString proxyAuth() const;
+    void setProxyAuth(const QString &value);
+    QString proxyAuthUser() const;
+    QString proxyAuthPass() const;
+    void setProxyAuthUser(const QString &value);
+    void setProxyAuthPass(const QString &value);
 
     QStringList scriptArgs() const;
     void setScriptArgs(const QStringList &value);
@@ -133,6 +141,8 @@ private:
     QString m_proxyType;
     QString m_proxyHost;
     int m_proxyPort;
+    QString m_proxyAuthUser;
+    QString m_proxyAuthPass;
     QStringList m_scriptArgs;
     QString m_scriptEncoding;
     QString m_scriptFile;

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -89,9 +89,13 @@ Phantom::Phantom(QObject *parent)
         if (proxyType == "socks5") {
             networkProxyType = QNetworkProxy::Socks5Proxy;
         }
-
-        QNetworkProxy proxy(networkProxyType, m_config.proxyHost(), m_config.proxyPort());
-        QNetworkProxy::setApplicationProxy(proxy);
+        if(!m_config.proxyAuthUser().isEmpty() && !m_config.proxyAuthPass().isEmpty()){
+            QNetworkProxy proxy(networkProxyType, m_config.proxyHost(), m_config.proxyPort(), m_config.proxyAuthUser(), m_config.proxyAuthPass());
+            QNetworkProxy::setApplicationProxy(proxy);
+        }else{
+            QNetworkProxy proxy(networkProxyType, m_config.proxyHost(), m_config.proxyPort());
+            QNetworkProxy::setApplicationProxy(proxy);
+        }
     }
 
     // Set output encoding

--- a/src/usage.txt
+++ b/src/usage.txt
@@ -15,6 +15,7 @@ Options:
   --remote-debugger-port=port            Starts the script in a debug harness and listens on the desired port.
   --remote-debugger-autorun=[yes|no]     Whether to run the script in the debugger immediately, or wait for the user to type __run() in the console. (default is 'no')
   --proxy=address:port                   Sets the network proxy (e.g. "--proxy=192.168.1.42:8080")
+  --proxy-auth=username:password         Sets authentication details for the proxy (basic auth)
   --proxy-type=[http|socks5]             Sets the proxy type, either "http" (default) or "socks5"
   --script-encoding                      Sets the encoding used for the starting script (default is 'utf8')
   -v, --version                          Prints out PhantomJS version


### PR DESCRIPTION
Following up with the proxy auth issue and related patch:
http://code.google.com/p/phantomjs/issues/detail?id=105

This patch adds an extra parameter to the command line args to allow for proxy authentication --proxy-auth, accepting a string in the format username:password. Anything not in this format is ignored.
