### PR TITLE
Provide scripts and workflow for building Linux packages for release.

### DIFF
--- a/deploy/.gitignore
+++ b/deploy/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,54 @@
+Packaging PhantomJS
+===================
+
+This directory contains various scripts to assist with making PhantomJS
+packages.
+
+Packaging for Linux
+-------------------
+
+Linux building/packaging is best done in a virtual machine to ensure
+isolation and clean state. This is also necessary to build for different
+architectures.
+
+We use [Vagrant](http://vagrantup.com/) to help with this. Please see
+the [Vagrant
+documentation](http://vagrantup.com/v1/docs/getting-started/index.html)
+for instructions on how to install VirtualBox and Vagrant.
+
+Once you have Vagrant installed, building should be as simple as
+running:
+
+    $ export PHANTOMJS_VERSION=1.6.0 # change as necessary
+    $ vagrant up $ARCH
+
+Where $ARCH is either `i686` or `x86_64`.
+
+This runs the `provision_vm.sh` script, which installs the necessary
+dependencies, checks out a fresh copy of the PhantomJS repository,
+switches to the relevant tag, builds and packages the software and the
+associated debugging symbols tarball, and copies the tarballs out of the
+VM onto your host machine.
+
+If it runs successfully, you will see the tarballs in this directory,
+ready for upload.
+
+If there are any problems, you can re-run the script with:
+
+    $ vagrant provision $ARCH
+
+Or SSH into the VM:
+
+    $ vagrant ssh $ARCH
+
+Once you're done, you can destroy the VM with:
+
+    $ vagrant destroy $ARCH
+
+If you need to build a new version, you should destroy the VM and start
+again to ensure a clean state. (Or SSH in and do a git clean.)
+
+Packaging for OS X
+------------------
+
+TODO

--- a/deploy/Vagrantfile
+++ b/deploy/Vagrantfile
@@ -1,0 +1,30 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+unless ENV['PHANTOMJS_VERSION']
+  STDERR.puts 'Please specify PhantomJS version in the PHANTOMJS_VERSION environment variable.'
+  STDERR.puts '(This can be any git ref, e.g. "1.5.0", "master", "origin/1.5", etc.)'
+  exit 1
+end
+
+Vagrant::Config.run do |config|
+  config.vm.define :i686 do |c|
+    c.vm.box_url = "http://files.vagrantup.com/lucid32.box"
+    c.vm.box     = "lucid32"
+  end
+
+  config.vm.define :x86_64 do |c|
+    c.vm.box_url = "http://files.vagrantup.com/lucid64.box"
+    c.vm.box     = "lucid64"
+  end
+
+  config.vm.provision :shell do |s|
+    s.path = "provision-vm.sh"
+    s.args = ENV['PHANTOMJS_VERSION']
+  end
+
+  # You may wish to tweak these, but be aware that you need quite a lot of
+  # memory for the linking stage.
+  config.vm.customize ["modifyvm", :id, "--memory", 2048]
+  config.vm.customize ["modifyvm", :id, "--cpus",   2]
+end

--- a/deploy/build-and-package.sh
+++ b/deploy/build-and-package.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+cd `dirname $0`/..
+
+./build.sh --qt-config "-debug -webkit-debug" || exit 1
+
+rm deploy/*.tar.bz2
+./deploy/package-linux-dynamic.sh || exit 1
+
+pushd src/breakpad
+./configure && make || exit 1
+popd
+
+./tools/dump-symbols.sh
+
+# The minidump_stackwalk program is architecture-specific, so copy the
+# binary for later use. This means that e.g. a developer on x86_64 can
+# analyse a crash dump produced by a i686 user.
+cp src/breakpad/src/processor/minidump_stackwalk symbols/
+
+read -r -d '' README <<EOT
+These are symbols files that can be used to analyse a crash dump
+produced by the corresponding binary. To generate a crash report,
+run:
+
+./minidump_stackwalk /path/to/crash.dmp .
+EOT
+
+echo "$README" > symbols/README
+
+tar -cjf $(ls deploy/*.bz2 | sed 's/\.tar\.bz2/-symbols.tar.bz2/') symbols/
+
+echo "PhantomJS built and packaged:"
+echo
+cd deploy
+ls -1 *.tar.bz2

--- a/deploy/package-linux-dynamic.sh
+++ b/deploy/package-linux-dynamic.sh
@@ -32,7 +32,7 @@ if [[ ! -f brandelf ]]; then
 fi
 
 src=..
-dest=phantomjs-$version
+dest="phantomjs-$version-linux-$(uname -m)-dynamic"
 
 rm -Rf $dest{.tar.bz2,} &> /dev/null
 mkdir -p $dest/bin $dest/lib

--- a/deploy/provision-vm.sh
+++ b/deploy/provision-vm.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+apt-get update
+apt-get install -y build-essential git-core libssl-dev libfontconfig1-dev gdb binutils-gold
+
+if [[ ! -d phantomjs ]]; then
+    git clone git://github.com/ariya/phantomjs.git
+fi
+
+cd phantomjs
+git fetch origin
+git checkout $1
+
+cp /vagrant/build-and-package.sh deploy/
+cp /vagrant/package-linux-dynamic.sh deploy/
+
+deploy/build-and-package.sh
+
+cp deploy/*.tar.bz2 /vagrant

--- a/src/qt/preconfig.sh
+++ b/src/qt/preconfig.sh
@@ -109,6 +109,12 @@ export MAKEFLAGS=-j$COMPILE_JOBS
 ./configure -prefix $PWD $QT_CFG
 make -j$COMPILE_JOBS
 
+if [[ $QT_CFG =~ "-webkit-debug" ]]; then
+  DEBUG_OR_RELEASE=debug
+else
+  DEBUG_OR_RELEASE=release
+fi
+
 # Extra step to ensure the static libraries are found
-cp -rp src/3rdparty/webkit/Source/JavaScriptCore/release/* lib/
-cp -rp src/3rdparty/webkit/Source/WebCore/release/* lib/
+cp -rp src/3rdparty/webkit/Source/JavaScriptCore/$DEBUG_OR_RELEASE/* lib/
+cp -rp src/3rdparty/webkit/Source/WebCore/$DEBUG_OR_RELEASE/* lib/

--- a/tools/dump-symbols.sh
+++ b/tools/dump-symbols.sh
@@ -11,6 +11,7 @@
 #
 #  $ tools/crash-report.sh /tmp/5e2cc287-96c8-7a1b-59c79999-00fa22a2.dmp
 
+mkdir -p symbols
 rm -r symbols/*
 
 files=""


### PR DESCRIPTION
Here are some scripts which fully automate the process of building Linux release packages in a VM, including generating breakpad symbols etc.

I have tested it. I also tried adding a deliberate segfault into WebKit. After getting the crash dump file by running the binary within the VM, I was able to successfully generate the stack trace on my 64 bit host machine. So it seems to work well.

I hope to provide a similar script for OS X (albeit without the VM part) when I work on breakpad OS X support tomorrow.

https://code.google.com/p/phantomjs/issues/detail?id=599
