### PR TITLE
Add --debug option

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -131,6 +131,10 @@ void Config::processArgs(const QStringList &args)
             loadJsonFile(configPath);
             continue;
         }
+        if (arg.startsWith("--debug")) {
+            setDebug(true);
+            continue;
+        }
         if (arg.startsWith("--remote-debugger-port=")) {
             setDebug(true);
             setRemoteDebugPort(arg.mid(23).trimmed().toInt());

--- a/src/modules/webpage.js
+++ b/src/modules/webpage.js
@@ -127,7 +127,10 @@ exports.create = function (opts) {
 
     defineSetter("onError", "javaScriptErrorSent");
 
-    page.onError = phantom.defaultErrorHandler;
+    // Set default error handler when in debug mode
+    if (phantom.isDebug) {
+      page.onError = phantom.defaultErrorHandler;
+    }
 
     page.open = function (url, arg1, arg2, arg3, arg4) {
         if (arguments.length === 1) {

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -210,6 +210,11 @@ QObject *Phantom::page() const
     return m_page;
 }
 
+bool Phantom::isDebug() const
+{
+    return m_config.debug();
+}
+
 // public slots:
 QObject *Phantom::createWebPage()
 {
@@ -327,6 +332,7 @@ void Phantom::initCompletions()
     // properties
     addCompletion("args");
     addCompletion("defaultPageSettings");
+    addCompletion("isDebug");
     addCompletion("libraryPath");
     addCompletion("outputEncoding");
     addCompletion("scriptName");

--- a/src/phantom.h
+++ b/src/phantom.h
@@ -53,6 +53,7 @@ class Phantom: public REPLCompletable
     Q_PROPERTY(QString scriptName READ scriptName)
     Q_PROPERTY(QVariantMap version READ version)
     Q_PROPERTY(QObject *page READ page)
+    Q_PROPERTY(bool isDebug READ isDebug)
 
 public:
     Phantom(QObject *parent = 0);
@@ -76,6 +77,8 @@ public:
     QVariantMap version() const;
 
     QObject* page() const;
+
+    bool isDebug() const;
 
 public slots:
     QObject *createWebPage();

--- a/src/usage.txt
+++ b/src/usage.txt
@@ -5,6 +5,7 @@ Options:
 
   --cookies-file=/path/to/cookies.txt    Sets the file name to store the persistent cookies
   --config=/path/to/config               Specifies path to a JSON-formatted config file
+  --debug                                Turn on debugging (e.g., error stacktraces)
   --disk-cache=[yes|no]                  Enables disk cache (at desktop services cache storage location, default is 'no')
   --ignore-ssl-errors=[yes|no]           Ignores SSL errors (i.e. expired or self-signed certificate errors)
   --load-images=[yes|no]                 Loads all inlined images (default is 'yes')

--- a/test/phantom-spec.js
+++ b/test/phantom-spec.js
@@ -67,4 +67,8 @@ describe("phantom global object", function() {
     it("should have 'exit' function", function() {
         expect(typeof phantom.exit).toEqual("function");
     });
+
+    it("should have 'isDebug' property", function() {
+        expect(typeof phantom.isDebug).toEqual("boolean");
+    });
 });


### PR DESCRIPTION
[Issue 436](http://code.google.com/p/phantomjs/issues/detail?id=436)

This adds a `--debug` option and makes it visible in JS-land via `phantom.isDebug`.  Also, when `phantom.isDebug` is `true`, new `WebPage`s have a default `onError` handler set.
