### PR TITLE
Properly pass --qt-config value from build.sh to src/qt/preconfig.sh.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -28,7 +28,7 @@ until [ -z "$1" ]; do
     case $1 in
         "--qt-config")
             shift
-            QT_CFG+=" $1"
+            QT_CFG=" $1"
             shift;;
         "--jobs")
             shift
@@ -48,6 +48,6 @@ until [ -z "$1" ]; do
     esac
 done
 
-cd src/qt && ./preconfig.sh --jobs $COMPILE_JOBS && cd ../..
+cd src/qt && ./preconfig.sh --jobs $COMPILE_JOBS --qt-config "$QT_CFG" && cd ../..
 src/qt/bin/qmake
 make -j$COMPILE_JOBS


### PR DESCRIPTION
This way one can properly cross-compile PhantomJS for different
platforms e.g. by passing --qt-config '-platform ...' to build.sh.

ISSUE: 507 (http://code.google.com/p/phantomjs/issues/detail?id=507)
