### PR TITLE
Fix script argument parsing to be compatible with 1.6 and CasperJS

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -62,7 +62,7 @@ static const struct QCommandLineConfigEntry flags[] =
     { QCommandLine::Option, '\0', "proxy-type", "Specifies the proxy type, 'http' (default), 'none' (disable completely), or 'socks5'", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "script-encoding", "Sets the encoding used for the starting script, default is 'utf8'", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "web-security", "Enables web security, 'yes' (default) or 'no'", QCommandLine::Optional },
-    { QCommandLine::Param, '\0', "script", "Script", QCommandLine::Optional },
+    { QCommandLine::Param, '\0', "script", "Script", QCommandLine::Flags(QCommandLine::Optional|QCommandLine::ParameterFence)},
     { QCommandLine::Param, '\0', "argument", "Script argument", QCommandLine::OptionalMultiple },
     { QCommandLine::Switch, 'h', "help", "Shows this message and quits", QCommandLine::Optional },
     { QCommandLine::Switch, 'v', "version", "Prints out PhantomJS version", QCommandLine::Optional },

--- a/src/qcommandline/qcommandline.cpp
+++ b/src/qcommandline/qcommandline.cpp
@@ -223,6 +223,10 @@ QCommandLine::parse()
 	entry.flags = (QCommandLine::Flags) (entry.flags & ~QCommandLine::Mandatory);
 	entry.flags = (QCommandLine::Flags) (entry.flags | QCommandLine::Optional);
       }
+  
+		if (entry.flags & QCommandLine::ParameterFence) {
+			allparam = true;
+		}
 
       emit paramFound(entry.longName, arg);
 

--- a/src/qcommandline/qcommandline.h
+++ b/src/qcommandline/qcommandline.h
@@ -83,6 +83,7 @@ public:
 	Mandatory = 0x01, /**< mandatory argument, will produce a parse error if not present */
 	Optional = 0x02, /**< optional argument */
 	Multiple = 0x04, /**< argument can be used multiple time and will produce multiple signals. */
+	ParameterFence = 0x08, //**< all arguments after this point are considered parameters, not options.  */
 	MandatoryMultiple = Mandatory|Multiple,
 	OptionalMultiple = Optional|Multiple,
     } Flags;


### PR DESCRIPTION
This fixes CapserJS which builds a command line like this:
`phantomjs bin/bootstrap.js --casper-path=~/capserjs --cli`

That works on Phantom 1.6 but not on master due to the qcommandline port.

Fix by extending qcommandlne to take a ParameterFence flag which causes it to treat any options after a parameter as arguments. Switch "scriptname" to use that so the 1.6 behaviour is restored.

Hacking qcommandline isn't ideal but I can't think of a forward/backward compatible way of coordinating a change with CasperJS
