### PR TITLE
Make exit terminating

### DIFF
--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -93,6 +93,7 @@ void Phantom::init()
     CookieJar::instance(m_config.cookiesFile());
 
     m_page = new WebPage(this, QUrl::fromLocalFile(m_config.scriptFile()));
+    m_pages.append(m_page);
 
     QString proxyType = m_config.proxyType();
     if (proxyType != "none") {
@@ -264,6 +265,10 @@ void Phantom::setCookiesEnabled(const bool value)
 QObject *Phantom::createWebPage()
 {
     WebPage *page = new WebPage(this);
+
+    // Store pointer to the page for later cleanup
+    m_pages.append(page);
+    // Apply default settings to the page
     page->applySettings(m_defaultPageSettings);
 
     // Show web-inspector if in debug mode
@@ -402,6 +407,9 @@ void Phantom::doExit(int code)
     emit aboutToExit(code);
     m_terminated = true;
     m_returnValue = code;
+    qDeleteAll(m_pages);
+    m_pages.clear();
+    m_page = 0;
     QApplication::instance()->exit(code);
 }
 

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -315,20 +315,27 @@ QObject* Phantom::createCallback()
 
 void Phantom::loadModule(const QString &moduleSource, const QString &filename)
 {
-   QString scriptSource =
-      "(function(require, exports, module) {" +
-      moduleSource +
-      "}.call({}," +
-      "require.cache['" + filename + "']._getRequire()," +
-      "require.cache['" + filename + "'].exports," +
-      "require.cache['" + filename + "']" +
-      "));";
-   m_page->mainFrame()->evaluateJavaScript(scriptSource, filename);
+    //m_page may not exist if doExit has been called.
+    if (m_page) {
+        QString scriptSource =
+          "(function(require, exports, module) {" +
+          moduleSource +
+          "}.call({}," +
+          "require.cache['" + filename + "']._getRequire()," +
+          "require.cache['" + filename + "'].exports," +
+          "require.cache['" + filename + "']" +
+          "));";
+        m_page->mainFrame()->evaluateJavaScript(scriptSource, filename);
+    }
 }
 
 bool Phantom::injectJs(const QString &jsFilePath)
 {
-    return Utils::injectJsInFrame(jsFilePath, libraryPath(), m_page->mainFrame());
+    //m_page may not exist if doExit has been called.
+    if (m_page) {
+        return Utils::injectJsInFrame(jsFilePath, libraryPath(), m_page->mainFrame());
+    }
+    return false;
 }
 
 void Phantom::exit(int code)

--- a/src/phantom.h
+++ b/src/phantom.h
@@ -182,6 +182,7 @@ private:
     QVariantMap m_defaultPageSettings;
     FileSystem *m_filesystem;
     System *m_system;
+    QList<QPointer<WebPage> > m_pages;
     QList<QPointer<WebServer> > m_servers;
     Config m_config;
 

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -189,6 +189,7 @@ protected:
             newPage = new WebPage(m_webPage);
         } else {
             newPage = new WebPage(Phantom::instance());
+            Phantom::instance()->m_pages.append(newPage);
         }
 
         // Apply default settings


### PR DESCRIPTION
This is a different fix to http://code.google.com/p/phantomjs/issues/detail?id=719 that will prevent many side effects of running code after phantom.exit, while still preventing certain classes of segmentation faults.
