### PR TITLE
Making mongoose read request bodies and write response bodies using UTF-8

### DIFF
--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -221,9 +221,9 @@ bool WebServer::handleRequest(mg_event event, mg_connection *conn, const mg_requ
             // Check if the 'Content-Type' requires decoding
             if (headersObject["Content-Type"] == "application/x-www-form-urlencoded") {
                 requestObject["post"] = UrlEncodedParser::parse(QByteArray(data, read));
-                requestObject["postRaw"] = QString::fromLocal8Bit(data, read);
+                requestObject["postRaw"] = QString::fromUtf8(data, read);
             } else {
-                requestObject["post"] = QString::fromLocal8Bit(data, read);
+                requestObject["post"] = QString::fromUtf8(data, read);
             }
             delete[] data;
         } else {
@@ -405,7 +405,7 @@ void WebServerResponse::write(const QString &body)
         writeHead(m_statusCode, m_headers);
     }
     ///TODO: encoding?!
-    const QByteArray data = body.toLocal8Bit();
+    const QByteArray data = body.toUtf8();
     mg_write(m_conn, data.constData(), data.size());
 }
 


### PR DESCRIPTION
For ease of interoperability with other web clients, particularly with international content, the Mongoose web server needs to read request bodies and write response bodies using UTF-8. This pull request migrates to using UTF-8 for those requests and responses.

http://code.google.com/p/phantomjs/issues/detail?id=809
