### PR TITLE
Deploy fixes

### DIFF
--- a/deploy/build-and-package.sh
+++ b/deploy/build-and-package.sh
@@ -8,8 +8,10 @@ echo
 echo "    $ make clean && cd src/qt && make clean && cd ../.."
 echo
 
-# Build the project
-./build.sh --qt-config "-debug -webkit-debug" --qmake-args "CONFIG-=release CONFIG+=debug" || exit 1
+# This incantation will cause Qt and WebKit and PhantomJS to all build in "release"
+# mode, with compiler optimisations, but also with debug symbols. (We will strip the
+# symbols in package.sh.)
+CFLAGS=-g CXXFLAGS=-g ./build.sh --qt-config '-webkit-debug' --qmake-args "QMAKE_CFLAGS=-g QMAKE_CXXFLAGS=-g" || exit 1
 
 # Package the release tarball
 rm deploy/*.tar.bz2 2>/dev/null

--- a/deploy/build-and-package.sh
+++ b/deploy/build-and-package.sh
@@ -32,13 +32,22 @@ fi
 
 ./tools/dump-symbols.sh
 
+version=$(bin/phantomjs --version | sed 's/ /-/' | sed 's/[()]//g')
+if [[ $OSTYPE = darwin* ]]; then
+    symbols="phantomjs-$version-macosx-static-symbols"
+else
+    symbols="phantomjs-$version-linux-$(uname -m)-dynamic-symbols"
+fi
+
+cp -r symbols/ $symbols
+
 # The minidump_stackwalk program is architecture-specific, so copy the
 # binary for later use. This means that e.g. a developer on x86_64 can
 # analyse a crash dump produced by a i686 user.
 #
 # We don't yet have a process for building minidump_stackwalk on OS X
 if [[ $OSTYPE != darwin* ]]; then
-    cp src/breakpad/src/processor/minidump_stackwalk symbols/
+    cp src/breakpad/src/processor/minidump_stackwalk $symbols
 
     read -r -d '' README <<EOT
 These are symbols files that can be used to analyse a crash dump
@@ -48,10 +57,11 @@ run:
 ./minidump_stackwalk /path/to/crash.dmp .
 EOT
 
-    echo "$README" > symbols/README
+    echo "$README" > $symbols/README
 fi
 
-tar -cjf $(ls deploy/*.bz2 | sed 's/\.tar\.bz2/-symbols.tar.bz2/') symbols/
+tar -cjf deploy/$symbols.tar.bz2 $symbols
+rm -r $symbols
 
 echo "PhantomJS built and packaged:"
 echo

--- a/deploy/package.sh
+++ b/deploy/package.sh
@@ -101,9 +101,11 @@ if [[ $OSTYPE != darwin* ]]; then
     echo
 fi
 
-echo -n "creating tarball..."
-tar -cjf $dest{.tar.bz2,}
+echo -n "creating archive..."
+if [[ $OSTYPE != darwin* ]]; then
+    zip -r $dest.zip $dest
+else
+    tar -cjf $dest{.tar.bz2,}
+fi
 echo "done"
 echo
-
-echo "you can now deploy $dest or $dest.tar.bz2"

--- a/src/qt/preconfig.sh
+++ b/src/qt/preconfig.sh
@@ -109,10 +109,10 @@ export MAKEFLAGS=-j$COMPILE_JOBS
 ./configure -prefix $PWD $QT_CFG
 make -j$COMPILE_JOBS
 
-if [[ $QT_CFG =~ "-webkit-debug" ]]; then
-  DEBUG_OR_RELEASE=debug
-else
+if [[ $QT_CFG =~ "-release" ]]; then
   DEBUG_OR_RELEASE=release
+else
+  DEBUG_OR_RELEASE=debug
 fi
 
 # Extra step to ensure the static libraries are found

--- a/tools/dump-symbols.sh
+++ b/tools/dump-symbols.sh
@@ -21,10 +21,7 @@ if [[ $OSTYPE = darwin* ]]; then
     # To compile this program, run ../src/qt/bin/qmake dump-syms-mac.pro && make from tools/
     dump_syms="tools/dump_syms.app/Contents/MacOS/dump_syms"
 else
-    files+="src/qt/lib/libQtCore.so.4.8.2 "
-    files+="src/qt/lib/libQtWebKit.so.4.9.2 "
-    files+="src/qt/lib/libQtGui.so.4.8.2 "
-    files+="src/qt/lib/libQtNetwork.so.4.8.2"
+    files+=`ldd bin/phantomjs | grep Qt | cut -d ' ' -f 3 | xargs`
 
     # To compile this program, run ./configure && make from src/breakpad/
     dump_syms="src/breakpad/src/tools/linux/dump_syms/dump_syms"


### PR DESCRIPTION
@ariya as discussed, this ensures that packages get built with compiler optimisations enabled, but with debug symbols. this seems to still produce reasonable stack traces for crashes, and makes phantomjs run much faster.

I've also fixed an issue I noticed with the symbol packaging, and made the OS X package spit out a zip as you requested.

After this is merged, please could you rebuild the OS X package and upload it? If you could also upload the generated symbols that would be great so that we can analyse any OS X crash dumps that come in. I will send a pull request which cherry picks the relevant stuff into the 1.6 branch so that you can do the rebuild with these changes.
