### PR TITLE
Javascript backtrace support

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -34,7 +34,6 @@
 */
 
 function require(name) {
-
     var code, func, exports;
 
     if (name === 'webpage' || name === 'fs' || name === 'webserver' || name === 'system') {
@@ -53,6 +52,32 @@ function require(name) {
     if (typeof exports === 'undefined') {
         throw 'Unknown module ' + name + ' for require()';
     }
+}
+
+(function() {
+    var handler;
+    var signal = phantom.page.javaScriptErrorSent;
+
+    phantom.__defineSetter__('onError', function(f) {
+        if (handler) {
+            try {
+                signal.disconnect(handler);
+            } catch (e) { console.log("got error") }
+        }
+        handler = f;
+        signal.connect(f);
+    })
+})();
+
+// TODO: Make this output to STDERR
+phantom.onError = function(error, backtrace) {
+    console.log(error + "\n");
+
+    backtrace.forEach(function(item) {
+        var message = item.file + ":" + item.line;
+        if (item.function) message += " in " + item.function
+        console.log("  " + message);
+    })
 }
 
 // Legacy way to use WebPage

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -60,9 +60,7 @@ function require(name) {
 
     phantom.__defineSetter__('onError', function(f) {
         if (handler) {
-            try {
-                signal.disconnect(handler);
-            } catch (e) { console.log("got error") }
+            try { signal.disconnect(handler) } catch (e) {}
         }
         handler = f;
         signal.connect(f);
@@ -70,7 +68,7 @@ function require(name) {
 })();
 
 // TODO: Make this output to STDERR
-phantom.onError = function(error, backtrace) {
+phantom.defaultErrorHandler = function(error, backtrace) {
     console.log(error + "\n");
 
     backtrace.forEach(function(item) {
@@ -79,6 +77,8 @@ phantom.onError = function(error, backtrace) {
         console.log("  " + message);
     })
 }
+
+phantom.onError = phantom.defaultErrorHandler;
 
 // Legacy way to use WebPage
 window.WebPage = require('webpage').create;

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -59,11 +59,15 @@ function require(name) {
     var signal = phantom.page.javaScriptErrorSent;
 
     phantom.__defineSetter__('onError', function(f) {
-        if (handler) {
+        if (handler && typeof handler === 'function') {
             try { signal.disconnect(handler) } catch (e) {}
         }
+
         handler = f;
-        signal.connect(f);
+
+        if (typeof f === 'function') {
+            signal.connect(f);
+        }
     })
 })();
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -205,7 +205,7 @@ void Config::loadJsonFile(const QString &filePath)
     // Add this object to the global scope
     webPage.mainFrame()->addToJavaScriptWindowObject("config", this);
     // Apply the JSON config settings to this very object
-    webPage.mainFrame()->evaluateJavaScript(configurator.arg(jsonConfig), QUrl());
+    webPage.mainFrame()->evaluateJavaScript(configurator.arg(jsonConfig), QString());
 }
 
 bool Config::autoLoadImages() const

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -205,7 +205,7 @@ void Config::loadJsonFile(const QString &filePath)
     // Add this object to the global scope
     webPage.mainFrame()->addToJavaScriptWindowObject("config", this);
     // Apply the JSON config settings to this very object
-    webPage.mainFrame()->evaluateJavaScript(configurator.arg(jsonConfig));
+    webPage.mainFrame()->evaluateJavaScript(configurator.arg(jsonConfig), QUrl());
 }
 
 bool Config::autoLoadImages() const

--- a/src/csconverter.cpp
+++ b/src/csconverter.cpp
@@ -48,17 +48,23 @@ CSConverter *CSConverter::instance()
 CSConverter::CSConverter()
     : QObject(QCoreApplication::instance())
 {
-    m_webPage.mainFrame()->evaluateJavaScript(Utils::readResourceFileUtf8(":/coffee-script.js"));
+    m_webPage.mainFrame()->evaluateJavaScript(
+        Utils::readResourceFileUtf8(":/coffee-script.js"),
+        QUrl("phantomjs://coffee-script.js")
+    );
     m_webPage.mainFrame()->addToJavaScriptWindowObject("converter", this);
 }
 
 QVariant CSConverter::convert(const QString &script)
 {
     setProperty("source", script);
-    QVariant result = m_webPage.mainFrame()->evaluateJavaScript("try {" \
-                                                                "    [true, this.CoffeeScript.compile(converter.source)];" \
-                                                                "} catch (error) {" \
-                                                                "    [false, error.message];" \
-                                                                "}");
+    QVariant result = m_webPage.mainFrame()->evaluateJavaScript(
+        "try {" \
+        "    [true, this.CoffeeScript.compile(converter.source)];" \
+        "} catch (error) {" \
+        "    [false, error.message];" \
+        "}",
+        QUrl()
+    );
     return result;
 }

--- a/src/csconverter.cpp
+++ b/src/csconverter.cpp
@@ -50,7 +50,7 @@ CSConverter::CSConverter()
 {
     m_webPage.mainFrame()->evaluateJavaScript(
         Utils::readResourceFileUtf8(":/coffee-script.js"),
-        QUrl("phantomjs://coffee-script.js")
+        QString("phantomjs://coffee-script.js")
     );
     m_webPage.mainFrame()->addToJavaScriptWindowObject("converter", this);
 }
@@ -64,7 +64,7 @@ QVariant CSConverter::convert(const QString &script)
         "} catch (error) {" \
         "    [false, error.message];" \
         "}",
-        QUrl()
+        QString()
     );
     return result;
 }

--- a/src/modules/webpage.js
+++ b/src/modules/webpage.js
@@ -99,8 +99,12 @@ exports.create = function (opts) {
                     this[signalName].disconnect(handlers[signalName]);
                 } catch (e) {}
             }
+
             handlers[signalName] = f;
-            this[signalName].connect(handlers[signalName]);
+
+            if (typeof f === 'function') {
+                this[signalName].connect(f);
+            }
         });
     }
 

