### PR TITLE
Add missing pageref attribute to HAR and end-time

### DIFF
--- a/examples/netsniff.coffee
+++ b/examples/netsniff.coffee
@@ -70,7 +70,8 @@ createHAR = (address, title, startTime, resources) ->
             startedDateTime: startTime.toISOString()
             id: address
             title: title
-            pageTimings: {}
+            pageTimings:
+                onLoad: page.endTime - page.startTime
         ]
         entries: entries
 
@@ -103,6 +104,7 @@ else
         if status isnt 'success'
             console.log 'FAIL to load the address'
         else
+            page.endTime = new Date()
             page.title = page.evaluate ->
                 document.title
 

--- a/examples/netsniff.coffee
+++ b/examples/netsniff.coffee
@@ -58,6 +58,7 @@ createHAR = (address, title, startTime, resources) ->
                 wait: startReply.time - request.time
                 receive: endReply.time - startReply.time
                 ssl: -1
+            pageref: address
 
     log:
         version: '1.2'

--- a/examples/netsniff.js
+++ b/examples/netsniff.js
@@ -61,7 +61,8 @@ function createHAR(address, title, startTime, resources)
                 wait: startReply.time - request.time,
                 receive: endReply.time - startReply.time,
                 ssl: -1
-            }
+            },
+            pageref: address
         });
     });
 

--- a/examples/netsniff.js
+++ b/examples/netsniff.js
@@ -78,7 +78,9 @@ function createHAR(address, title, startTime, resources)
                 startedDateTime: startTime.toISOString(),
                 id: address,
                 title: title,
-                pageTimings: {}
+                pageTimings: {
+                    onLoad: page.endTime - page.startTime
+                }
             }],
             entries: entries
         }
@@ -122,6 +124,7 @@ if (system.args.length === 1) {
         if (status !== 'success') {
             console.log('FAIL to load the address');
         } else {
+            page.endTime = new Date();
             page.title = page.evaluate(function () {
                 return document.title;
             });


### PR DESCRIPTION
The pageref attribute is required to associate the requests with the appropriate pages. Without it, many tools fail to interpet the data.

Also, added the "onLoad" timer, albeit I'm not 100% sure that the way I have it there is the best way to do it. I tried adding an `onLoadFinished` callback, but for whatever reason, it just didn't want to fire. Any tips?

Also, I'd love to surface other data such as `onDomContentLoaded` - is there any way to register this callback? Or, alternatively, is there any way to get access to the performance timing data from phantom? Does the QT port support it?
