### PR TITLE
Improve error handling

### DIFF
--- a/src/modules/webpage.js
+++ b/src/modules/webpage.js
@@ -125,7 +125,7 @@ exports.create = function (opts) {
 
     defineSetter("onConsoleMessage", "javaScriptConsoleMessageSent");
 
-    defineSetter("onError", "javaScriptErrorSent");
+    phantom.__defineErrorSetter__(page, page);
 
     page.onError = phantom.defaultErrorHandler;
 

--- a/src/qt/src/3rdparty/webkit/Source/WebCore/bindings/js/JSDOMBinding.cpp
+++ b/src/qt/src/3rdparty/webkit/Source/WebCore/bindings/js/JSDOMBinding.cpp
@@ -185,6 +185,11 @@ void reportException(ExecState* exec, JSValue exception)
     if (!scriptExecutionContext)
         return;
 
+    exec->dynamicGlobalObject()->putWithAttributes(
+        exec, Identifier(exec, "__exception"),
+        exception, ReadOnly
+    );
+
     scriptExecutionContext->reportException(ustringToString(errorMessage), lineNumber, ustringToString(exceptionSourceURL), 0);
 }
 

--- a/src/qt/src/3rdparty/webkit/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
+++ b/src/qt/src/3rdparty/webkit/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
@@ -109,24 +109,7 @@ bool JSDOMWindowBase::supportsProfiling() const
 
 bool JSDOMWindowBase::supportsRichSourceInfo() const
 {
-#if PLATFORM(ANDROID)
     return true;
-#elif !ENABLE(JAVASCRIPT_DEBUGGER) || !ENABLE(INSPECTOR)
-    return false;
-#else
-    Frame* frame = impl()->frame();
-    if (!frame)
-        return false;
-
-    Page* page = frame->page();
-    if (!page)
-        return false;
-
-    bool enabled = page->inspectorController()->enabled();
-    ASSERT(enabled || !debugger());
-    ASSERT(enabled || !supportsProfiling());
-    return enabled;
-#endif
 }
 
 bool JSDOMWindowBase::shouldInterruptScript() const

--- a/src/qt/src/3rdparty/webkit/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/src/qt/src/3rdparty/webkit/Source/WebCore/bindings/js/ScriptController.cpp
@@ -154,6 +154,10 @@ ScriptValue ScriptController::evaluateInWorld(const ScriptSourceCode& sourceCode
         return ScriptValue(exec->globalData(), comp.value());
     }
 
+    if (comp.complType() == Throw || comp.complType() == Interrupted) {
+        reportException(exec, comp.value());
+    }
+
     m_sourceURL = savedSourceURL;
     return ScriptValue();
 }

--- a/src/qt/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebpage.h
+++ b/src/qt/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebpage.h
@@ -244,41 +244,6 @@ public:
         friend class QWebPage;
     };
 
-    class QWEBKIT_EXPORT JavaScriptFrame {
-    public:
-        JavaScriptFrame(const QString& file, int line, const QString& function)
-          : m_file(file)
-          , m_line(line)
-          , m_function(function)
-        {
-        }
-
-        QString file() const { return m_file; };
-        int line() const { return m_line; };
-        QString function() const { return m_function; };
-
-    private:
-        QString m_file;
-        int m_line;
-        QString m_function;
-    };
-
-    class QWEBKIT_EXPORT JavaScriptError {
-    public:
-        JavaScriptError(const QString& message, const QList<JavaScriptFrame>& backtrace)
-          : m_message(message)
-          , m_backtrace(backtrace)
-        {
-        }
-
-        QString message() const { return m_message; };
-        QList<JavaScriptFrame> backtrace() const { return m_backtrace; };
-
-    private:
-        QString m_message;
-        QList<JavaScriptFrame> m_backtrace;
-    };
-
     explicit QWebPage(QObject *parent = 0);
     ~QWebPage();
 
@@ -448,7 +413,7 @@ protected:
     virtual bool javaScriptConfirm(QWebFrame *originatingFrame, const QString& msg);
     virtual bool javaScriptPrompt(QWebFrame *originatingFrame, const QString& msg, const QString& defaultValue, QString* result);
     virtual void javaScriptConsoleMessage(const QString& message, int lineNumber, const QString& sourceID);
-    virtual void javaScriptError(const JavaScriptError& error);
+    virtual void javaScriptError(const QString& message, int lineNumber, const QString& sourceID);
 
     virtual QString userAgentForUrl(const QUrl& url) const;
 
@@ -463,7 +428,6 @@ private:
 
     friend class QWebFrame;
     friend class QWebPagePrivate;
-    friend class QWebPagePrivateDebugger;
     friend class QWebView;
     friend class QWebViewPrivate;
     friend class QGraphicsWebView;

