### PR TITLE
Properly handle fourth CLI parameter in rasterize.js example.

### DIFF
--- a/examples/rasterize.js
+++ b/examples/rasterize.js
@@ -10,10 +10,10 @@ if (system.args.length < 3 || system.args.length > 4) {
     address = system.args[1];
     output = system.args[2];
     page.viewportSize = { width: 600, height: 600 };
-    if (system.args.length === 3 && system.args[1].substr(-4) === ".pdf") {
-        size = system.args[2].split('*');
+    if (system.args.length === 4 && system.args[2].substr(-4) === ".pdf") {
+        size = system.args[3].split('*');
         page.paperSize = size.length === 2 ? { width: size[0], height: size[1], margin: '0px' }
-                                           : { format: system.args[2], orientation: 'portrait', margin: '1cm' };
+                                           : { format: system.args[3], orientation: 'portrait', margin: '1cm' };
     }
     page.open(address, function (status) {
         if (status !== 'success') {


### PR DESCRIPTION
After the change to system.args which has the app as first element,
the rasterize example was not properly adapted. Due to that, one
could not pass a size parameter to it anymore, resulting in PDFs
without page breaks.

ISSUE: 523 (http://code.google.com/p/phantomjs/issues/detail?id=523)
