### PR TITLE
Reuse number of jobs configured in MAKEFLAGS env var if available

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,11 @@ QT_CFG=''
 
 COMPILE_JOBS=1
 
-if [[ $OSTYPE = darwin* ]]; then
+MAKEFLAGS_JOBS=$(echo $MAKEFLAGS | egrep -o '\-j[0-9]+' | egrep -o '[0-9]+')
+if [[ "$MAKEFLAGS_JOBS" != "" ]]; then
+  # user defined number of jobs in MAKEFLAGS, re-use that number
+  COMPILE_JOBS=$MAKEFLAGS_JOBS
+elif [[ $OSTYPE = darwin* ]]; then
    # We only support modern Mac machines, they are at least using
    # hyperthreaded dual-core CPU.
    COMPILE_JOBS=4


### PR DESCRIPTION
Especially on machines that are connected to a compile farm, the
MAKEFLAGS env var is usually set to configure the default number
of jobs that should be used. This way, one can just call the
PhantomJS build script without passing the number of jobs every
time.

ISSUE 503 (http://code.google.com/p/phantomjs/issues/detail?id=503)
