### PR TITLE
More logging on run-qunit example

### DIFF
--- a/examples/run-qunit.coffee
+++ b/examples/run-qunit.coffee
@@ -56,6 +56,8 @@ page.open system.args[1], (status) ->
             failedNum = page.evaluate ->
                 el = document.getElementById 'qunit-testresult'
                 console.log el.innerText
+                failed = document.getElementsByClassName 'fail'
+                console.log fail.innerHTML+"\n---------------\n" for fail in failed
                 try
                     return el.getElementsByClassName('failed')[0].innerHTML
                 catch e

--- a/examples/run-qunit.js
+++ b/examples/run-qunit.js
@@ -65,6 +65,11 @@ page.open(system.args[1], function(status){
             var failedNum = page.evaluate(function(){
                 var el = document.getElementById('qunit-testresult');
                 console.log(el.innerText);
+                failed = document.getElementsByClassName('fail');
+                for (_i = 0, _len = failed.length; _i < _len; _i++) {
+                    fail = failed[_i];
+                    console.log(fail.innerHTML + "\n---------------\n");
+                }
                 try {
                     return el.getElementsByClassName('failed')[0].innerHTML;
                 } catch (e) { }


### PR DESCRIPTION
Hi,

I made a small change to the run-qunit.\* files to give more information when a test fails.  I changed both the coffee and js files, but the change is the same.  Wasn't clear to me whether you generate the .js from the .coffee file, so I thought I'd be safe.

I'm sorry this isn't on a topic branch--I'm a github newbie and was just following the tutorials I could find.  By the time I learned about topic branches, I'd already committed and pushed to my repo.

If there's something else you'd like me to do in order to accept this contribution, let me know.

Thanks.
