### PR TITLE
Fix segfault when using e.g. console.error

### DIFF
--- a/src/qt/src/3rdparty/webkit/Source/WebKit/qt/WebCoreSupport/ChromeClientQt.cpp
+++ b/src/qt/src/3rdparty/webkit/Source/WebKit/qt/WebCoreSupport/ChromeClientQt.cpp
@@ -302,9 +302,7 @@ void ChromeClientQt::addMessageToConsole(MessageSource src, MessageType type, Me
     QString x = message;
     QString y = sourceID;
 
-    // the MessageType value isn't useful - it will be LogMessageType for both errors
-    // and log messages.
-    if (level == ErrorMessageLevel) {
+    if (src == JSMessageSource && type == UncaughtExceptionMessageType && level == ErrorMessageLevel) {
         QString stack = callStack->buildInspectorArray()->toJSONString();
         m_webPage->javaScriptError(x, lineNumber, y, stack);
     } else {


### PR DESCRIPTION
When console.error was called, there was a segfault because it was
treated as an uncaught exception, but did not have the correct stack
trace information (I am not sure why, but still...)

Now that we are generating the stackTrace in WebCore::reportException,
the MessageType gets set correctly, so we can use this to differentiate
between uncaught exceptions and other messages.

https://code.google.com/p/phantomjs/issues/detail?id=47
