### PR TITLE
Remove premature WebPage deletion.

### DIFF
--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -97,7 +97,6 @@ void Phantom::init()
     }
 
     m_page = new WebPage(this, QUrl::fromLocalFile(m_config.scriptFile()));
-    m_pages.append(m_page);
 
     if (m_config.proxyHost().isEmpty()) {
         QNetworkProxyFactory::setUseSystemConfiguration(true);
@@ -253,10 +252,6 @@ bool Phantom::printDebugMessages() const
 QObject *Phantom::createWebPage()
 {
     WebPage *page = new WebPage(this);
-
-    // Store pointer to the page for later cleanup
-    m_pages.append(page);
-    // Apply default settings to the page
     page->applySettings(m_defaultPageSettings);
 
     // Show web-inspector if in debug mode
@@ -362,9 +357,6 @@ void Phantom::doExit(int code)
     emit aboutToExit(code);
     m_terminated = true;
     m_returnValue = code;
-    qDeleteAll(m_pages);
-    m_pages.clear();
-    m_page = 0;
     QApplication::instance()->exit(code);
 }
 

--- a/src/phantom.h
+++ b/src/phantom.h
@@ -129,7 +129,6 @@ private:
     QVariantMap m_defaultPageSettings;
     FileSystem *m_filesystem;
     System *m_system;
-    QList<QPointer<WebPage> > m_pages;
     QList<QPointer<WebServer> > m_servers;
     Config m_config;
     QVariantMap m_keyMap;


### PR DESCRIPTION
This reverts two commits: 

5acaa6b42d510f529ea77507f678b114bac73d9c
8094cdb4e7d3179066eb3ecba581ec36baacdfee

Both commits attempt to overcome a bug with QtWebKit where WebPages needed to be destroyed before our QtApplication was destroyed. If this bug were not there then our QObject relations would handle the necessary cleanup for us. I looked back on the issues that led to the fix in the first place which are #136 #148 and #149. I couldn't reproduce the issues at all. For instance:

$ phantomjs loadspeed.js http://dl.dropbox.com/u/9451381/tmp/test1.html

Should lead to a segmentation fault, but it doesn't for me. This leads me to believe (perhaps naively) that this was fixed upstream for us. So in theory we should be able to remove the hack that is commit  5acaa6b42d510f529ea77507f678b114bac73d9c.

8094cdb4e7d3179066eb3ecba581ec36baacdfee alludes to wanting Phantom::exit to actually exit before running the rest of the code. I'm not sure if the intention is to have phantom.exit() be the last call in a script, but if it is then it currently isn't and we should create another issue for that.
