### PR TITLE
Second attempt to solve Issue 439.

### DIFF
--- a/src/phantomjs.pro
+++ b/src/phantomjs.pro
@@ -4,7 +4,7 @@ QT += network webkit
 CONFIG += console
 
 # Comment to enable Debug Messages
-DEFINES += QT_NO_DEBUG_OUTPUT
+DEFINES += QT_NO_DEBUG_OUTPUT QT_NO_WARNING_OUTPUT
 
 DESTDIR = ../bin
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -52,14 +52,12 @@ void Utils::messageHandler(QtMsgType type, const char *msg)
     QDateTime now = QDateTime::currentDateTime();
 
     switch (type) {
-#ifndef QT_NO_DEBUG
     case QtDebugMsg:
         fprintf(stdout, "%s [DEBUG] %s\n", qPrintable(now.toString(Qt::ISODate)), msg);
         break;
     case QtWarningMsg:
         fprintf(stderr, "%s [WARNING] %s\n", qPrintable(now.toString(Qt::ISODate)), msg);
         break;
-#endif
     case QtCriticalMsg:
         fprintf(stderr, "%s [CRITICAL] %s\n", qPrintable(now.toString(Qt::ISODate)), msg);
         break;


### PR DESCRIPTION
[Issue 439](http://code.google.com/p/phantomjs/issues/detail?id=439).
This works for all kind of "Content Body" but with raw bytes: the issue is that QtWebKit doesn't know how to convert a "QByteArray" to a "QVariant" (to inject it in the JavaScript space), resulting in a malformed conversion (somehow it decides to create a map where byte position is the 'key' and the byte at that position is the 'value').

This fix covers most scenarios (hopefully) but we are blocked on solving it completely.

In this pull request there is an "extra" tiny commit that sorts out our use of "QT_NO_DEBUG_OUTPUT" and "QT_NO_WARNING_OUTPUT". Apology for the "mixture" but was too small to go anywhere else.