--- a/src/qt/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebpage_p.h
+++ b/src/qt/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebpage_p.h
@@ -35,11 +35,8 @@
 #include "KURL.h"
 #include "PlatformString.h"
 
-#include <debugger/Debugger.h>
-
 #include <wtf/OwnPtr.h>
 #include <wtf/RefPtr.h>
-#include <wtf/text/TextPosition.h>
 
 #include "ViewportArguments.h"
 
@@ -57,15 +54,6 @@ namespace WebCore {
     class NodeList;
     class Page;
     class Frame;
-    class JavaScriptCallFrame;
-}
-
-namespace JSC {
-    class JSGlobalObject;
-    class ExecState;
-    class SourceProvider;
-    class DebuggerCallFrame;
-    class UString;
 }
 
 QT_BEGIN_NAMESPACE
@@ -84,41 +72,6 @@ public:
     { }
 
     QWebPage::ViewportAttributes* q;
-};
-
-class QWebPagePrivateDebugger : public JSC::Debugger {
-public:
-    QWebPagePrivateDebugger(QWebPage*);
-    ~QWebPagePrivateDebugger();
-
-    void detach(JSC::JSGlobalObject*);
-
-    void sourceParsed(JSC::ExecState*, JSC::SourceProvider*, int errorLineNumber, const JSC::UString& errorMessage);
-    void exception(const JSC::DebuggerCallFrame&, intptr_t sourceID, int lineNumber, bool hasHandler);
-    void atStatement(const JSC::DebuggerCallFrame&, intptr_t sourceID, int lineNumber);
-    void callEvent(const JSC::DebuggerCallFrame&, intptr_t sourceID, int lineNumber);
-    void returnEvent(const JSC::DebuggerCallFrame&, intptr_t sourceID, int lineNumber);
-
-    void willExecuteProgram(const JSC::DebuggerCallFrame&, intptr_t sourceID, int lineNumber);
-    void didExecuteProgram(const JSC::DebuggerCallFrame&, intptr_t sourceID, int lineNumber);
-    void didReachBreakpoint(const JSC::DebuggerCallFrame&, intptr_t sourceID, int lineNumber);
-
-private:
-    void stepIn(const JSC::DebuggerCallFrame& frame, intptr_t sourceID, int lineNumber);
-    void stepOver(const JSC::DebuggerCallFrame& frame, intptr_t sourceID, int lineNumber);
-    void stepOut(const JSC::DebuggerCallFrame& frame);
-    void reportError(const JSC::JSValue& exception);
-
-    WTF::TextPosition0 textPosition(int lineNumber)
-    {
-        WTF::ZeroBasedNumber zeroBasedNumber = WTF::OneBasedNumber::fromOneBasedInt(lineNumber).convertToZeroBased();
-        return WTF::TextPosition0(zeroBasedNumber, WTF::ZeroBasedNumber::base());
-    }
-
-    RefPtr<WebCore::JavaScriptCallFrame> m_callFrame;
-    RefPtr<WebCore::JavaScriptCallFrame> m_exceptionFrame;
-    int m_stackDepth;
-    QWebPage* m_webPage;
 };
 
 class QWebPagePrivate {
@@ -257,7 +210,6 @@ public:
     QWebInspector* inspector;
     bool inspectorIsInternalOnly; // True if created through the Inspect context menu action
     Qt::DropAction m_lastDropAction;
-    QWebPagePrivateDebugger* debugger;
 
     static bool drtRun;
 };

--- a/src/qt/src/3rdparty/webkit/Source/WebKit/qt/WebCoreSupport/ChromeClientQt.cpp
+++ b/src/qt/src/3rdparty/webkit/Source/WebKit/qt/WebCoreSupport/ChromeClientQt.cpp
@@ -294,12 +294,19 @@ void ChromeClientQt::setResizable(bool)
     notImplemented();
 }
 
-void ChromeClientQt::addMessageToConsole(MessageSource, MessageType, MessageLevel, const String& message,
+void ChromeClientQt::addMessageToConsole(MessageSource src, MessageType type, MessageLevel level, const String& message,
                                          unsigned int lineNumber, const String& sourceID)
 {
     QString x = message;
     QString y = sourceID;
-    m_webPage->javaScriptConsoleMessage(x, lineNumber, y);
+
+    // the MessageType value isn't useful - it will be LogMessageType for both errors
+    // and log messages.
+    if (level == ErrorMessageLevel) {
+      m_webPage->javaScriptError(x, lineNumber, y);
+    } else {
+      m_webPage->javaScriptConsoleMessage(x, lineNumber, y);
+    }
 }
 
 void ChromeClientQt::chromeDestroyed()

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -97,8 +97,8 @@ protected:
         m_webPage->emitConsoleMessage(message);
     }
 
