### PR TITLE
CSS selectors in run-jasmine.js updated

### DIFF
--- a/examples/run-jasmine.js
+++ b/examples/run-jasmine.js
@@ -74,6 +74,8 @@ page.open(system.args[1], function(status){
                       console.log(msg.innerText);
                       console.log('');
                   }
+                } else {
+                  console.log(document.body.querySelector('.alert > .passingAlert.bar').innerText);
                 }
             });
             phantom.exit();

--- a/examples/run-jasmine.js
+++ b/examples/run-jasmine.js
@@ -58,7 +58,7 @@ page.open(system.args[1], function(status){
                 return document.body.querySelector('.symbolSummary .pending') === null
             });
         }, function(){
-            page.evaluate(function(){
+            var exitCode = page.evaluate(function(){
                 console.log('');
                 console.log(document.body.querySelector('.description').innerText);
                 var list = document.body.querySelectorAll('.results > #details > .specDetail.failed');
@@ -74,11 +74,13 @@ page.open(system.args[1], function(status){
                       console.log(msg.innerText);
                       console.log('');
                   }
+                  return 1;
                 } else {
                   console.log(document.body.querySelector('.alert > .passingAlert.bar').innerText);
+                  return 0;
                 }
             });
-            phantom.exit();
+            phantom.exit(exitCode);
         });
     }
 });

--- a/examples/run-jasmine.js
+++ b/examples/run-jasmine.js
@@ -55,10 +55,7 @@ page.open(system.args[1], function(status){
     } else {
         waitFor(function(){
             return page.evaluate(function(){
-                if (document.body.querySelector('.runner .description')) {
-                    return true;
-                }
-                return false;
+                return document.body.querySelector('.symbolSummary .pending') === null
             });
         }, function(){
             page.evaluate(function(){

--- a/examples/run-jasmine.js
+++ b/examples/run-jasmine.js
@@ -59,15 +59,21 @@ page.open(system.args[1], function(status){
             });
         }, function(){
             page.evaluate(function(){
+                console.log('');
                 console.log(document.body.querySelector('.description').innerText);
-                list = document.body.querySelectorAll('div.jasmine_reporter > div.suite.failed');
-                for (i = 0; i < list.length; ++i) {
-                    el = list[i];
-                    desc = el.querySelectorAll('.description');
-                    console.log('');
-                    for (j = 0; j < desc.length; ++j) {
-                        console.log(desc[j].innerText);
-                    }
+                var list = document.body.querySelectorAll('.results > #details > .specDetail.failed');
+                if (list && list.length > 0) {
+                  console.log('');
+                  console.log(list.length + ' test(s) FAILED:');
+                  for (i = 0; i < list.length; ++i) {
+                      var el = list[i],
+                          desc = el.querySelector('.description'),
+                          msg = el.querySelector('.resultMessage.fail');
+                      console.log('');
+                      console.log(desc.innerText);
+                      console.log(msg.innerText);
+                      console.log('');
+                  }
                 }
             });
             phantom.exit();


### PR DESCRIPTION
When running against the standalone Jasmine 1.2.0, `waitFor` was timing out because the CSS selectors used to check if the tests had finished weren't matching any elements.

I've changed the CSS selectors used:
- to check if the tests have finished
- to iterate through any failing tests (and output details to the console)

Other changes:
- adding a 'tests pass' message to the console if all tests pass
- returning a non-zero exit code if any tests fail
