### PR TITLE
Make QWebPage::zoomFactor accessible to PhantomJS scripts.

### DIFF
--- a/examples/rasterize.js
+++ b/examples/rasterize.js
@@ -2,18 +2,21 @@ var page = require('webpage').create(),
     system = require('system'),
     address, output, size;
 
-if (system.args.length < 3 || system.args.length > 4) {
-    console.log('Usage: rasterize.js URL filename [paperwidth*paperheight|paperformat]');
+if (system.args.length < 3 || system.args.length > 5) {
+    console.log('Usage: rasterize.js URL filename [paperwidth*paperheight|paperformat] [zoom]');
     console.log('  paper (pdf output) examples: "5in*7.5in", "10cm*20cm", "A4", "Letter"');
     phantom.exit(1);
 } else {
     address = system.args[1];
     output = system.args[2];
     page.viewportSize = { width: 600, height: 600 };
-    if (system.args.length === 4 && system.args[2].substr(-4) === ".pdf") {
+    if (system.args.length > 3 && system.args[2].substr(-4) === ".pdf") {
         size = system.args[3].split('*');
         page.paperSize = size.length === 2 ? { width: size[0], height: size[1], margin: '0px' }
                                            : { format: system.args[3], orientation: 'portrait', margin: '1cm' };
+    }
+    if (system.args.length > 4) {
+        page.zoomFactor = system.args[4];
     }
     page.open(address, function (status) {
         if (status !== 'success') {

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -618,6 +618,16 @@ bool WebPage::renderPdf(const QString &fileName)
     return true;
 }
 
+void WebPage::setZoomFactor(qreal zoom)
+{
+    m_mainFrame->setZoomFactor(zoom);
+}
+
+qreal WebPage::zoomFactor() const
+{
+    return m_mainFrame->zoomFactor();
+}
+
 qreal getHeight(const QVariantMap &map, const QString &key)
 {
     QVariant footer = map.value(key);

--- a/src/webpage.h
+++ b/src/webpage.h
@@ -55,6 +55,7 @@ class WebPage: public REPLCompletable, public QWebFrame::PrintCallback
     Q_PROPERTY(QVariantMap clipRect READ clipRect WRITE setClipRect)
     Q_PROPERTY(QVariantMap scrollPosition READ scrollPosition WRITE setScrollPosition)
     Q_PROPERTY(QVariantMap customHeaders READ customHeaders WRITE setCustomHeaders)
+    Q_PROPERTY(qreal zoomFactor READ zoomFactor WRITE setZoomFactor)
 
 public:
     WebPage(QObject *parent, const Config *config, const QUrl &baseUrl = QUrl());
@@ -90,6 +91,9 @@ public:
     qreal footerHeight() const;
     QString header(int page, int numPages);
     qreal headerHeight() const;
+
+    void setZoomFactor(qreal zoom);
+    qreal zoomFactor() const;
 
 public slots:
     void openUrl(const QString &address, const QVariant &op, const QVariantMap &settings);

--- a/test/webpage-spec.js
+++ b/test/webpage-spec.js
@@ -81,6 +81,11 @@ describe("WebPage object", function() {
             expect(page.customHeaders).toEqual({});
     });
 
+    expectHasProperty(page, 'zoomFactor');
+    it("should have zoomFactor of 1", function() {
+            expect(page.zoomFactor).toEqual(1.0);
+    });
+
     checkViewportSize(page, {height:300,width:400});
 
     expectHasFunction(page, 'deleteLater');


### PR DESCRIPTION
This adds a new WebPage::zoomFactor property, which can be used to
zoom the page, i.e.:

page.zoomFactor = 1.5; // zoom by 50% in
page.zoomFactor = 0.5; // zoom by 50% out

The rasterize.js example is adapted to take an optional fourth argument
to set the zoom factor. Furthermore, the webpage-spec is extended with
a simple test case for the new property.

ISSUE: 579 (http://code.google.com/p/phantomjs/issues/detail?id=579)
