### PR TITLE
support keep-alive in the webserver

### DIFF
--- a/src/modules/webserver.js
+++ b/src/modules/webserver.js
@@ -112,11 +112,15 @@ exports.create = function (opts) {
 
     defineSetter("onNewRequest", "newRequest");
 
-    server.listen = function (port, handler) {
-        if (arguments.length === 2 && typeof handler === 'function') {
-            this.onNewRequest = handler;
-            //TODO: settings?
-            return this.listenOnPort(port);
+    server.listen = function (port, arg1, arg2) {
+        if (arguments.length === 2 && typeof arg1 === 'function') {
+            this.onNewRequest = arg1;
+            return this.listenOnPort(port, {});
+        }
+        if (arguments.length === 3 && typeof arg2 === 'function') {
+            this.onNewRequest = arg2;
+            // arg1 == settings
+            return this.listenOnPort(port, arg1);
         }
         throw "Wrong use of WebServer#listen";
     };

--- a/src/mongoose/mongoose.h
+++ b/src/mongoose/mongoose.h
@@ -54,7 +54,7 @@ enum mg_event {
   MG_NEW_REQUEST,   // New HTTP request has arrived from the client
   MG_HTTP_ERROR,    // HTTP error must be returned to the client
   MG_EVENT_LOG,     // Mongoose logs an event, request_info.log_message
-  MG_INIT_SSL,      // Mongoose initializes SSL. Instead of mg_connection *,
+  MG_INIT_SSL       // Mongoose initializes SSL. Instead of mg_connection *,
                     // SSL context is passed to the callback function.
 };
 
@@ -92,7 +92,7 @@ typedef void * (*mg_callback_t)(enum mg_event event,
 //     "listening_ports", "80,443s",
 //     NULL
 //   };
-//   struct mg_context *ctx = mg_start(&my_func, options);
+//   struct mg_context *ctx = mg_start(&my_func, NULL, options);
 //
 // Please refer to http://code.google.com/p/mongoose/wiki/MongooseManual
 // for the list of valid option and their possible values.
@@ -138,8 +138,10 @@ const char **mg_get_valid_option_names(void);
 //
 // Return:
 //   1 on success, 0 on error.
-int mg_modify_passwords_file(struct mg_context *ctx,
-    const char *passwords_file_name, const char *user, const char *password);
+int mg_modify_passwords_file(const char *passwords_file_name,
+                             const char *domain,
+                             const char *user,
+                             const char *password);
 
 // Send data to the client.
 int mg_write(struct mg_connection *, const void *buf, size_t len);
@@ -156,16 +158,6 @@ int mg_printf(struct mg_connection *, const char *fmt, ...);
 
 // Read data from the remote end, return number of bytes read.
 int mg_read(struct mg_connection *, void *buf, size_t len);
-
-
-// Allow a user_callback to handle a request on its own thread, in its
-// own time.  Useful, for example, for doing long pull requests without
-// needing a dedicated thread for each.
-void mg_detach(struct mg_connection *, int);
-
-
-// Release the resources associated with this connection.
-void mg_close_detached_connection(struct mg_connection *conn);
 
 
 // Get the value of particular HTTP header.


### PR DESCRIPTION
The recent patch that brought asynchronous webserver response handling
made it impossible to have proper keep-alive support in the server.

We want the server to support keep-alive though, which is especially
useful when writing a PhantomJS script that allows one to "remote control"
PhantomJS, using the WebServer API, without flooding the TCP connections.
Also the performance might be improved.

Note: This patch reverts commit bbce8920d0a56874daba39c7d69f64e3d64c2eb8,
and resets the Mongoose code to the vanilla 3.0 version. Instead we now
support the async handling of HTTP requests using some QWaitCondition
magic.

Note: keep-alive support is optional, and disabled by default. To enable
it, use something like:

server.listen(port, {"keep-alive": true}, function(request, response) {...});

Like before, calling response.close() is crucial. Furthermore though, a
server that has keep-alive enabled _must_ set a proper "Content-Length: ..."
header in it's response, otherwise clients will not be able to know when
the response has finished.

ISSUE: 416 (http://code.google.com/p/phantomjs/issues/detail?id=416)
