### PR TITLE
Support for keyboard events

### DIFF
--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -34,6 +34,8 @@
 #include <QDir>
 #include <QFileInfo>
 #include <QFile>
+// note: QMetaObject apparently does not define QMetaEnum...
+#include <qmetaobject.h>
 #include <QWebPage>
 
 #include "consts.h"
@@ -44,7 +46,6 @@
 #include "repl.h"
 #include "system.h"
 #include "callback.h"
-
 
 // public:
 Phantom::Phantom(QObject *parent)
@@ -61,6 +62,16 @@ Phantom::Phantom(QObject *parent)
     args.removeFirst();
 
     m_config.init(&args);
+
+    // initialize key map
+    QMetaEnum keys = staticQtMetaObject.enumerator( staticQtMetaObject.indexOfEnumerator("Key") );
+    for(int i = 0; i < keys.keyCount(); ++i) {
+        QString name = keys.key(i);
+        if (name.startsWith("Key_")) {
+            name.remove(0, 4);
+        }
+        m_keyMap[name] = keys.value(i);
+    }
 }
 
 void Phantom::init()
@@ -348,4 +359,9 @@ void Phantom::initCompletions()
     // functions
     addCompletion("exit");
     addCompletion("injectJs");
+}
+
+QVariantMap Phantom::keys() const
+{
+    return m_keyMap;
 }

--- a/src/phantom.h
+++ b/src/phantom.h
@@ -53,6 +53,7 @@ class Phantom: public REPLCompletable
     Q_PROPERTY(QString scriptName READ scriptName)
     Q_PROPERTY(QVariantMap version READ version)
     Q_PROPERTY(QObject *page READ page)
+    Q_PROPERTY(QVariantMap keys READ keys)
 
 public:
     Phantom(QObject *parent = 0);
@@ -79,6 +80,8 @@ public:
     QObject* page() const;
 
     bool printDebugMessages() const;
+
+    QVariantMap keys() const;
 
 public slots:
     QObject *createWebPage();
@@ -115,6 +118,7 @@ private:
     QList<QPointer<WebPage> > m_pages;
     QList<QPointer<WebServer> > m_servers;
     Config m_config;
+    QVariantMap m_keyMap;
 };
 
 #endif // PHANTOM_H

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -942,15 +942,42 @@ void WebPage::sendEvent(const QString &type, const QVariant &arg1, const QVarian
             keyEventType = QKeyEvent::KeyRelease;
         Q_ASSERT(keyEventType != QEvent::None);
 
-        QKeyEvent *keyEvent = new QKeyEvent(keyEventType, arg1.toInt(), Qt::NoModifier);
+        int key = 0;
+        QString text;
+        if (arg1.type() == QVariant::Char) {
+            // a single char was given
+            text = arg1.toChar();
+            key = text.at(0).toAscii();
+        } else if (arg1.type() == QVariant::String) {
+            // javascript invokation of a single char
+            text = arg1.toString();
+            if (!text.isEmpty()) {
+                key = text.at(0).toAscii();
+            }
+        } else {
+            // assume a raw integer char code was given
+            key = arg1.toInt();
+        }
+        QKeyEvent *keyEvent = new QKeyEvent(keyEventType, key, Qt::NoModifier, text);
         QApplication::postEvent(m_webPage, keyEvent);
         QApplication::processEvents();
         return;
     }
 
     if (type == "keypress") {
-        sendEvent("keydown", arg1.toInt());
-        sendEvent("keyup", arg1.toInt());
+        if (arg1.type() == QVariant::String) {
+            // this is the case for e.g. sendEvent("...", 'A')
+            // but also works with sendEvent("...", "ABCD")
+            foreach(QChar typeChar, arg1.toString()) {
+                sendEvent("keydown", typeChar);
+                sendEvent("keyup", typeChar);
+            }
+        } else {
+            // otherwise we assume a raw integer char-code was given
+            sendEvent("keydown", arg1.toInt());
+            sendEvent("keyup", arg1.toInt());
+        }
+        return;
     }
 
     // mouse events

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -37,6 +37,7 @@
 #include <QDateTime>
 #include <QDir>
 #include <QFileInfo>
+#include <QKeyEvent>
 #include <QMouseEvent>
 #include <QNetworkAccessManager>
 #include <QNetworkCookie>
