### PR TITLE
Compile the breakpad client in directly.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -48,10 +48,6 @@ until [ -z "$1" ]; do
     esac
 done
 
-if [[ $OSTYPE = linux* ]]; then
-    cd src/breakpad && ./configure && make && cd ../..
-fi
-
 cd src/qt && ./preconfig.sh --jobs $COMPILE_JOBS --qt-config "$QT_CFG" && cd ../..
 src/qt/bin/qmake
 make -j$COMPILE_JOBS

--- a/src/phantomjs.pro
+++ b/src/phantomjs.pro
@@ -59,8 +59,22 @@ include(mongoose/mongoose.pri)
 include(linenoise/linenoise.pri)
 
 linux* {
-    INCLUDEPATH += $$PWD/breakpad/src
-    LIBS += $$PWD/breakpad/src/client/linux/libbreakpad_client.a
+    INCLUDEPATH += breakpad/src
+
+    SOURCES += breakpad/src/client/linux/crash_generation/crash_generation_client.cc \
+      breakpad/src/client/linux/handler/exception_handler.cc \
+      breakpad/src/client/linux/log/log.cc \
+      breakpad/src/client/linux/minidump_writer/linux_dumper.cc \
+      breakpad/src/client/linux/minidump_writer/linux_ptrace_dumper.cc \
+      breakpad/src/client/linux/minidump_writer/minidump_writer.cc \
+      breakpad/src/client/minidump_file_writer.cc \
+      breakpad/src/common/convert_UTF.c \
+      breakpad/src/common/md5.cc \
+      breakpad/src/common/string_conversion.cc \
+      breakpad/src/common/linux/file_id.cc \
+      breakpad/src/common/linux/guid_creator.cc \
+      breakpad/src/common/linux/memory_mapped_file.cc \
+      breakpad/src/common/linux/safe_readlink.cc
 }
 
 win32: RC_FILE = phantomjs_win.rc


### PR DESCRIPTION
This removes the need to build breakpad as a separate step.

PhantomJS developers will still need to cd src/breakpad && ./configure
&& make in order to analyse crash dumps, but it is not longer necessary
in order to build PhantomJS itself.

https://code.google.com/p/phantomjs/issues/detail?id=576
