### PR TITLE
Support for keyboard events

### DIFF
--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -37,6 +37,7 @@
 #include <QDateTime>
 #include <QDir>
 #include <QFileInfo>
+#include <QKeyEvent>
 #include <QMouseEvent>
 #include <QNetworkAccessManager>
 #include <QNetworkCookie>
@@ -932,7 +933,28 @@ QObject *WebPage::_getJsPromptCallback() {
 
 void WebPage::sendEvent(const QString &type, const QVariant &arg1, const QVariant &arg2)
 {
-    if (type == "mousedown" ||  type == "mouseup" || type == "mousemove") {
+    // keyboard events
+    if (type == "keydown" || type == "keyup") {
+        QKeyEvent::Type keyEventType = QEvent::None;
+        if (type == "keydown")
+            keyEventType = QKeyEvent::KeyPress;
+        if (type == "keyup")
+            keyEventType = QKeyEvent::KeyRelease;
+        Q_ASSERT(keyEventType != QEvent::None);
+
+        QKeyEvent *keyEvent = new QKeyEvent(keyEventType, arg1.toInt(), Qt::NoModifier);
+        QApplication::postEvent(m_webPage, keyEvent);
+        QApplication::processEvents();
+        return;
+    }
+
+    if (type == "keypress") {
+        sendEvent("keydown", arg1.toInt());
+        sendEvent("keyup", arg1.toInt());
+    }
+
+    // mouse events
+    if (type == "mousedown" || type == "mouseup" || type == "mousemove") {
         QMouseEvent::Type eventType = QEvent::None;
         Qt::MouseButton button = Qt::LeftButton;
         Qt::MouseButtons buttons = Qt::LeftButton;

--- a/test/webpage-spec.js
+++ b/test/webpage-spec.js
@@ -169,6 +169,83 @@ describe("WebPage object", function() {
     expectHasFunction(page, 'switchToParentFrame');
     expectHasFunction(page, 'currentFrameName');
 
+    it("should handle keydown event", function() {
+        runs(function() {
+            page.evaluate(function() {
+                window.addEventListener('keydown', function(event) {
+                    window.loggedEvent = window.loggedEvent || {};
+                    window.loggedEvent.keydown = event;
+                }, false);
+            });
+            page.sendEvent('keydown', 65);
+        });
+
+        waits(50);
+
+        runs(function() {
+            var event = page.evaluate(function() {
+                return window.loggedEvent.keydown;
+            });
+            expect(event.which).toEqual(65);
+        });
+    });
+
+    it("should handle keyup event", function() {
+        runs(function() {
+            page.evaluate(function() {
+                window.addEventListener('keyup', function(event) {
+                    window.loggedEvent = window.loggedEvent || {};
+                    window.loggedEvent.keyup = event;
+                }, false);
+            });
+            page.sendEvent('keyup', 65);
+        });
+
+        waits(50);
+
+        runs(function() {
+            var event = page.evaluate(function() {
+                return window.loggedEvent.keyup;
+            });
+            expect(event.which).toEqual(65);
+        });
+    });
+
+    it("should handle keypress event", function() {
+        runs(function() {
+            page.evaluate(function() {
+                window.addEventListener('keypress', function(event) {
+                    window.loggedEvent = window.loggedEvent || {};
+                    window.loggedEvent.keypress = event;
+                }, false);
+            });
+            page.sendEvent('keypress', 65);
+        });
+
+        waits(50);
+
+        runs(function() {
+            var event = page.evaluate(function() {
+                return window.loggedEvent.keypress;
+            });
+            expect(event.which).toEqual(65);
+        });
+    });
+
+    it("should handle keypress event with inputs", function() {
+        runs(function() {
+            page.content = '<input type="text">';
+            page.evaluate(function() {
+                document.querySelector('input').focus();
+            });
+            page.sendEvent('keypress', 65);
+            var text = page.evaluate(function() {
+                return document.querySelector('input').value;
+            });
+            expect(text).toEqual("A");
+        });
+    });
+
     it("should handle mousedown event", function() {
         runs(function() {
             page.evaluate(function() {


### PR DESCRIPTION
**Disclaimer:** this PR is not intended for being merged as is, but rather to start a discussion.

This is (very) basic support for being able to send _native_ keyboard events: `keydown`, `keyup` and `keypress`.

This is my first attempt at writing C++, so please forgive any mistake made (feedback welcome.)

Also, I don't much like the look and feel of the API. Basically, right now the `sendEvent` method allows to send keyboard events like this:

``` javascript
var page = require('webpage').create();
page.content = '<input>';
page.evaluate(function() {
    document.querySelector('input').focus();
});
page.sendEvent('keypress', 65);
page.sendEvent('keypress', 66);
console.log(page.evaluate(function() {
    return document.querySelector('input').value; // "AB"
}));
```

What I don't like:
1. we have to use the `focus()` through `evaluate()` trick to get the focus on the element we want to send keys to;
2. the `sendEvent` method signature looks messy; I hesitated to create a new `sendKeyEvent()` method, but then we would also need to rename `sendEvent()` to `sendMouseEvent()` for consistency;
3. there's no way to use char instead of key code;
4. there's no obvious way to directly send a list of chars (a.k.a strings) to the input element.

I've no clue how hard would be to resolve each point of the list above, therefore I'm asking here :)