@@ -932,7 +933,28 @@ QObject *WebPage::_getJsPromptCallback() {
 
 void WebPage::sendEvent(const QString &type, const QVariant &arg1, const QVariant &arg2)
 {
-    if (type == "mousedown" ||  type == "mouseup" || type == "mousemove") {
+    // keyboard events
+    if (type == "keydown" || type == "keyup") {
+        QKeyEvent::Type keyEventType = QEvent::None;
+        if (type == "keydown")
+            keyEventType = QKeyEvent::KeyPress;
+        if (type == "keyup")
+            keyEventType = QKeyEvent::KeyRelease;
+        Q_ASSERT(keyEventType != QEvent::None);
+
+        QKeyEvent *keyEvent = new QKeyEvent(keyEventType, arg1.toInt(), Qt::NoModifier);
+        QApplication::postEvent(m_webPage, keyEvent);
+        QApplication::processEvents();
+        return;
+    }
+
+    if (type == "keypress") {
+        sendEvent("keydown", arg1.toInt());
+        sendEvent("keyup", arg1.toInt());
+    }
+
+    // mouse events
+    if (type == "mousedown" || type == "mouseup" || type == "mousemove") {
         QMouseEvent::Type eventType = QEvent::None;
         Qt::MouseButton button = Qt::LeftButton;
         Qt::MouseButtons buttons = Qt::LeftButton;

--- a/test/phantom-spec.js
+++ b/test/phantom-spec.js
@@ -1,5 +1,4 @@
 describe("phantom global object", function() {
-
     it("should exist", function() {
         expect(typeof phantom).toEqual('object');
     });
@@ -66,5 +65,9 @@ describe("phantom global object", function() {
 
     it("should have 'exit' function", function() {
         expect(typeof phantom.exit).toEqual("function");
+    });
+
+    it("should have 'keys' property", function() {
+        expect(phantom.hasOwnProperty('keys')).toBeTruthy();
     });
 });

--- a/test/webpage-spec.js
+++ b/test/webpage-spec.js
@@ -169,6 +169,83 @@ describe("WebPage object", function() {
     expectHasFunction(page, 'switchToParentFrame');
     expectHasFunction(page, 'currentFrameName');
 
+    it("should handle keydown event", function() {
+        runs(function() {
+            page.evaluate(function() {
+                window.addEventListener('keydown', function(event) {
+                    window.loggedEvent = window.loggedEvent || {};
+                    window.loggedEvent.keydown = event;
+                }, false);
+            });
+            page.sendEvent('keydown', 65);
+        });
+
+        waits(50);
+
+        runs(function() {
+            var event = page.evaluate(function() {
+                return window.loggedEvent.keydown;
+            });
+            expect(event.which).toEqual(65);
+        });
+    });
+
+    it("should handle keyup event", function() {
+        runs(function() {
+            page.evaluate(function() {
+                window.addEventListener('keyup', function(event) {
+                    window.loggedEvent = window.loggedEvent || {};
+                    window.loggedEvent.keyup = event;
+                }, false);
+            });
+            page.sendEvent('keyup', 65);
+        });
+
+        waits(50);
+
+        runs(function() {
+            var event = page.evaluate(function() {
+                return window.loggedEvent.keyup;
+            });
+            expect(event.which).toEqual(65);
+        });
+    });
+
+    it("should handle keypress event", function() {
+        runs(function() {
+            page.evaluate(function() {
+                window.addEventListener('keypress', function(event) {
+                    window.loggedEvent = window.loggedEvent || {};
+                    window.loggedEvent.keypress = event;
+                }, false);
+            });
+            page.sendEvent('keypress', 65);
+        });
+
+        waits(50);
+
+        runs(function() {
+            var event = page.evaluate(function() {
+                return window.loggedEvent.keypress;
+            });
+            expect(event.which).toEqual(65);
+        });
+    });
+
+    it("should handle keypress event with inputs", function() {
+        runs(function() {
+            page.content = '<input type="text">';
+            page.evaluate(function() {
+                document.querySelector('input').focus();
+            });
+            page.sendEvent('keypress', 65);
+            var text = page.evaluate(function() {
+                return document.querySelector('input').value;
+            });
+            expect(text).toEqual("A");
+        });
+    });
+
     it("should handle mousedown event", function() {
         runs(function() {
             page.evaluate(function() {

--- a/test/webpage-spec.js
+++ b/test/webpage-spec.js
@@ -246,6 +246,34 @@ describe("WebPage object", function() {
         });
     });
 
+    it("should handle keypress event of string with inputs", function() {
+        runs(function() {
+            page.content = '<input type="text">';
+            page.evaluate(function() {
+                document.querySelector('input').focus();
+            });
+            page.sendEvent('keypress', "ABCD");
+            var text = page.evaluate(function() {
+                return document.querySelector('input').value;
+            });
+            expect(text).toEqual("ABCD");
+        });
+    });
+
+    it("should handle keypress event of umlaut char with inputs", function() {
+        runs(function() {
+            page.content = '<input type="text">';
+            page.evaluate(function() {
+                document.querySelector('input').focus();
+            });
+            page.sendEvent('keypress', "ä");
+            var text = page.evaluate(function() {
+                return document.querySelector('input').value;
+            });
+            expect(text).toEqual("ä");
+        });
+    });
+
     it("should handle mousedown event", function() {
         runs(function() {
             page.evaluate(function() {

--- a/test/webpage-spec.js
+++ b/test/webpage-spec.js
@@ -177,7 +177,7 @@ describe("WebPage object", function() {
                     window.loggedEvent.keydown = event;
                 }, false);
             });
-            page.sendEvent('keydown', 65);
+            page.sendEvent('keydown', phantom.keys.A);
         });
 
         waits(50);
@@ -186,7 +186,7 @@ describe("WebPage object", function() {
             var event = page.evaluate(function() {
                 return window.loggedEvent.keydown;
             });
-            expect(event.which).toEqual(65);
+            expect(event.which).toEqual(phantom.keys.A);
         });
     });
 
@@ -198,7 +198,7 @@ describe("WebPage object", function() {
                     window.loggedEvent.keyup = event;
                 }, false);
             });
-            page.sendEvent('keyup', 65);
+            page.sendEvent('keyup', phantom.keys.A);
         });
 
         waits(50);
@@ -207,7 +207,7 @@ describe("WebPage object", function() {
             var event = page.evaluate(function() {
                 return window.loggedEvent.keyup;
             });
-            expect(event.which).toEqual(65);
+            expect(event.which).toEqual(phantom.keys.A);
         });
     });
 
@@ -219,7 +219,7 @@ describe("WebPage object", function() {
                     window.loggedEvent.keypress = event;
                 }, false);
             });
-            page.sendEvent('keypress', 65);
+            page.sendEvent('keypress', phantom.keys.A);
         });
 
         waits(50);
@@ -228,7 +228,7 @@ describe("WebPage object", function() {
             var event = page.evaluate(function() {
                 return window.loggedEvent.keypress;
             });
-            expect(event.which).toEqual(65);
+            expect(event.which).toEqual(phantom.keys.A);
         });
     });
 
