### PR TITLE
Make static build work on Linux.

### DIFF
--- a/deploy/build-and-package.sh
+++ b/deploy/build-and-package.sh
@@ -2,10 +2,10 @@
 
 cd `dirname $0`/..
 
-echo "Building Qt and PhantomJS in debug mode. If you have previously" \
-     "built in release mode, you should run:"
+echo "Building Qt and PhantomJS with debugging symbols. If you have previously" \
+     "built without debugging symbols, you should run:"
 echo
-echo "    $ make clean && cd src/qt && make clean && cd ../.."
+echo "    $ git clean -xdff"
 echo
 
 # This incantation will cause Qt and WebKit and PhantomJS to all build in "release"
@@ -34,9 +34,9 @@ fi
 
 version=$(bin/phantomjs --version | sed 's/ /-/' | sed 's/[()]//g')
 if [[ $OSTYPE = darwin* ]]; then
-    symbols="phantomjs-$version-macosx-static-symbols"
+    symbols="phantomjs-$version-macosx-symbols"
 else
-    symbols="phantomjs-$version-linux-$(uname -m)-dynamic-symbols"
+    symbols="phantomjs-$version-linux-$(uname -m)-symbols"
 fi
 
 cp -r symbols/ $symbols

--- a/deploy/provision-vm.sh
+++ b/deploy/provision-vm.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 apt-get update
-apt-get install -y build-essential git-core libssl-dev libfontconfig1-dev gdb binutils-gold
+apt-get install -y build-essential git-core libssl-dev libfontconfig1-dev gdb binutils-gold upx-ucl
 
 if [[ ! -d phantomjs ]]; then
     git clone git://github.com/ariya/phantomjs.git

--- a/src/qt/preconfig.sh
+++ b/src/qt/preconfig.sh
@@ -6,9 +6,9 @@ QT_CFG=''
 QT_CFG+=' -opensource'          # Use the open-source license
 QT_CFG+=' -confirm-license'     # Silently acknowledge the license confirmation
 QT_CFG+=' -v'                   # Makes it easier to see what header dependencies are missing
+QT_CFG+=' -static'
 
 if [[ $OSTYPE = darwin* ]]; then
-    QT_CFG+=' -static'          # Static build on Mac OS X only
     QT_CFG+=' -arch x86'
     QT_CFG+=' -cocoa'           # Cocoa only, ignore Carbon
     QT_CFG+=' -no-dwarf2'
@@ -108,13 +108,3 @@ export MAKEFLAGS=-j$COMPILE_JOBS
 
 ./configure -prefix $PWD $QT_CFG
 make -j$COMPILE_JOBS
