### PR TITLE
Add WebPage.setCookies and WebPage.getCookies apis for the issue 354.

### DIFF
--- a/src/modules/webpage.js
+++ b/src/modules/webpage.js
@@ -209,7 +209,33 @@ exports.create = function (opts) {
         }
         str = str.replace(/,$/, '') + '); }';
         return this.evaluateJavaScript(str);
-    }
+    };
+
+	/**
+	 * get cookies from the page
+	 * @param   string  url			the url to represent/identify the page
+	*/
+	page.getCookies = function (url) {
+		return this.getCookies(url);
+	};
+
+	/**
+	 * set cookies to the page
+	 * @param   string  url			the url to represent/identify the page
+	 * @param   []{...} cookies		an array of cookies object with arguments in mozilla format
+	 * 			cookies[0] = {
+	 *				'name' => 'Cookie-Name',
+	 *				'value' => 'Cookie-Value',
+	 *				'domain' => 'foo.com',
+	 *				'path' => 'Cookie-Path',
+	 *				'expires' => 'Cookie-Expiration-Date',
+	 *				'httponly' => true | false,
+	 *				'secure' => true | false
+	 * 			};
+	*/
+	page.setCookies = function (url, cookies) {
+		this.setCookies(url, cookies);
+	};
 
     // Copy options into page
     if (opts) {

--- a/src/webpage.h
+++ b/src/webpage.h
@@ -101,6 +101,8 @@ public slots:
     void _appendScriptElement(const QString &scriptUrl);
     void uploadFile(const QString &selector, const QString &fileName);
     void sendEvent(const QString &type, const QVariant &arg1 = QVariant(), const QVariant &arg2 = QVariant());
+	void setCookies(const QString &address, const QVariantList &cookies);
+	QVariantMap getCookies(const QString &address);
 
 signals:
     void initialized();

--- a/test/webpage-spec.js
+++ b/test/webpage-spec.js
@@ -98,6 +98,8 @@ describe("WebPage object", function() {
     expectHasFunction(page, 'resourceReceived');
     expectHasFunction(page, 'resourceRequested');
     expectHasFunction(page, 'uploadFile');
+	expectHasFunction(page, 'setCookies');
+	expectHasFunction(page, 'getCookies');
 
     expectHasFunction(page, 'sendEvent');
 
@@ -323,6 +325,46 @@ describe("WebPage object", function() {
         });
 
     });
+
+	it("should set cookies properly", function() {
+		var server = require('webserver').create();
+		server.listen(12345, function(request, response) {
+			// echo received request headers in response body
+			response.write(JSON.stringify(request.headers));
+			response.close();
+		});
+
+		var url = "http://localhost:12345/foo/headers.txt?ab=cd";
+
+		var cookies = [];
+		cookies[0] = {
+			'name' : 'Cookie-Name',
+			'value' : 'Cookie-Value',
+			'domain' : 'localhost'
+		};
+		page.setCookies(url, cookies);
+
+		var handled = false;
+		runs(function() {
+			expect(handled).toEqual(false);
+			page.open(url, function (status) {
+				expect(status == 'success').toEqual(true);
+				handled = true;
+
+				var cookies = page.getCookies(url);
+				// console.log(JSON.stringify(cookies));
+				expect(cookies["Cookie-Name"]).toEqual("Cookie-Value");
+			});
+		});
+
+		waits(50);
+
+		runs(function() {
+			expect(handled).toEqual(true);
+			server.close();
+		});
+
+	});
 
     it("should pass variables to functions properly", function() {
         var testPrimitiveArgs = function() {


### PR DESCRIPTION
Add WebPage.setCookies and WebPage.getCookies apis for the issue 354.

Add sanity check for the cookies api in test/webpage-spec.js.

http://code.google.com/p/phantomjs/issues/detail?id=354
