### PR TITLE
Handle binary data passed to WebServer's write method correctly.

### DIFF
--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -398,7 +398,12 @@ void WebServerResponse::write(const QString &body)
         writeHead(m_statusCode, m_headers);
     }
     ///TODO: encoding?!
-    const QByteArray data = body.toLocal8Bit();
+
+    QByteArray data(body.size(), Qt::Uninitialized);
+    for(int i = 0; i < body.size(); ++i) {
+      data[i] = body.at(i).toAscii();
+    }
+
     mg_write(m_conn, data.constData(), data.size());
 }
 


### PR DESCRIPTION
When trying to pass binary data to webserver.write() (for instance rendered PDF file, opened later with fs module in binary mode), data has been being corrupted due to QString method toLocal8Bit which stops execution on approaching '\0' character.

This change implements custom handling of QString->QByteArray conversion in order to fix that problem.
