### PR TITLE
Fixing test specs and addressing Issue 451 and 452

### DIFF
--- a/src/modules/webpage.js
+++ b/src/modules/webpage.js
@@ -158,6 +158,14 @@ exports.create = function (opts) {
                 data: arg2
             }, this.settings);
             return;
+        } else if (arguments.length === 5) {
+            this.onLoadFinished = arg4;
+            this.openUrl(url, {
+                operation: arg1,
+                data: arg2,
+                headers : arg3
+            }, this.settings);
+            return;
         }
         throw "Wrong use of WebPage#open";
     };

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -45,6 +45,7 @@
 #include <QWebFrame>
 #include <QWebPage>
 #include <QWebInspector>
+#include <QMapIterator>
 
 #include "networkaccessmanager.h"
 #include "utils.h"
@@ -346,6 +347,7 @@ void WebPage::openUrl(const QString &address, const QVariant &op, const QVariant
 {
     QString operation;
     QByteArray body;
+    QNetworkRequest request;
 
     applySettings(settings);
     m_webPage->triggerAction(QWebPage::Stop);
@@ -356,6 +358,13 @@ void WebPage::openUrl(const QString &address, const QVariant &op, const QVariant
     if (op.type() == QVariant::Map) {
         operation = op.toMap().value("operation").toString();
         body = op.toMap().value("data").toByteArray();
+        if (op.toMap().contains("headers")) {
+            QMapIterator<QString, QVariant> i(op.toMap().value("headers").toMap());
+            while (i.hasNext()) {
+                i.next();
+                request.setRawHeader(i.key().toUtf8(), i.value().toString().toUtf8());
+            }
+        }
     }
 
     if (operation.isEmpty())
@@ -391,8 +400,8 @@ void WebPage::openUrl(const QString &address, const QVariant &op, const QVariant
             url.setScheme("file");
         }
 #endif
-
-        m_mainFrame->load(QNetworkRequest(url), networkOp, body);
+        request.setUrl(url);
+        m_mainFrame->load(request, networkOp, body);
     }
 }
 

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -191,6 +191,7 @@ bool WebServer::handleRequest(mg_event event, mg_connection *conn, const mg_requ
     for (int i = 0; i < request->num_headers; ++i) {
         QString key = QString::fromLocal8Bit(request->http_headers[i].name);
         QString value = QString::fromLocal8Bit(request->http_headers[i].value);
+        qDebug() << "HTTP Request - Receiving Header" << key << "=" << value;
         headersObject[key] = value;
     }
     requestObject["headers"] = headersObject;
@@ -204,8 +205,6 @@ bool WebServer::handleRequest(mg_event event, mg_connection *conn, const mg_requ
 
         // Proceed only if we were able to read the "Content-Length"
         if (contentLengthKnown) {
-            qDebug() << "HTTP Request - 'Content-Length'" << qPrintable(contentLengthKnown);
-
             ++contentLength; //< make space for null termination
             char *data = new char[contentLength];
             int read = mg_read(conn, data, contentLength);
@@ -406,6 +405,12 @@ void WebServerResponse::write(const QString &body)
 void WebServerResponse::close()
 {
     m_close->release();
+}
+
+void WebServerResponse::closeGracefully()
+{
+    write("");
+    close();
 }
 
 int WebServerResponse::statusCode() const

--- a/src/webserver.h
+++ b/src/webserver.h
@@ -129,6 +129,9 @@ public slots:
      */
     void close();
 
+    /// Same as 'close()', but ensures response headers have been sent first
+    void closeGracefully();
+
     /// get the currently set status code, 200 is the default
     int statusCode() const;
     /// set the status code to @p code

--- a/test/fs-spec-03.js
+++ b/test/fs-spec-03.js
@@ -1,14 +1,13 @@
 describe("Files and Directories API", function() {
 	var TEST_DIR = "testdir",
 		TEST_FILE = "testfile",
-		START_CWD = null;
-	
-	it("should create a new temporary directory and change the Current Working Directory to it", function() {
 		START_CWD = fs.workingDirectory;
+
+	it("should create a new temporary directory and change the Current Working Directory to it", function() {
 		expect(fs.makeDirectory(TEST_DIR)).toBeTruthy();
 		expect(fs.changeWorkingDirectory(TEST_DIR)).toBeTruthy();
 	});
-	
+
 	it("should create a file in the Current Working Directory and check it's absolute path", function() {
 		fs.write(TEST_FILE, TEST_FILE, "w");
 		var suffix = fs.separator + TEST_DIR + fs.separator +  TEST_FILE,
@@ -17,18 +16,16 @@ describe("Files and Directories API", function() {
 		expect(lastIndex).toNotEqual(-1);
 		expect(lastIndex + suffix.length === abs.length);
 	});
-	
+
 	it("should return to previous Current Working Directory and remove temporary directory", function() {
 		expect(fs.changeWorkingDirectory(START_CWD)).toBeTruthy();
 		fs.removeTree(TEST_DIR);
 	});
 
-	it("should copy Current Working Directory tree in a temporary directory, compare with the original and remove", function() {
-		expect(fs.changeWorkingDirectory("../")).toBeTruthy();
-		fs.copyTree(START_CWD, TEST_DIR);
-		expect(fs.list(START_CWD).length).toEqual(fs.list(TEST_DIR).length);
+	it("should copy Content of the '/test/' Directory in a temporary directory, compare with the original and then remove", function() {
+		fs.copyTree(phantom.libraryPath, TEST_DIR);
+		expect(fs.list(phantom.libraryPath).length).toEqual(fs.list(TEST_DIR).length);
 		fs.removeTree(TEST_DIR);
-		expect(fs.changeWorkingDirectory(START_CWD)).toBeTruthy();
 	});
 
     // TODO: test the actual functionality once we can create symlink.

--- a/test/system-spec.js
+++ b/test/system-spec.js
@@ -23,7 +23,7 @@ describe("System object", function() {
     });
 
     it("should have args[0] as the this test runner", function() {
-        expect(system.args[0]).toEqual('run-tests.js');
+        expect(system.args[0]).toMatch(/run-tests.js$/);
     });
 
     it("should have env as object", function() {

--- a/test/webserver-spec.js
+++ b/test/webserver-spec.js
@@ -32,12 +32,14 @@ function checkRequest(request, response) {
         expect(request.method).toEqual("POST");
         expect(request.hasOwnProperty('post')).toBeTruthy();
         expect(typeof request.post).toEqual('object');
-        console.log(JSON.stringify(request.post, null, 4));
-        console.log(JSON.stringify(expectedPostData, null, 4));
-        console.log(JSON.stringify(request.headersappl, null, 4));
+        console.log("request.post => " + JSON.stringify(request.post, null, 4));
+        console.log("expectedPostData => " + JSON.stringify(expectedPostData, null, 4));
+        console.log("request.headers => " + JSON.stringify(request.headers, null, 4));
         expect(request.post).toEqual(expectedPostData);
-        expect(request.hasOwnProperty('rawData')).toBeTruthy();
-        expect(typeof request.rawData).toEqual('object');
+        if (request.headers["Content-Type"] && request.headers["Content-Type"] === "application/x-www-form-urlencoded") {
+            expect(request.hasOwnProperty('postRaw')).toBeTruthy();
+            expect(typeof request.postRaw).toEqual('string');
+        }
         expectedPostData = false;
     }
 
@@ -83,7 +85,7 @@ describe("WebServer object", function() {
     });
     it("should be able to listen to some port", function() {
         //NOTE: this can fail if the port is already being listend on...
-        expect(server.listen(12345, checkRequest)).toEqual(true);
+        expect(server.listen("12345", checkRequest)).toEqual(true);
         expect(server.port).toEqual("12345");
     });
 


### PR DESCRIPTION
This pull request covers a bit of extra ground:
- fixes the test spec for the "webserver" and "fs" modules
- addresses Issue 451 (that I opened) to add a "closeGracefully" method to the "response" object
- addresses Issue 452 (that I opened) to allow passing "headers" to the "webpage.open()" method

I know 2 are "features" but putting them in branches would have been too much for too little (the code is minimal to add the features).

_PS_ I'm sort of "adding features" as I come across scenarios that we don't cover for my work on [ghostdriver](https://github.com/detro/ghostdriver). I'm keeping myself as general as possible, so hopefully nothing I do is biased by my needs :)
_PPS_ I know, this will probably end in 1.6 as 1.5 has already been released. And it's OK, because none of those are fixes to functionality.