-
-if [[ $QT_CFG =~ "-release" ]]; then
-  DEBUG_OR_RELEASE=release
-else
-  DEBUG_OR_RELEASE=debug
-fi
-
-# Extra step to ensure the static libraries are found
-cp -rp src/3rdparty/webkit/Source/JavaScriptCore/$DEBUG_OR_RELEASE/* lib/
-cp -rp src/3rdparty/webkit/Source/WebCore/$DEBUG_OR_RELEASE/* lib/

--- a/src/qt/src/3rdparty/webkit/Source/WebKit.pro
+++ b/src/qt/src/3rdparty/webkit/Source/WebKit.pro
@@ -3,14 +3,8 @@ CONFIG += ordered
 
 include(WebKit.pri)
 
-!v8 {
-    exists($$PWD/JavaScriptCore/JavaScriptCore.pro): SUBDIRS += JavaScriptCore/JavaScriptCore.pro
-    exists($$PWD/JavaScriptCore/jsc.pro): SUBDIRS += JavaScriptCore/jsc.pro
-}
-
 webkit2:exists($$PWD/WebKit2/WebKit2.pro): SUBDIRS += WebKit2/WebKit2.pro
 
-SUBDIRS += WebCore
 SUBDIRS += WebKit/qt/QtWebKit.pro
 
 webkit2 {

--- a/src/qt/src/3rdparty/webkit/Source/WebKit/qt/QtWebKit.pro
+++ b/src/qt/src/3rdparty/webkit/Source/WebKit/qt/QtWebKit.pro
@@ -2,7 +2,6 @@
 CONFIG += building-libs
 CONFIG += depend_includepath
 
-TARGET = QtWebKit
 TEMPLATE = lib
 
 DEFINES += BUILDING_WEBKIT
@@ -15,23 +14,45 @@ else: CONFIG_DIR = release
 
 SOURCE_DIR = $$replace(PWD, /WebKit/qt, "")
 
-include($$PWD/Api/headers.pri)
 include($$SOURCE_DIR/WebKit.pri)
-include($$SOURCE_DIR/JavaScriptCore/JavaScriptCore.pri)
+
+include($$SOURCE_DIR/JavaScriptCore/JavaScriptCore.pro)
+
+for(item, SOURCES):JAVASCRIPT_CORE_SOURCES += ../../JavaScriptCore/$$item
+
+unset(SOURCES)
+
+include($$SOURCE_DIR/WebCore/WebCore.pro)
+
+for(item, SOURCES): {
+    path = $$split(item, '/')
+
+    contains(path, sqlite3.c) {
+        WEB_CORE_SOURCES += $$item
+    }
+
+    !contains(path, sqlite3.c) {
+        WEB_CORE_SOURCES += ../../WebCore/$$item
+    }
+}
+for(item, HEADERS):WEB_CORE_HEADERS += ../../WebCore/$$item
+
+SOURCES = $$JAVASCRIPT_CORE_SOURCES $$WEB_CORE_SOURCES
+HEADERS = $$WEB_CORE_HEADERS
+
+include($$PWD/Api/headers.pri)
+
 webkit2 {
     include($$SOURCE_DIR/WebKit2/WebKit2.pri)
     include($$SOURCE_DIR/WebKit2/WebKit2API.pri)
 }
-include($$SOURCE_DIR/WebCore/WebCore.pri)
 
-!v8:prependJavaScriptCoreLib(../../JavaScriptCore)
-prependWebCoreLib(../../WebCore)
-webkit2:prependWebKit2Lib(../../WebKit2)
+TARGET = QtWebKit
 
 # This is needed for syncqt when it parses the dependencies on module's main pro file so
 # the generated includes are containing the dependencies.
 # It used to be in WebCore.pro but now that this is the main pro file it has to be here.
-QT += network
+QT += network gui
 
 isEmpty(OUTPUT_DIR): OUTPUT_DIR = ../..
 

--- a/tools/dump-symbols.sh
+++ b/tools/dump-symbols.sh
@@ -14,23 +14,15 @@
 mkdir -p symbols
 rm -r symbols/*
 
-files=""
-files+="bin/phantomjs "
-
 if [[ $OSTYPE = darwin* ]]; then
     # To compile this program, run ../src/qt/bin/qmake dump-syms-mac.pro && make from tools/
     dump_syms="tools/dump_syms.app/Contents/MacOS/dump_syms"
 else
-    files+=`ldd bin/phantomjs | grep Qt | cut -d ' ' -f 3 | xargs`
-
     # To compile this program, run ./configure && make from src/breakpad/
     dump_syms="src/breakpad/src/tools/linux/dump_syms/dump_syms"
 fi
 
-for file in $files; do
-    name=`basename $file`
-    $dump_syms $file > $name.sym
-    dir=symbols/$name/`head -n1 $name.sym | cut -d ' ' -f 4`
-    mkdir -p $dir
-    mv $name.sym $dir
-done
+$dump_syms bin/phantomjs > phantomjs.sym
+dir=symbols/phantomjs/`head -n1 phantomjs.sym | cut -d ' ' -f 4`
+mkdir -p $dir
+mv phantomjs.sym $dir


### PR DESCRIPTION
Previously, a static build would produce three separate files:
QtWebKit.a, libjscore.a and libwebcore.a. These seem to have
dependencies on each other and this caused the build errors on Linux.

This change means that the sources of jscore and webcore are both built
directly into the QtWebKit.a target. libjscore.a and libwebcore.a are no
longer built. It is then possible to create a static binary on Linux.

@ariya, I don't know if this works on OS X. I don't see why it wouldn't, but please could you try it out?
