### PR TITLE
Fix remote inspector when building statically.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,11 +61,6 @@ int main(int argc, char** argv, const char** envp)
     Utils::printDebugMessages = phantom.printDebugMessages();
     qInstallMsgHandler(Utils::messageHandler);
 
-#ifdef STATIC_BUILD
-    Q_INIT_RESOURCE(WebKit);
-    Q_INIT_RESOURCE(InspectorBackendStub);
-#endif
-
     app.setWindowIcon(QIcon(":/phantomjs-icon.png"));
     app.setApplicationName("PhantomJS");
     app.setOrganizationName("Ofi Labs");

--- a/src/phantomjs.pro
+++ b/src/phantomjs.pro
@@ -5,7 +5,9 @@ CONFIG += console
 
 DESTDIR = ../bin
 
-RESOURCES = phantomjs.qrc
+RESOURCES = phantomjs.qrc \
+    qt/src/3rdparty/webkit/Source/WebCore/inspector/front-end/WebKit.qrc \
+    qt/src/3rdparty/webkit/Source/WebCore/generated/InspectorBackendStub.qrc
 
 HEADERS += csconverter.h \
     phantom.h \
@@ -102,7 +104,4 @@ mac {
     CONFIG -= app_bundle
 # Uncomment to build a Mac OS X Universal Binary (i.e. x86 + ppc)
 #    CONFIG += x86 ppc
-}
-CONFIG(static) {
-    DEFINES += STATIC_BUILD
 }


### PR DESCRIPTION
For some reason, it seems that checking CONFIG(static) inside
src/phantomjs.pro is not reliable. That caused the STATIC_BUILD define
not to be set, and hence Q_INIT_RESOURCE would never get called in
main.cpp.

Instead of using Q_INIT_RESOURCE, let's just compile the resources
directly into the phantomjs binary. This means we don't need to detect
whether Qt is linked statically or dynamically.

https://code.google.com/p/phantomjs/issues/detail?id=430

(I have manage to make a static build on Linux to reproduce this issue - PR for that coming up - but I haven't been able to verify this fix on OS X. I am pretty sure that it works, but it would be worth verifying. Also, please cherry-pick to the 1.6 branch?)