--- a/src/modules/webpage.js
+++ b/src/modules/webpage.js
@@ -121,6 +121,8 @@ exports.create = function (opts) {
 
     defineSetter("onConsoleMessage", "javaScriptConsoleMessageSent");
 
+    defineSetter("onError", "javaScriptErrorSent");
+
     page.open = function (url, arg1, arg2, arg3, arg4) {
         if (arguments.length === 1) {
             this.openUrl(url, 'get', this.settings);

--- a/src/modules/webpage.js
+++ b/src/modules/webpage.js
@@ -123,6 +123,8 @@ exports.create = function (opts) {
 
     defineSetter("onError", "javaScriptErrorSent");
 
+    page.onError = phantom.defaultErrorHandler;
+
     page.open = function (url, arg1, arg2, arg3, arg4) {
         if (arguments.length === 1) {
             this.openUrl(url, 'get', this.settings);

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -122,8 +122,6 @@ Phantom::Phantom(QObject *parent)
     m_page->applySettings(m_defaultPageSettings);
 
     setLibraryPath(QFileInfo(m_config.scriptFile()).dir().absolutePath());
-
-    onInitialized();
 }
 
 Phantom::~Phantom()
@@ -208,6 +206,11 @@ QVariantMap Phantom::version() const
     return result;
 }
 
+QObject *Phantom::page() const
+{
+    return m_page;
+}
+
 // public slots:
 QObject *Phantom::createWebPage()
 {
@@ -287,10 +290,7 @@ void Phantom::debugExit(int code)
 // private slots:
 void Phantom::printConsoleMessage(const QString &message, int lineNumber, const QString &source)
 {
-    QString msg = message;
-    if (!source.isEmpty())
-        msg = source + ":" + QString::number(lineNumber) + " " + msg;
-    Terminal::instance()->cout(msg);
+    Terminal::instance()->cout(message);
 }
 
 void Phantom::onInitialized()
@@ -299,7 +299,10 @@ void Phantom::onInitialized()
     m_page->mainFrame()->addToJavaScriptWindowObject("phantom", this);
 
     // Bootstrap the PhantomJS scope
-    m_page->mainFrame()->evaluateJavaScript(Utils::readResourceFileUtf8(":/bootstrap.js"));
+    m_page->mainFrame()->evaluateJavaScript(
+        Utils::readResourceFileUtf8(":/bootstrap.js"),
+        QUrl("phantomjs://boostrap.js")
+    );
 }
 
 // private:

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -301,7 +301,7 @@ void Phantom::onInitialized()
     // Bootstrap the PhantomJS scope
     m_page->mainFrame()->evaluateJavaScript(
         Utils::readResourceFileUtf8(":/bootstrap.js"),
-        QUrl("phantomjs://boostrap.js")
+        QString("phantomjs://bootstrap.js")
     );
 }
 

--- a/src/phantom.h
+++ b/src/phantom.h
@@ -52,6 +52,7 @@ class Phantom: public REPLCompletable
     Q_PROPERTY(QString outputEncoding READ outputEncoding WRITE setOutputEncoding)
     Q_PROPERTY(QString scriptName READ scriptName)
     Q_PROPERTY(QVariantMap version READ version)
+    Q_PROPERTY(QObject *page READ page)
 
 public:
     Phantom(QObject *parent = 0);
@@ -73,6 +74,8 @@ public:
     QString scriptName() const;
 
     QVariantMap version() const;
+
+    QObject* page() const;
 
 public slots:
     QObject *createWebPage();

--- a/src/qt/src/3rdparty/webkit/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/src/qt/src/3rdparty/webkit/Source/WebCore/bindings/js/ScriptController.cpp
@@ -154,9 +154,6 @@ ScriptValue ScriptController::evaluateInWorld(const ScriptSourceCode& sourceCode
         return ScriptValue(exec->globalData(), comp.value());
     }
 
-    if (comp.complType() == Throw || comp.complType() == Interrupted)
-        reportException(exec, comp.value());
-
     m_sourceURL = savedSourceURL;
     return ScriptValue();
 }

--- a/src/qt/src/3rdparty/webkit/Source/WebCore/bindings/js/ScriptSourceCode.h
+++ b/src/qt/src/3rdparty/webkit/Source/WebCore/bindings/js/ScriptSourceCode.h
@@ -49,6 +49,13 @@ public:
     {
     }
 
+    ScriptSourceCode(const String& source, const String& url, const TextPosition1& startPosition = TextPosition1::minimumPosition())
+        : m_provider(StringSourceProvider::create(source, url, startPosition))
+        , m_code(m_provider, startPosition.m_line.oneBasedInt())
+        , m_url(KURL(ParsedURLString, url))
+    {
+    }
+
     ScriptSourceCode(CachedScript* cs)
         : m_provider(CachedScriptSourceProvider::create(cs))
         , m_code(m_provider)

--- a/src/qt/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebframe.cpp
+++ b/src/qt/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebframe.cpp
@@ -1529,14 +1529,14 @@ void QWebFrame::print(QPrinter *printer) const
 
     \sa addToJavaScriptWindowObject(), javaScriptWindowObjectCleared()
 */
-QVariant QWebFrame::evaluateJavaScript(const QString& scriptSource)
+QVariant QWebFrame::evaluateJavaScript(const QString& scriptSource, const QUrl& file)
 {
     ScriptController *proxy = d->frame->script();
     QVariant rc;
     if (proxy) {
 #if USE(JSC)
         int distance = 0;
-        JSC::JSValue v = d->frame->script()->executeScript(ScriptSourceCode(scriptSource)).jsValue();
+        JSC::JSValue v = d->frame->script()->executeScript(ScriptSourceCode(scriptSource, file)).jsValue();
 
         rc = JSC::Bindings::convertValueToQVariant(proxy->globalObject(mainThreadNormalWorld())->globalExec(), v, QMetaType::Void, &distance);
 #elif USE(V8)

--- a/src/qt/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebframe.cpp
+++ b/src/qt/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebframe.cpp
@@ -1529,14 +1529,14 @@ void QWebFrame::print(QPrinter *printer) const
 
     \sa addToJavaScriptWindowObject(), javaScriptWindowObjectCleared()
 */
-QVariant QWebFrame::evaluateJavaScript(const QString& scriptSource, const QUrl& file)
+QVariant QWebFrame::evaluateJavaScript(const QString& scriptSource, const QString& location)
 {
     ScriptController *proxy = d->frame->script();
     QVariant rc;
     if (proxy) {
 #if USE(JSC)
         int distance = 0;
-        JSC::JSValue v = d->frame->script()->executeScript(ScriptSourceCode(scriptSource, file)).jsValue();
+        JSC::JSValue v = d->frame->script()->executeScript(ScriptSourceCode(scriptSource, WTF::String(location))).jsValue();
 
         rc = JSC::Bindings::convertValueToQVariant(proxy->globalObject(mainThreadNormalWorld())->globalExec(), v, QMetaType::Void, &distance);
 #elif USE(V8)

--- a/src/qt/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebframe.h
+++ b/src/qt/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebframe.h
@@ -200,7 +200,7 @@ public:
     QWebSecurityOrigin securityOrigin() const;
 
 public Q_SLOTS:
-    QVariant evaluateJavaScript(const QString& scriptSource);
+    QVariant evaluateJavaScript(const QString& scriptSource, const QUrl& file);
 #ifndef QT_NO_PRINTER
     void print(QPrinter *printer) const;
 #endif

--- a/src/qt/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebframe.h
+++ b/src/qt/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebframe.h
@@ -200,7 +200,7 @@ public:
     QWebSecurityOrigin securityOrigin() const;
 
 public Q_SLOTS:
-    QVariant evaluateJavaScript(const QString& scriptSource, const QUrl& file);
+    QVariant evaluateJavaScript(const QString& scriptSource, const QString& file);
 #ifndef QT_NO_PRINTER
     void print(QPrinter *printer) const;
 #endif

--- a/src/qt/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebpage.cpp
+++ b/src/qt/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebpage.cpp
@@ -116,6 +116,9 @@
 #include "WorkerThread.h"
 #include "runtime/InitializeThreading.h"
 #include "wtf/Threading.h"
+#include "DebuggerCallFrame.h"
+#include "JavaScriptCallFrame.h"
+#include "SourceProvider.h"
 
 #include <QApplication>
 #include <QBasicTimer>
@@ -290,6 +293,105 @@ static inline Qt::DropAction dragOpToDropAction(unsigned actions)
     return result;
 }
 
+QWebPagePrivateDebugger::QWebPagePrivateDebugger(QWebPage* page)
+  : m_webPage(page)
+{
+}
+
+QWebPagePrivateDebugger::~QWebPagePrivateDebugger()
+{
+}
+
+void QWebPagePrivateDebugger::detach(JSC::JSGlobalObject*)
+{
+}
+
+void QWebPagePrivateDebugger::sourceParsed(JSC::ExecState*, JSC::SourceProvider*, int errorLineNumber, const JSC::UString& errorMessage)
+{
+}
+
+void QWebPagePrivateDebugger::exception(const JSC::DebuggerCallFrame& frame, intptr_t sourceID, int lineNumber, bool hasHandler)
+{
+    if (!hasHandler) {
+        reportError(frame.exception());
+    }
+}
+
+void QWebPagePrivateDebugger::reportError(const JSC::JSValue& exception)
+{
+    WTF::RefPtr<WebCore::JavaScriptCallFrame> frame = m_callFrame;
+
+    JSC::ExecState* exec = frame->dynamicGlobalObject()->globalExec();
+    JSC::UString message = exception.toString(exec);
+
+    QString qmessage = QString::fromUtf8(message.utf8().data());
+    QList<QWebPage::JavaScriptFrame> qbacktrace;
+
+    JSC::SourceProvider* provider;
+
+    QString file;
+    int line;
+    QString function;
+
+    while (frame) {
+        provider = reinterpret_cast<JSC::SourceProvider*>(frame->sourceID());
+
+        line = frame->line();
+        file = QString::fromUtf8(provider->url().utf8().data());
+        function = QString::fromUtf8(frame->functionName().utf8().data());
+
+        qbacktrace << QWebPage::JavaScriptFrame(file, line + 1, function);
+        frame = frame->caller();
+    }
+
+    m_webPage->javaScriptError(QWebPage::JavaScriptError(qmessage, qbacktrace));
+}
+
+void QWebPagePrivateDebugger::atStatement(const JSC::DebuggerCallFrame& frame, intptr_t sourceID, int lineNumber)
+{
+    stepOver(frame, sourceID, lineNumber);
+}
+
+void QWebPagePrivateDebugger::callEvent(const JSC::DebuggerCallFrame& frame, intptr_t sourceID, int lineNumber)
+{
+    stepIn(frame, sourceID, lineNumber);
+}
+
+void QWebPagePrivateDebugger::returnEvent(const JSC::DebuggerCallFrame&, intptr_t sourceID, int lineNumber)
+{
+    stepOut();
+}
+
+void QWebPagePrivateDebugger::willExecuteProgram(const JSC::DebuggerCallFrame& frame, intptr_t sourceID, int lineNumber)
+{
+    stepIn(frame, sourceID, lineNumber);
+}
+
+void QWebPagePrivateDebugger::didExecuteProgram(const JSC::DebuggerCallFrame&, intptr_t sourceID, int lineNumber)
+{
+    stepOut();
+}
+
+void QWebPagePrivateDebugger::didReachBreakpoint(const JSC::DebuggerCallFrame&, intptr_t sourceID, int lineNumber)
+{
+}
+
+void QWebPagePrivateDebugger::stepIn(const JSC::DebuggerCallFrame& frame, intptr_t sourceID, int lineNumber)
+{
+    m_callFrame = WebCore::JavaScriptCallFrame::create(frame, m_callFrame, sourceID, textPosition(lineNumber));
+}
+
+void QWebPagePrivateDebugger::stepOver(const JSC::DebuggerCallFrame& frame, intptr_t sourceID, int lineNumber)
+{
+    m_callFrame->update(frame, sourceID, textPosition(lineNumber));
+}
+
+void QWebPagePrivateDebugger::stepOut()
+{
+    m_callFrame = m_callFrame->caller();
+}
+
+
 QWebPagePrivate::QWebPagePrivate(QWebPage *qq)
     : q(qq)
     , page(0)
@@ -370,6 +472,8 @@ QWebPagePrivate::QWebPagePrivate(QWebPage *qq)
 #if ENABLE(NOTIFICATIONS)    
     NotificationPresenterClientQt::notificationPresenter()->addClient();
 #endif
+
+    page->setDebugger(new QWebPagePrivateDebugger(q));
 }
 
 QWebPagePrivate::~QWebPagePrivate()
@@ -2098,6 +2202,12 @@ void QWebPage::javaScriptConsoleMessage(const QString& message, int lineNumber, 
         if (message == QLatin1String("PLUGIN: NPP_Destroy"))
             fprintf (stdout, "CONSOLE MESSAGE: line %d: %s\n", lineNumber, message.toUtf8().constData());
     }
+}
+
+/* Subclasses should reimplement this to add error handling. */
+void QWebPage::javaScriptError(const QWebPage::JavaScriptError& error)
+{
+    Q_UNUSED(error)
 }
 
 /*!

--- a/src/qt/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebpage.cpp
+++ b/src/qt/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebpage.cpp
@@ -473,7 +473,8 @@ QWebPagePrivate::QWebPagePrivate(QWebPage *qq)
     NotificationPresenterClientQt::notificationPresenter()->addClient();
 #endif
 
-    page->setDebugger(new QWebPagePrivateDebugger(q));
+    debugger = new QWebPagePrivateDebugger(q);
+    page->setDebugger(debugger);
 }
 
 QWebPagePrivate::~QWebPagePrivate()
@@ -491,6 +492,7 @@ QWebPagePrivate::~QWebPagePrivate()
 #endif
     delete settings;
     delete page;
+    delete debugger;
     
     if (inspector)
         inspector->setPage(0);

--- a/src/qt/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebpage.h
+++ b/src/qt/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebpage.h
@@ -244,6 +244,40 @@ public:
         friend class QWebPage;
     };
 
+    class QWEBKIT_EXPORT JavaScriptFrame {
+    public:
+        JavaScriptFrame(const QString& file, int line, const QString& function)
+          : m_file(file)
+          , m_line(line)
+          , m_function(function)
+        {
+        }
+
+        QString file() const { return m_file; };
+        int line() const { return m_line; };
+        QString function() const { return m_function; };
+
+    private:
+        QString m_file;
+        int m_line;
+        QString m_function;
+    };
+
+    class QWEBKIT_EXPORT JavaScriptError {
+    public:
+        JavaScriptError(const QString& message, const QList<JavaScriptFrame>& backtrace)
+          : m_message(message)
+          , m_backtrace(backtrace)
+        {
+        }
+
+        QString message() const { return m_message; };
+        QList<JavaScriptFrame> backtrace() const { return m_backtrace; };
+
+    private:
+        QString m_message;
+        QList<JavaScriptFrame> m_backtrace;
+    };
 
     explicit QWebPage(QObject *parent = 0);
     ~QWebPage();
@@ -414,6 +448,7 @@ protected:
     virtual bool javaScriptConfirm(QWebFrame *originatingFrame, const QString& msg);
     virtual bool javaScriptPrompt(QWebFrame *originatingFrame, const QString& msg, const QString& defaultValue, QString* result);
     virtual void javaScriptConsoleMessage(const QString& message, int lineNumber, const QString& sourceID);
+    virtual void javaScriptError(const JavaScriptError& error);
 
     virtual QString userAgentForUrl(const QUrl& url) const;
 
@@ -428,6 +463,7 @@ private:
 
     friend class QWebFrame;
     friend class QWebPagePrivate;
+    friend class QWebPagePrivateDebugger;
     friend class QWebView;
     friend class QWebViewPrivate;
     friend class QGraphicsWebView;

--- a/src/qt/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebpage_p.h
+++ b/src/qt/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebpage_p.h
@@ -255,6 +255,7 @@ public:
     QWebInspector* inspector;
     bool inspectorIsInternalOnly; // True if created through the Inspect context menu action
     Qt::DropAction m_lastDropAction;
+    QWebPagePrivateDebugger* debugger;
 
     static bool drtRun;
 };

--- a/src/qt/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebpage_p.h
+++ b/src/qt/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebpage_p.h
@@ -35,8 +35,11 @@
 #include "KURL.h"
 #include "PlatformString.h"
 
+#include <debugger/Debugger.h>
+
 #include <wtf/OwnPtr.h>
 #include <wtf/RefPtr.h>
+#include <wtf/text/TextPosition.h>
 
 #include "ViewportArguments.h"
 
@@ -54,6 +57,15 @@ namespace WebCore {
     class NodeList;
     class Page;
     class Frame;
+    class JavaScriptCallFrame;
+}
+
+namespace JSC {
+    class JSGlobalObject;
+    class ExecState;
+    class SourceProvider;
+    class DebuggerCallFrame;
+    class UString;
 }
 
 QT_BEGIN_NAMESPACE
@@ -72,6 +84,39 @@ public:
     { }
 
     QWebPage::ViewportAttributes* q;
+};
+
+class QWebPagePrivateDebugger : public JSC::Debugger {
+public:
+    QWebPagePrivateDebugger(QWebPage*);
+    ~QWebPagePrivateDebugger();
+
+    void detach(JSC::JSGlobalObject*);
+
+    void sourceParsed(JSC::ExecState*, JSC::SourceProvider*, int errorLineNumber, const JSC::UString& errorMessage);
+    void exception(const JSC::DebuggerCallFrame&, intptr_t sourceID, int lineNumber, bool hasHandler);
+    void atStatement(const JSC::DebuggerCallFrame&, intptr_t sourceID, int lineNumber);
+    void callEvent(const JSC::DebuggerCallFrame&, intptr_t sourceID, int lineNumber);
+    void returnEvent(const JSC::DebuggerCallFrame&, intptr_t sourceID, int lineNumber);
+
+    void willExecuteProgram(const JSC::DebuggerCallFrame&, intptr_t sourceID, int lineNumber);
+    void didExecuteProgram(const JSC::DebuggerCallFrame&, intptr_t sourceID, int lineNumber);
+    void didReachBreakpoint(const JSC::DebuggerCallFrame&, intptr_t sourceID, int lineNumber);
+
+private:
+    void stepIn(const JSC::DebuggerCallFrame& frame, intptr_t sourceID, int lineNumber);
+    void stepOver(const JSC::DebuggerCallFrame& frame, intptr_t sourceID, int lineNumber);
+    void stepOut();
+    void reportError(const JSC::JSValue& exception);
+
+    WTF::TextPosition0 textPosition(int lineNumber)
+    {
+        WTF::ZeroBasedNumber zeroBasedNumber = WTF::OneBasedNumber::fromOneBasedInt(lineNumber).convertToZeroBased();
+        return WTF::TextPosition0(zeroBasedNumber, WTF::ZeroBasedNumber::base());
+    }
+
+    RefPtr<WebCore::JavaScriptCallFrame> m_callFrame;
+    QWebPage* m_webPage;
 };
 
 class QWebPagePrivate {

--- a/src/repl.cpp
+++ b/src/repl.cpp
@@ -99,7 +99,7 @@ REPL::REPL(QWebFrame *webframe, Phantom *parent)
     linenoiseSetCompletionCallback(REPL::offerCompletion);
 
     // Inject REPL utility functions
-    m_webframe->evaluateJavaScript(Utils::readResourceFileUtf8(":/repl.js"), QUrl("phantomjs://repl.js"));
+    m_webframe->evaluateJavaScript(Utils::readResourceFileUtf8(":/repl.js"), QString("phantomjs://repl.js"));
 
     // Start the REPL's loop
     QTimer::singleShot(0, this, SLOT(startLoop()));
@@ -134,7 +134,7 @@ void REPL::offerCompletion(const char *buf, linenoiseCompletions *lc)
                 QString(JS_RETURN_POSSIBLE_COMPLETIONS).arg(
                     toInspect,
                     toComplete),
-                QUrl()
+                QString()
                 ).toStringList();
 
     foreach (QString c, completions) {
@@ -159,7 +159,7 @@ void REPL::startLoop()
             // Send the user input to the main Phantom frame for evaluation
             m_webframe->evaluateJavaScript(
                         QString(JS_EVAL_USER_INPUT).arg(
-                            QString(userInput).replace('"', "\\\"")), QUrl("repl://"));
+                            QString(userInput).replace('"', "\\\"")), QString("phantomjs://repl-input"));
 
             // Save command in the REPL history
             linenoiseHistoryAdd(userInput);

--- a/src/repl.cpp
+++ b/src/repl.cpp
@@ -99,7 +99,7 @@ REPL::REPL(QWebFrame *webframe, Phantom *parent)
     linenoiseSetCompletionCallback(REPL::offerCompletion);
 
     // Inject REPL utility functions
-    m_webframe->evaluateJavaScript(Utils::readResourceFileUtf8(":/repl.js"));
+    m_webframe->evaluateJavaScript(Utils::readResourceFileUtf8(":/repl.js"), QUrl("phantomjs://repl.js"));
 
     // Start the REPL's loop
     QTimer::singleShot(0, this, SLOT(startLoop()));
@@ -133,7 +133,8 @@ void REPL::offerCompletion(const char *buf, linenoiseCompletions *lc)
     QStringList completions = REPL::getInstance()->m_webframe->evaluateJavaScript(
                 QString(JS_RETURN_POSSIBLE_COMPLETIONS).arg(
                     toInspect,
-                    toComplete)
+                    toComplete),
+                QUrl()
                 ).toStringList();
 
     foreach (QString c, completions) {
@@ -158,7 +159,7 @@ void REPL::startLoop()
             // Send the user input to the main Phantom frame for evaluation
             m_webframe->evaluateJavaScript(
                         QString(JS_EVAL_USER_INPUT).arg(
-                            QString(userInput).replace('"', "\\\"")));
+                            QString(userInput).replace('"', "\\\"")), QUrl("repl://"));
 
             // Save command in the REPL history
             linenoiseHistoryAdd(userInput);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -94,7 +94,7 @@ bool Utils::injectJsInFrame(const QString &jsFilePath, const Encoding &jsFileEnc
         return false;
     }
     // Execute JS code in the context of the document
-    targetFrame->evaluateJavaScript(scriptBody);
+    targetFrame->evaluateJavaScript(scriptBody, QUrl(jsFilePath));
     return true;
 }
 
@@ -113,7 +113,7 @@ bool Utils::loadJSForDebug(const QString& jsFilePath, const Encoding& jsFileEnc,
     targetFrame->setHtml(remoteDebuggerHarnessSrc);
 
     if (autorun) {
-        targetFrame->evaluateJavaScript("__run()");
+        targetFrame->evaluateJavaScript("__run()", QUrl());
     }
 
     return true;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -94,7 +94,7 @@ bool Utils::injectJsInFrame(const QString &jsFilePath, const Encoding &jsFileEnc
         return false;
     }
     // Execute JS code in the context of the document
-    targetFrame->evaluateJavaScript(scriptBody, QUrl(jsFilePath));
+    targetFrame->evaluateJavaScript(scriptBody, jsFilePath);
     return true;
 }
 
@@ -113,7 +113,7 @@ bool Utils::loadJSForDebug(const QString& jsFilePath, const Encoding& jsFileEnc,
     targetFrame->setHtml(remoteDebuggerHarnessSrc);
 
     if (autorun) {
-        targetFrame->evaluateJavaScript("__run()", QUrl());
+        targetFrame->evaluateJavaScript("__run()", QString());
     }
 
     return true;

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -292,7 +292,7 @@ QVariant WebPage::evaluate(const QString &code)
 {
     QString function = "(" + code + ")()";
     // TODO: use the proper URL
-    return m_mainFrame->evaluateJavaScript(function, QUrl("phantomjs://WebPage::evaluate"));
+    return m_mainFrame->evaluateJavaScript(function, QString("phantomjs://WebPage::evaluate"));
 }
 
 void WebPage::emitAlert(const QString &msg)
@@ -373,7 +373,7 @@ void WebPage::openUrl(const QString &address, const QVariant &op, const QVariant
         networkOp = QNetworkAccessManager::DeleteOperation;
 
     if (networkOp == QNetworkAccessManager::UnknownOperation) {
-        m_mainFrame->evaluateJavaScript("console.error('Unknown network operation: " + operation + "');", QUrl());
+        m_mainFrame->evaluateJavaScript("console.error('Unknown network operation: " + operation + "');", QString());
         return;
     }
 
@@ -622,7 +622,7 @@ bool WebPage::injectJs(const QString &jsFilePath) {
 }
 
 void WebPage::_appendScriptElement(const QString &scriptUrl) {
-    m_mainFrame->evaluateJavaScript( QString(JS_APPEND_SCRIPT_ELEMENT).arg(scriptUrl), QUrl(scriptUrl) );
+    m_mainFrame->evaluateJavaScript( QString(JS_APPEND_SCRIPT_ELEMENT).arg(scriptUrl), scriptUrl );
 }
 
 void WebPage::sendEvent(const QString &type, const QVariant &arg1, const QVariant &arg2)

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -291,8 +291,7 @@ QVariantMap WebPage::paperSize() const
 QVariant WebPage::evaluate(const QString &code)
 {
     QString function = "(" + code + ")()";
-    // TODO: use the proper URL
-    return m_mainFrame->evaluateJavaScript(function, QString("phantomjs://WebPage::evaluate"));
+    return m_mainFrame->evaluateJavaScript(function, QString("phantomjs://webpage.evaluate()"));
 }
 
 void WebPage::emitAlert(const QString &msg)

--- a/src/webpage.h
+++ b/src/webpage.h
@@ -102,6 +102,7 @@ signals:
     void loadFinished(const QString &status);
     void javaScriptAlertSent(const QString &msg);
     void javaScriptConsoleMessageSent(const QString &message, int lineNumber, const QString &source);
+    void javaScriptErrorSent(const QString &message, const QVariantList &backtrace);
     void resourceRequested(const QVariant &req);
     void resourceReceived(const QVariant &resource);
 
@@ -116,6 +117,7 @@ private:
 
     void emitAlert(const QString &msg);
     void emitConsoleMessage(const QString &msg, int lineNumber, const QString &source);
+    void emitError(const QWebPage::JavaScriptError& error);
 
     virtual void initCompletions();
 


### PR DESCRIPTION
This is a WIP pull request to discuss my backtraces patch.

It's unfinished, but currently works to an extent:

```
$ cat test.js 
function a() {
  foo
}

a()
$ phantomjs test.js 
ReferenceError: Can't find variable: foo

  test.js:2 in a
  test.js:5
```

I will comment more tomorrow when I have time, right now I need to sleep.
