### PR TITLE
Fixing the "request.url" field, excluding symbols '/', '&' and '#'  from "percent encoding".

### DIFF
--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -172,7 +172,7 @@ bool WebServer::handleRequest(mg_event event, mg_connection *conn, const mg_requ
 
     QByteArray uri(request->uri);
     if (uri.startsWith('/'))
-        uri = '/' + QUrl::toPercentEncoding(QString::fromLatin1(request->uri + 1));
+        uri = '/' + QUrl::toPercentEncoding(QString::fromLatin1(request->uri + 1), "/?&#");
     if (request->query_string)
         uri.append('?').append(QByteArray(request->query_string));
     requestObject["url"] = uri.data();


### PR DESCRIPTION
Well, it's not really necessary for '#' but I'm just being safe (non-browser clients).

[Issue #437](http://code.google.com/p/phantomjs/issues/detail?id=437)
