### PR TITLE
Add option to only request local resources

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -168,6 +168,14 @@ void Config::processArgs(const QStringList &args)
             setPrintDebugMessages(false);
             continue;
         }
+        if (arg == "--local-only=yes") {
+            setLocalOnly(true);
+            continue;
+        }
+        if (arg == "--local-only=no") {
+            setLocalOnly(false);
+            continue;
+        }
         if (arg.startsWith("--")) {
             setUnknownOption(QString("Unknown option '%1'").arg(arg));
             return;
@@ -532,6 +540,7 @@ void Config::resetToDefaults()
     m_javascriptCanCloseWindows = true;
     m_helpFlag = false;
     m_printDebugMessages = false;
+    m_localOnly = false;
 }
 
 void Config::setProxyAuthPass(const QString &value)
@@ -572,4 +581,14 @@ bool Config::printDebugMessages() const
 void Config::setPrintDebugMessages(const bool value)
 {
     m_printDebugMessages = value;
+}
+
+void Config::setLocalOnly(const bool value)
+{
+    m_localOnly = value;
+}
+
+bool Config::localOnly() const
+{
+    return m_localOnly;
 }

--- a/src/config.h
+++ b/src/config.h
@@ -143,6 +143,9 @@ public:
     void setJavascriptCanCloseWindows(const bool value);
     bool javascriptCanCloseWindows() const;
 
+    void setLocalOnly(const bool value);
+    bool localOnly() const;
+
 private:
     void resetToDefaults();
     void setProxyHost(const QString &value);
@@ -179,6 +182,7 @@ private:
     bool m_printDebugMessages;
     bool m_javascriptCanOpenWindows;
     bool m_javascriptCanCloseWindows;
+    bool m_localOnly;
 };
 
 #endif // CONFIG_H

--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -86,6 +86,8 @@ NetworkAccessManager::NetworkAccessManager(QObject *parent, const Config *config
 
     connect(this, SIGNAL(authenticationRequired(QNetworkReply*,QAuthenticator*)), SLOT(provideAuthentication(QNetworkReply*,QAuthenticator*)));
     connect(this, SIGNAL(finished(QNetworkReply*)), SLOT(handleFinished(QNetworkReply*)));
+
+    m_config = config;
 }
 
 void NetworkAccessManager::setUserName(const QString &userName)
@@ -126,6 +128,11 @@ QNetworkReply *NetworkAccessManager::createRequest(Operation op, const QNetworkR
     // Get the URL string before calling the superclass. Seems to work around
     // segfaults in Qt 4.8: https://gist.github.com/1430393
     QByteArray url = req.url().toEncoded();
+
+    // Return a blank reply for any external requests
+    if (m_config->localOnly() && req.url().scheme() != "file") {
+        return QNetworkAccessManager::createRequest(QNetworkAccessManager::GetOperation, QNetworkRequest(QUrl()));
+    }
 
     // http://code.google.com/p/phantomjs/issues/detail?id=337
     if (op == QNetworkAccessManager::PostOperation) {

--- a/src/networkaccessmanager.h
+++ b/src/networkaccessmanager.h
@@ -74,6 +74,7 @@ private:
     QNetworkDiskCache* m_networkDiskCache;
     QVariantMap m_customHeaders;
     QVariantList m_cookies;
+    const Config* m_config;
 };
 
 #endif // NETWORKACCESSMANAGER_H

--- a/src/usage.txt
+++ b/src/usage.txt
@@ -8,6 +8,7 @@ Options:
   --disk-cache=[yes|no]                  Enables disk cache (at desktop services cache storage location, default is 'no')
   --ignore-ssl-errors=[yes|no]           Ignores SSL errors (i.e. expired or self-signed certificate errors)
   --load-images=[yes|no]                 Loads all inlined images (default is 'yes')
+  --local-only=[yes|no]                  Only request local resources (default is 'no')
   --local-to-remote-url-access=[yes|no]  Local content can access remote URL (default is 'no')
   --max-disk-cache-size=size             Limits the size of disk cache (in KB)
   --output-encoding                      Sets the encoding used for terminal output (default is 'utf8')


### PR DESCRIPTION
Added an option, --local-only=[yes|no], to stop phantomjs requesting remote resources. The code simply checks the URL is using the "file" scheme.

http://code.google.com/p/phantomjs/issues/detail?id=720