@@ -238,11 +238,17 @@ describe("WebPage object", function() {
             page.evaluate(function() {
                 document.querySelector('input').focus();
             });
-            page.sendEvent('keypress', 65);
-            var text = page.evaluate(function() {
-                return document.querySelector('input').value;
-            });
-            expect(text).toEqual("A");
+            var getText = function() {
+                return page.evaluate(function() {
+                    return document.querySelector('input').value;
+                });
+            }
+            page.sendEvent('keypress', phantom.keys.A);
+            expect(getText()).toEqual("A");
+            page.sendEvent('keypress', phantom.keys.B);
+            expect(getText()).toEqual("AB");
+            page.sendEvent('keypress', phantom.keys.Backspace);
+            expect(getText()).toEqual("A");
         });
     });
 


### PR DESCRIPTION
This is based off https://github.com/ariya/phantomjs/pull/287 , see that merge request for more information and discussion.

The changes proposed here allow us to do things like:

```
page.sendEvent('keydown', phantom.keys.Escape);
page.sendEvent('keyup', phantom.keys.Escape);
// same as the above
page.sendEvent('keypress', phantom.keys.Escape);
// also works with chars
page.sendEvent('keypress', "a");
// and even with strings
page.sendEvent('keypress', "adsfsadf");
```

Personally I think this patchset is ready to be merged. It lays the cornerstone for future work, as mentioned in the merge request above, namely:
- improved events API, maybe following the one that jQuery uses
- simplified focusing of elements, or generally a simplified way of sending events to arbitrary elements on the page
