### PR TITLE
Fix: the last part of the stack trace was missing

### DIFF
--- a/src/qt/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebpage_p.h
+++ b/src/qt/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebpage_p.h
@@ -119,6 +119,10 @@ private:
     RefPtr<WebCore::JavaScriptCallFrame> m_exceptionFrame;
     int m_stackDepth;
     QWebPage* m_webPage;
+    
+    QString s_file;
+    int s_line;
+    QString s_function;
 };
 
 class QWebPagePrivate {


### PR DESCRIPTION
PhantomJS did not give away the full stack trace, which made tracking errors really hard. This patch basically tracks the last part of the stack and adds it on top when needed.
