### PR TITLE
Fixing Windows-specific path issues with loading of modules

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -123,7 +123,11 @@ phantom.onError = phantom.defaultErrorHandler;
     }
 
     function dirname(path) {
-        return path.replace(/\/[^\/]*\/?$/, '');
+        var replaced = path.replace(/\/[^\/]*\/?$/, '');
+        if (replaced == path) {
+            replaced = '';
+        }
+        return replaced;
     }
 
     function basename(path) {
@@ -131,8 +135,12 @@ phantom.onError = phantom.defaultErrorHandler;
     }
 
     function joinPath() {
+        // It should be okay to hard-code a slash here.
+        // The FileSystem module returns a platform-specific
+        // separator, but the JavaScript engine only expects
+        // the slash.
         var args = Array.prototype.slice.call(arguments);
-        return args.join(fs.separator);
+        return args.join('/');
     }
 
     function tryFile(path) {


### PR DESCRIPTION
Fixes issue 721 (http://code.google.com/p/phantomjs/issues/detail?id=721).

The dirname() function in bootstrap.js strips everything after the last slash character ('/'). Module.prototype._getPaths() calls dirname() in a loop until all tokens have been processed. The problem is when there is no slash in the final token of the directory, as in the case of a Windows path with a drive designator. _getPaths() eventually calls dirname() with only the drive designator (e.g., 'C:'), which is not empty, which causes _getPaths() to call dirname() again with only the drive designator, resulting in an infinite loop.

Note that a secondary change included as part of this pull request is that joinPath() now uses a slash ('/') instead of a platform-specific separator. While the QT framework will properly normalize path separators, the JavaScript engine requires an already-normalized path.
