### PR TITLE
Stacktraces

### DIFF
--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -107,8 +107,8 @@ Phantom::Phantom(QObject *parent)
     // Set script file encoding
     m_scriptFileEnc.setEncoding(m_config.scriptEncoding());
 
-    connect(m_page, SIGNAL(javaScriptConsoleMessageSent(QString, int, QString)),
-            SLOT(printConsoleMessage(QString, int, QString)));
+    connect(m_page, SIGNAL(javaScriptConsoleMessageSent(QString)),
+            SLOT(printConsoleMessage(QString)));
     connect(m_page, SIGNAL(initialized()),
             SLOT(onInitialized()));
 
@@ -288,7 +288,7 @@ void Phantom::debugExit(int code)
 }
 
 // private slots:
-void Phantom::printConsoleMessage(const QString &message, int lineNumber, const QString &source)
+void Phantom::printConsoleMessage(const QString &message)
 {
     Terminal::instance()->cout(message);
 }

--- a/src/phantom.h
+++ b/src/phantom.h
@@ -93,7 +93,7 @@ signals:
     void aboutToExit(int code);
 
 private slots:
-    void printConsoleMessage(const QString &msg, int lineNumber, const QString &source);
+    void printConsoleMessage(const QString &msg);
 
     void onInitialized();
 private:

--- a/src/qt/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebpage_p.h
+++ b/src/qt/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebpage_p.h
@@ -106,7 +106,7 @@ public:
 private:
     void stepIn(const JSC::DebuggerCallFrame& frame, intptr_t sourceID, int lineNumber);
     void stepOver(const JSC::DebuggerCallFrame& frame, intptr_t sourceID, int lineNumber);
-    void stepOut();
+    void stepOut(const JSC::DebuggerCallFrame& frame);
     void reportError(const JSC::JSValue& exception);
 
     WTF::TextPosition0 textPosition(int lineNumber)
@@ -116,6 +116,8 @@ private:
     }
 
     RefPtr<WebCore::JavaScriptCallFrame> m_callFrame;
+    RefPtr<WebCore::JavaScriptCallFrame> m_exceptionFrame;
+    int m_stackDepth;
     QWebPage* m_webPage;
 };
 

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -89,7 +89,10 @@ protected:
     }
 
     void javaScriptConsoleMessage(const QString &message, int lineNumber, const QString &sourceID) {
-        m_webPage->emitConsoleMessage(message, lineNumber, sourceID);
+        Q_UNUSED(lineNumber);
+        Q_UNUSED(sourceID);
+
+        m_webPage->emitConsoleMessage(message);
     }
 
     void javaScriptError(const QWebPage::JavaScriptError& error) {
@@ -299,9 +302,9 @@ void WebPage::emitAlert(const QString &msg)
     emit javaScriptAlertSent(msg);
 }
 
-void WebPage::emitConsoleMessage(const QString &message, int lineNumber, const QString &source)
+void WebPage::emitConsoleMessage(const QString &message)
 {
-    emit javaScriptConsoleMessageSent(message, lineNumber, source);
+    emit javaScriptConsoleMessageSent(message);
 }
 
 void WebPage::emitError(const QWebPage::JavaScriptError& error)

--- a/src/webpage.h
+++ b/src/webpage.h
@@ -101,7 +101,7 @@ signals:
     void loadStarted();
     void loadFinished(const QString &status);
     void javaScriptAlertSent(const QString &msg);
-    void javaScriptConsoleMessageSent(const QString &message, int lineNumber, const QString &source);
+    void javaScriptConsoleMessageSent(const QString &message);
     void javaScriptErrorSent(const QString &message, const QVariantList &backtrace);
     void resourceRequested(const QVariant &req);
     void resourceReceived(const QVariant &resource);
@@ -116,7 +116,7 @@ private:
     QString userAgent() const;
 
     void emitAlert(const QString &msg);
-    void emitConsoleMessage(const QString &msg, int lineNumber, const QString &source);
+    void emitConsoleMessage(const QString &msg);
     void emitError(const QWebPage::JavaScriptError& error);
 
     virtual void initCompletions();

--- a/test/webpage-spec.js
+++ b/test/webpage-spec.js
@@ -229,6 +229,52 @@ describe("WebPage object", function() {
             expect(page.evaluate(function () { return window.navigator.plugins.length })).toEqual(0);
         });
     });
+
+    it("reports unhandled errors", function() {
+        var hadError = false;
+
+        runs(function() {
+            page = new require('webpage').create();
+            page.onError = function() { hadError = true };
+            page.evaluate(function() {
+              setTimeout(function() { referenceError }, 0)
+            });
+        });
+
+        waits(0);
+
+        runs(function() {
+            expect(hadError).toEqual(true);
+        });
+    })
+
+    it("doesn't report handled errors", function() {
+        var hadError    = false;
+        var caughtError = false;
+
+        page = new require('webpage').create();
+
+        runs(function() {
+            page.onError = function() { hadError = true };
+            page.evaluate(function() {
+                caughtError = false;
+                setTimeout(function() {
+                    try {
+                        referenceError
+                    } catch(e) {
+                        caughtError = true;
+                    }
+                }, 0)
+            });
+        });
+
+        waits(0);
+
+        runs(function() {
+            expect(hadError).toEqual(false);
+            expect(page.evaluate(function() { return caughtError })).toEqual(true);
+        });
+    })
 });
 
 describe("WebPage construction with options", function () {


### PR DESCRIPTION
I realised that `try { ... } catch (e) { ... }` exceptions would still be reported if the `catch` occurred in a different call frame to the exception.

This is fixed, which sorts out a bunch of error output that appeared in the tests.

Plus a couple of other minor commits.
