### PR TITLE
Fixing issue with CookieJar not loading at boot.

### DIFF
--- a/src/cookiejar.cpp
+++ b/src/cookiejar.cpp
@@ -84,7 +84,7 @@ CookieJar::CookieJar(QString cookiesFile, QObject *parent)
     , m_cookieStorage(new QSettings(cookiesFile, QSettings::IniFormat, this))
     , m_enabled(true)
 {
-    QTimer::singleShot(0, this, SLOT(load()));
+    load();
 }
 
 // public:


### PR DESCRIPTION
- Using the "QTimer::singleShot" bites back in the ass
- The "script" takes priority and runs before the SLOT is actually invoked

Why was I using a Timer?
Not sure anymore: it must have slipped in while I was trying to work out
all the other issues I had with QNetworkCookieJar, and I left it there.
