### PR TITLE
Use a more descriptive format for --cookies-file

### DIFF
--- a/src/cookiejar.cpp
+++ b/src/cookiejar.cpp
@@ -43,13 +43,13 @@ bool CookieJar::setCookiesFromUrl(const QList<QNetworkCookie> & cookieList, cons
     QSettings settings(m_cookiesFile, QSettings::IniFormat);
 
     settings.beginGroup(url.host());
-    
+
     for (QList<QNetworkCookie>::const_iterator i = cookieList.begin(); i != cookieList.end(); i++) {
-        settings.setValue((*i).name(), QString((*i).value()));
+      settings.setValue((*i).name(), (*i).toRawForm());
     }
-    
+
     settings.sync();
-    
+
     return true;
 }
 
@@ -61,10 +61,10 @@ QList<QNetworkCookie> CookieJar::cookiesForUrl(const QUrl & url) const
     settings.beginGroup(url.host());
 
     QStringList keys = settings.childKeys();
-    
+
     for (QStringList::iterator i = keys.begin(); i != keys.end(); i++) {
-        cookieList.push_back(QNetworkCookie((*i).toLocal8Bit(), settings.value(*i).toByteArray()));
+        cookieList.append(QNetworkCookie::parseCookies(settings.value(*i).toByteArray()));
     }
-    
+
     return cookieList;
 }


### PR DESCRIPTION
Currently, --cookies-file only stores the name-value pairs for cookies,
e.g.:

[mobile.twitter.com]
k=00.000.00.000.000000000000

After this commit, all cookie details are stored, e.g.:

[mobile.twitter.com]
k="@ByteArray(k=00.000.00.000.0000000000000000; expires=Wed, 25-Apr-2012
08:11:49 GMT; domain=.twitter.com; path=/)"

Loading the "expires" variable can make cookies less reusable,
but having the domain and path is required for cookies to work properly
in some websites. HttpOnly and Secure cookie flags can also change the
functionality of a page.

This patch presents one way to get access to more detailed cookies. A
better approach would be to add a page.cookies() function.
