### PR TITLE
Minor adjustments before 1.6

### DIFF
--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -50,6 +50,7 @@
 #include <QMapIterator>
 #include <QBuffer>
 #include <QDebug>
+#include <QImageWriter>
 
 #include "networkaccessmanager.h"
 #include "utils.h"
@@ -612,34 +613,27 @@ bool WebPage::render(const QString &fileName)
     return buffer.save(fileName);
 }
 
-QString WebPage::renderBase64PNG()
+QString WebPage::renderBase64(const QByteArray &format)
 {
-    return renderBase64("PNG");
-}
+    QByteArray nformat = format.toLower();
 
-QString WebPage::renderBase64JPG()
-{
-    return renderBase64("JPG");
-}
+    // Check if the given format is supported
+    if (QImageWriter::supportedImageFormats().contains(nformat)) {
+        QImage rawPageRendering = renderImage();
 
-QString WebPage::renderBase64BMP()
-{
-    return renderBase64("BMP");
-}
+        // Prepare buffer for writing
+        QByteArray bytes;
+        QBuffer buffer(&bytes);
+        buffer.open(QIODevice::WriteOnly);
 
-QString WebPage::renderBase64(const char *format)
-{
-    QImage rawPageRendering = renderImage();
+        // Writing image to the buffer, using PNG encoding
+        rawPageRendering.save(&buffer, nformat);
 
-    // Prepare buffer for writing
-    QByteArray bytes;
-    QBuffer buffer(&bytes);
-    buffer.open(QIODevice::WriteOnly);
+        return bytes.toBase64();
+    }
 
-    // Writing image to the buffer, using PNG encoding
-    rawPageRendering.save(&buffer, format);
-
-    return bytes.toBase64();
+    // Return an empty string in case an unsupported format was provided
+    return "";
 }
 
 QImage WebPage::renderImage()

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -85,6 +85,8 @@ public:
     }
 
     bool extension(Extension extension, const ExtensionOption* option, ExtensionReturn* output) {
+        Q_UNUSED(option);
+
         if (extension == ChooseMultipleFilesExtension) {
             static_cast<ChooseMultipleFilesExtensionReturn*>(output)->fileNames = QStringList(m_uploadFile);
             return true;

--- a/src/webpage.h
+++ b/src/webpage.h
@@ -113,9 +113,19 @@ public slots:
 
     QVariant evaluateJavaScript(const QString &code);
     bool render(const QString &fileName);
-    QString renderBase64PNG();
-    QString renderBase64JPG();
-    QString renderBase64BMP();
+    /**
+     * Render the page as base-64 encoded string.
+     * Default image format is "png".
+     *
+     * To choose a different format, pass a string with it's name.
+     * Available formats are the one supported by Qt QImageWriter class:
+     * @link http://qt-project.org/doc/qt-4.8/qimagewriter.html#supportedImageFormats.
+     *
+     * @brief renderBase64
+     * @param format String containing one of the supported types
+     * @return Rendering base-64 encoded of the page if the given format is supported, otherwise an empty string
+     */
+    QString renderBase64(const QByteArray &format = "png");
     bool injectJs(const QString &jsFilePath);
     void _appendScriptElement(const QString &scriptUrl);
     QObject *_getGenericCallback();
@@ -191,7 +201,6 @@ private slots:
 
 private:
     QImage renderImage();
-    QString renderBase64(const char *format = "PNG");
     bool renderPdf(const QString &fileName);
     void applySettings(const QVariantMap &defaultSettings);
     QString userAgent() const;

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -53,8 +53,11 @@ function expectHasPropertyString(o, name) {
     });
 }
 
-// Load specs
+// Setting the "working directory" to the "/test" directory
 var fs = require('fs');
+fs.changeWorkingDirectory(phantom.libraryPath);
+
+// Load specs
 phantom.injectJs("./phantom-spec.js");
 phantom.injectJs("./module-spec.js");
 phantom.injectJs("./webpage-spec.js");


### PR DESCRIPTION
This addresses:
- Issue 547 (based on our discussion about the single renderBase64(format = "png")
- Addition of a "Q_UNUSED": it annoys the hell out of me
- An issue with "run-tests.js" that was making the frame tests fail
