### PR TITLE
fix crash on close

### DIFF
--- a/src/qt/src/gui/kernel/qeventdispatcher_qpa.cpp
+++ b/src/qt/src/gui/kernel/qeventdispatcher_qpa.cpp
@@ -121,6 +121,7 @@ public:
            barrierBeforeBlocking(0),
            barrierReturnValue(0),
            selectReturnMutex(0),
+           selectWorker(0),
            selectWorkerNeedsSync(true),
            selectWorkerHasResult(false),
            m_integrationInitialised(false),


### PR DESCRIPTION
selectWorker was uninitialized in QEventDispatcherQPAPrivate and leads to a crash on close when the invalid pointer adress is tried to be deleted
