### PR TITLE
Added WebServerResponse::writeBinary to allow writing binary contents

### DIFF
--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -402,6 +402,15 @@ void WebServerResponse::write(const QString &body)
     mg_write(m_conn, data.constData(), data.size());
 }
 
+void WebServerResponse::writeBinary(const QString &body)
+{
+    if (!m_headersSent) {
+        writeHead(m_statusCode, m_headers);
+    }
+    const QByteArray data = body.toAscii();
+    mg_write(m_conn, data.constData(), data.size());
+}
+
 void WebServerResponse::close()
 {
     m_close->release();

--- a/src/webserver.h
+++ b/src/webserver.h
@@ -116,6 +116,8 @@ public slots:
     void writeHead(int statusCode, const QVariantMap &headers);
     /// sends @p data to client and makes sure the headers are send beforehand
     void write(const QString &data);
+    /// sends @p binary data to client and makes sure the headers are send beforehand
+    void writeBinary(const QString &data);
 
     /**
      * Closes the request once all data has been written to the client.


### PR DESCRIPTION
This is my poor — but working — attempt at making possible to serve binary files from the built-in phantomjs webserver. This possibly fixes [issue 505](http://code.google.com/p/phantomjs/issues/detail?id=505).

I'm really new to C++, so please forgive the more than probably crappy code.

Sample usage:

``` javascript
var fs = require('fs');
var server = require('webserver').create();
var service = server.listen(54321, function(request, response) {
    var pageFile = require('fs').workingDirectory + request.url;
    if (!fs.isFile(pageFile)) {
        response.statusCode = 404;
        response.write("404 - NOT FOUND");
    } else {
        response.statusCode = 200;
        if (/\.png$/.test(pageFile.toLowerCase())) {
            var image = fs.read(pageFile, 'b');
            response.headers = {
                'Accept-Ranges': 'bytes',
                'Content-Type': 'image/png',
                'Content-Length': image.length
            };
            response.writeBinary(image);
        } else {
            response.write(fs.read(pageFile));
        }
    }
    response.close();
});
```

This server code works for me on OSX Lion, I don't know for other platforms.

Note: I tried to add a `mode` char arg to the `write()` method, but… well, C++ is not my thing =)