-    void javaScriptError(const QWebPage::JavaScriptError& error) {
-        m_webPage->emitError(error);
+    void javaScriptError(const QString &message, int lineNumber, const QString &sourceID) {
+        m_webPage->emitError();
     }
 
     QString userAgentForUrl(const QUrl &url) const {
@@ -308,23 +308,9 @@ void WebPage::emitConsoleMessage(const QString &message)
     emit javaScriptConsoleMessageSent(message);
 }
 
-void WebPage::emitError(const QWebPage::JavaScriptError& error)
+void WebPage::emitError()
 {
-    QList<QWebPage::JavaScriptFrame> backtrace = error.backtrace();
-    QVariantList newBacktrace = QVariantList();
-
-    for (int i = 0; i < backtrace.size(); ++i) {
-        QWebPage::JavaScriptFrame frame = backtrace.at(i);
-
-        QVariantMap newFrame = QVariantMap();
-        newFrame["file"] = frame.file();
-        newFrame["line"] = frame.line();
-        newFrame["function"] = frame.function();
-
-        newBacktrace << newFrame;
-    }
-
-    emit javaScriptErrorSent(error.message(), newBacktrace);
+    emit javaScriptErrorSent();
 }
 
 void WebPage::finish(bool ok)

--- a/src/webpage.h
+++ b/src/webpage.h
@@ -108,7 +108,7 @@ signals:
     void loadFinished(const QString &status);
     void javaScriptAlertSent(const QString &msg);
     void javaScriptConsoleMessageSent(const QString &message);
-    void javaScriptErrorSent(const QString &message, const QVariantList &backtrace);
+    void javaScriptErrorSent();
     void resourceRequested(const QVariant &req);
     void resourceReceived(const QVariant &resource);
 
@@ -123,7 +123,7 @@ private:
 
     void emitAlert(const QString &msg);
     void emitConsoleMessage(const QString &msg);
-    void emitError(const QWebPage::JavaScriptError& error);
+    void emitError();
 
     virtual void initCompletions();
 

--- a/test/fixtures/error-helper.js
+++ b/test/fixtures/error-helper.js
@@ -1,0 +1,9 @@
+ErrorHelper = {
+    foo: function foo() {
+        this.bar()
+    },
+
+    bar: function bar() {
+        referenceError
+    }
+};

--- a/test/webpage-spec.js
+++ b/test/webpage-spec.js
@@ -303,6 +303,40 @@ describe("WebPage object", function() {
         });
     });
 
+    it("reports the stack of errors", function() {
+        var helperFile = "./fixtures/error-helper.js";
+        phantom.injectJs(helperFile);
+
+        runs(function() {
+            function test() {
+                ErrorHelper.foo()
+            };
+
+            var err;
+            try {
+                test()
+            } catch (e) {
+                err = e
+            };
+
+            var frame;
+
+            frame = err.stack[0];
+            expect(frame.sourceURL).toEqual(helperFile);
+            expect(frame.line).toEqual(7);
+            expect(frame.function).toEqual("bar");
+
+            frame = err.stack[1];
+            expect(frame.sourceURL).toEqual(helperFile);
+            expect(frame.line).toEqual(3);
+            expect(frame.function).toEqual("foo");
+
+            frame = err.stack[2];
+            expect(frame.sourceURL).toMatch(/webpage-spec.js$/);
+            expect(frame.function).toEqual("test");
+        });
+    });
+
     it("should set custom headers properly", function() {
         var server = require('webserver').create();
         server.listen(12345, function(request, response) {

--- a/test/webpage-spec.js
+++ b/test/webpage-spec.js
@@ -281,6 +281,28 @@ describe("WebPage object", function() {
         });
     })
 
+    it("reports the sourceURL and line of errors", function() {
+        runs(function() {
+            var e1, e2;
+
+            try {
+                referenceError
+            } catch (e) {
+                e1 = e
+            };
+
+            try {
+                referenceError
+            } catch (e) {
+                e2 = e
+            };
+
+            expect(e1.sourceURL).toMatch(/webpage-spec.js$/);
+            expect(e1.line).toBeGreaterThan(1);
+            expect(e2.line).toEqual(e1.line + 6);
+        });
+    });
+
     it("should set custom headers properly", function() {
         var server = require('webserver').create();
         server.listen(12345, function(request, response) {


### PR DESCRIPTION
- Adds `e.stack`
- Sends `page.evaluate(...)` errors to the `page.onError` rather than `phantom.onError` handler
- Sends proper objects to the `onError` handler

https://code.google.com/p/phantomjs/issues/detail?id=166
