### PR TITLE
Add breakpad support for Windows (crashdumps)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,6 +42,8 @@
 #include <QApplication>
 
 #ifdef Q_OS_WIN32
+using namespace google_breakpad;
+static google_breakpad::ExceptionHandler* eh;
 #if !defined(QT_SHARED) && !defined(QT_DLL)
 #include <QtPlugin>
 
@@ -92,7 +94,28 @@ int main(int argc, char** argv, const char** envp)
 #ifdef Q_OS_MAC
     google_breakpad::ExceptionHandler eh("/tmp", NULL, Utils::exceptionHandler, NULL, true, NULL);
 #endif
+#ifdef Q_OS_WIN32
+    // This is needed for CRT to not show dialog for invalid param
+    // failures and instead let the code handle it.
+    _CrtSetReportMode(_CRT_ASSERT, 0);
 
+    DWORD cbBuffer = ExpandEnvironmentStrings(TEXT("%TEMP%"), NULL, 0);
+
+    if (cbBuffer == 0)
+        eh = new ExceptionHandler(TEXT("."), NULL, Utils::exceptionHandler, NULL, ExceptionHandler::HANDLER_ALL);
+    else
+    {
+        LPWSTR szBuffer = (LPWSTR)malloc(sizeof(TCHAR) * (cbBuffer + 1));
+        
+        if (ExpandEnvironmentStrings(TEXT("%TEMP%"), szBuffer, cbBuffer + 1) > 0)
+        {
+            wstring lpResult(szBuffer);
+            eh = new ExceptionHandler(lpResult, NULL, Utils::exceptionHandler, NULL, ExceptionHandler::HANDLER_ALL);
+        }
+        free(szBuffer);
+    }
+#endif
+   
     QApplication app(argc, argv);
 
     app.setWindowIcon(QIcon(":/phantomjs-icon.png"));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -101,16 +101,14 @@ int main(int argc, char** argv, const char** envp)
 
     DWORD cbBuffer = ExpandEnvironmentStrings(TEXT("%TEMP%"), NULL, 0);
 
-    if (cbBuffer == 0)
+    if (cbBuffer == 0) {
         eh = new ExceptionHandler(TEXT("."), NULL, Utils::exceptionHandler, NULL, ExceptionHandler::HANDLER_ALL);
-    else
-    {
-        LPWSTR szBuffer = (LPWSTR)malloc(sizeof(TCHAR) * (cbBuffer + 1));
+	} else {
+        LPWSTR szBuffer = reinterpret_cast<LPWSTR>(malloc(sizeof(TCHAR) * (cbBuffer + 1)));
         
-        if (ExpandEnvironmentStrings(TEXT("%TEMP%"), szBuffer, cbBuffer + 1) > 0)
-        {
-            wstring lpResult(szBuffer);
-            eh = new ExceptionHandler(lpResult, NULL, Utils::exceptionHandler, NULL, ExceptionHandler::HANDLER_ALL);
+        if (ExpandEnvironmentStrings(TEXT("%TEMP%"), szBuffer, cbBuffer + 1) > 0) {
+            wstring lpDumpPath(szBuffer);
+            eh = new ExceptionHandler(lpDumpPath, NULL, Utils::exceptionHandler, NULL, ExceptionHandler::HANDLER_ALL);
         }
         free(szBuffer);
     }

--- a/src/phantomjs.pro
+++ b/src/phantomjs.pro
@@ -108,6 +108,10 @@ mac {
 
 win32-msvc* {
     LIBS += -lCrypt32
+    INCLUDEPATH += breakpad/src
+    SOURCES += breakpad/src/client/windows/handler/exception_handler.cc \
+      breakpad/src/client/windows/crash_generation/crash_generation_client.cc \
+      breakpad/src/common/windows/guid_string.cc
     CONFIG(static) {
         DEFINES += STATIC_BUILD
         QTPLUGIN += \

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -71,7 +71,23 @@ void Utils::messageHandler(QtMsgType type, const char *msg)
         abort();
     }
 }
-
+#ifdef Q_OS_WIN32
+bool Utils::exceptionHandler(const TCHAR* dump_path, const TCHAR* minidump_id,
+                             void* context, EXCEPTION_POINTERS* exinfo,
+                             MDRawAssertionInfo *assertion, bool succeeded)
+{
+    Q_UNUSED(exinfo);
+    Q_UNUSED(assertion);
+    Q_UNUSED(context);
+  
+    fprintf(stderr, "PhantomJS has crashed. Please read the crash reporting guide at " \
+                    "https://code.google.com/p/phantomjs/wiki/CrashReporting and file a " \
+                    "bug report at https://code.google.com/p/phantomjs/issues/entry with the " \
+                    "crash dump file attached: %ls\\%ls.dmp\n",
+                    dump_path, minidump_id);
+    return succeeded;
+}
+#else
 bool Utils::exceptionHandler(const char* dump_path, const char* minidump_id, void* context, bool succeeded)
 {
     Q_UNUSED(context);
@@ -82,6 +98,7 @@ bool Utils::exceptionHandler(const char* dump_path, const char* minidump_id, voi
                     dump_path, minidump_id);
     return succeeded;
 }
+#endif
 
 QVariant Utils::coffee2js(const QString &script)
 {

--- a/src/utils.h
+++ b/src/utils.h
@@ -38,6 +38,10 @@
 #include "csconverter.h"
 #include "encoding.h"
 
+#ifdef Q_OS_WIN32
+#include "client/windows/handler/exception_handler.h"
+#endif
+
 class QTemporaryFile;
 /**
  * Aggregate common utility functions.
@@ -49,7 +53,11 @@ class Utils
 public:
     static void showUsage();
     static void messageHandler(QtMsgType type, const char *msg);
+#ifdef Q_OS_WIN32
+    static bool exceptionHandler(const wchar_t* dump_path, const wchar_t* minidump_id, void* context, EXCEPTION_POINTERS* exinfo, MDRawAssertionInfo *assertion, bool succeeded);
+#else
     static bool exceptionHandler(const char* dump_path, const char* minidump_id, void* context, bool succeeded);
+#endif    
     static QVariant coffee2js(const QString &script);
     static bool injectJsInFrame(const QString &jsFilePath, const QString &libraryPath, QWebFrame *targetFrame, const bool startingScript = false);
     static bool injectJsInFrame(const QString &jsFilePath, const Encoding &jsFileEnc, const QString &libraryPath, QWebFrame *targetFrame, const bool startingScript = false);


### PR DESCRIPTION
Added creating crash dumps on the Windows platform.

Issue: http://code.google.com/p/phantomjs/issues/detail?id=576
