### PR TITLE
Fix parsing dates in ISO8601 format

### DIFF
--- a/src/qt/src/3rdparty/webkit/Source/JavaScriptCore/JavaScriptCore.pro
+++ b/src/qt/src/3rdparty/webkit/Source/JavaScriptCore/JavaScriptCore.pro
@@ -152,6 +152,7 @@ SOURCES += \
     runtime/JSArray.cpp \
     runtime/JSByteArray.cpp \
     runtime/JSCell.cpp \
+    runtime/JSDateMath.cpp \
     runtime/JSFunction.cpp \
     runtime/JSGlobalData.cpp \
     runtime/JSGlobalObject.cpp \

--- a/src/qt/src/3rdparty/webkit/Source/JavaScriptCore/runtime/DateConstructor.cpp
+++ b/src/qt/src/3rdparty/webkit/Source/JavaScriptCore/runtime/DateConstructor.cpp
@@ -25,6 +25,7 @@
 #include "DateConversion.h"
 #include "DateInstance.h"
 #include "DatePrototype.h"
+#include "JSDateMath.h"
 #include "JSFunction.h"
 #include "JSGlobalObject.h"
 #include "JSString.h"
@@ -32,7 +33,6 @@
 #include "ObjectPrototype.h"
 #include <math.h>
 #include <time.h>
-#include <wtf/DateMath.h>
 #include <wtf/MathExtras.h>
 
 #if OS(WINCE) && !PLATFORM(QT)

--- a/src/qt/src/3rdparty/webkit/Source/JavaScriptCore/runtime/DateConversion.cpp
+++ b/src/qt/src/3rdparty/webkit/Source/JavaScriptCore/runtime/DateConversion.cpp
@@ -55,18 +55,6 @@ using namespace WTF;
 
 namespace JSC {
 
-double parseDate(ExecState* exec, const UString &date)
-{
-    if (date == exec->globalData().cachedDateString)
-        return exec->globalData().cachedDateStringValue;
-    double value = parseES5DateFromNullTerminatedCharacters(date.utf8().data());
-    if (isnan(value))
-        value = parseDateFromNullTerminatedCharacters(exec, date.utf8().data());
-    exec->globalData().cachedDateString = date;
-    exec->globalData().cachedDateStringValue = value;
-    return value;
-}
-
 void formatDate(const GregorianDateTime &t, DateConversionBuffer& buffer)
 {
     snprintf(buffer, DateConversionBufferSize, "%s %s %02d %04d",

--- a/src/qt/src/3rdparty/webkit/Source/JavaScriptCore/runtime/JSDateMath.cpp
+++ b/src/qt/src/3rdparty/webkit/Source/JavaScriptCore/runtime/JSDateMath.cpp
@@ -1,0 +1,226 @@
+/*
+ * Copyright (C) 1999-2000 Harri Porten (porten@kde.org)
+ * Copyright (C) 2006, 2007 Apple Inc. All rights reserved.
+ * Copyright (C) 2009 Google Inc. All rights reserved.
+ * Copyright (C) 2007-2009 Torch Mobile, Inc.
+ * Copyright (C) 2010 &yet, LLC. (nate@andyet.net)
+ *
+ * The Original Code is Mozilla Communicator client code, released
+ * March 31, 1998.
+ *
+ * The Initial Developer of the Original Code is
+ * Netscape Communications Corporation.
+ * Portions created by the Initial Developer are Copyright (C) 1998
+ * the Initial Developer. All Rights Reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Alternatively, the contents of this file may be used under the terms
+ * of either the Mozilla Public License Version 1.1, found at
+ * http://www.mozilla.org/MPL/ (the "MPL") or the GNU General Public
+ * License Version 2.0, found at http://www.fsf.org/copyleft/gpl.html
+ * (the "GPL"), in which case the provisions of the MPL or the GPL are
+ * applicable instead of those above.  If you wish to allow use of your
+ * version of this file only under the terms of one of those two
+ * licenses (the MPL or the GPL) and not to allow others to use your
+ * version of this file under the LGPL, indicate your decision by
+ * deletingthe provisions above and replace them with the notice and
+ * other provisions required by the MPL or the GPL, as the case may be.
+ * If you do not delete the provisions above, a recipient may use your
+ * version of this file under any of the LGPL, the MPL or the GPL.
+
+ * Copyright 2006-2008 the V8 project authors. All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ *       copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "JSDateMath.h"
+
+#include "JSObject.h"
+
+#include <algorithm>
+#include <limits.h>
+#include <limits>
+#include <stdint.h>
+#include <time.h>
+#include <wtf/ASCIICType.h>
+#include <wtf/Assertions.h>
+#include <wtf/CurrentTime.h>
+#include <wtf/MathExtras.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/StringExtras.h>
+#include <wtf/text/StringBuilder.h>
+
+#if HAVE(ERRNO_H)
+#include <errno.h>
+#endif
+
+#if HAVE(SYS_TIME_H)
+#include <sys/time.h>
+#endif
+
+#if HAVE(SYS_TIMEB_H)
+#include <sys/timeb.h>
+#endif
+
+using namespace WTF;
+
+namespace JSC {
+
+static inline double timeToMS(double hour, double min, double sec, double ms)
+{
+    return (((hour * minutesPerHour + min) * secondsPerMinute + sec) * msPerSecond + ms);
+}
+
+static inline int msToSeconds(double ms)
+{
+    double result = fmod(floor(ms / msPerSecond), secondsPerMinute);
+    if (result < 0)
+        result += secondsPerMinute;
+    return static_cast<int>(result);
+}
+
+static inline int msToDays(double ms)
+{
+    return floor(ms / msPerDay);
+}
+
+// 0: Sunday, 1: Monday, etc.
+static inline int msToWeekDay(double ms)
+{
+    int wd = (static_cast<int>(msToDays(ms)) + 4) % 7;
+    if (wd < 0)
+        wd += 7;
+    return wd;
+}
+	
+// Get the DST offset for the time passed in.
+//
+// NOTE: The implementation relies on the fact that no time zones have
+// more than one daylight savings offset change per month.
+// If this function is called with NaN it returns NaN.
+static double getDSTOffset(ExecState* exec, double ms, double utcOffset)
+{
+    DSTOffsetCache& cache = exec->globalData().dstOffsetCache;
+    double start = cache.start;
+    double end = cache.end;
+
+    if (start <= ms) {
+        // If the time fits in the cached interval, return the cached offset.
+        if (ms <= end) return cache.offset;
+
+        // Compute a possible new interval end.
+        double newEnd = end + cache.increment;
+
+        if (ms <= newEnd) {
+            double endOffset = calculateDSTOffset(newEnd, utcOffset);
+            if (cache.offset == endOffset) {
+                // If the offset at the end of the new interval still matches
+                // the offset in the cache, we grow the cached time interval
+                // and return the offset.
+                cache.end = newEnd;
+                cache.increment = msPerMonth;
+                return endOffset;
+            } else {
+                double offset = calculateDSTOffset(ms, utcOffset);
+                if (offset == endOffset) {
+                    // The offset at the given time is equal to the offset at the
+                    // new end of the interval, so that means that we've just skipped
+                    // the point in time where the DST offset change occurred. Updated
+                    // the interval to reflect this and reset the increment.
+                    cache.start = ms;
+                    cache.end = newEnd;
+                    cache.increment = msPerMonth;
+                } else {
+                    // The interval contains a DST offset change and the given time is
+                    // before it. Adjust the increment to avoid a linear search for
+                    // the offset change point and change the end of the interval.
+                    cache.increment /= 3;
+                    cache.end = ms;
+                }
+                // Update the offset in the cache and return it.
+                cache.offset = offset;
+                return offset;
+            }
+        }
+    }
+
+    // Compute the DST offset for the time and shrink the cache interval
+    // to only contain the time. This allows fast repeated DST offset
+    // computations for the same time.
+    double offset = calculateDSTOffset(ms, utcOffset);
+    cache.offset = offset;
+    cache.start = ms;
+    cache.end = ms;
+    cache.increment = msPerMonth;
+    return offset;
+}
+
+double parseDateFromNullTerminatedCharacters(ExecState* exec, const char* dateString)
+{
+    ASSERT(exec);
+    bool haveTZ;
+    int offset;
+    double ms = WTF::parseDateFromNullTerminatedCharacters(dateString, haveTZ, offset);
+    if (isnan(ms))
+        return std::numeric_limits<double>::quiet_NaN();
+
+    // fall back to local timezone
+    if (!haveTZ) {
+        double utcOffset = getUTCOffset(exec);
+        double dstOffset = getDSTOffset(exec, ms, utcOffset);
+        offset = static_cast<int>((utcOffset + dstOffset) / WTF::msPerMinute);
+    }
+
+    return ms - (offset * WTF::msPerMinute);
+}
+
+double parseDate(ExecState* exec, const UString& date)
+{
+    if (date == exec->globalData().cachedDateString)
+        return exec->globalData().cachedDateStringValue;
+    double value = parseES5DateFromNullTerminatedCharacters(date.utf8().data());
+    if (isnan(value))
+        value = parseDateFromNullTerminatedCharacters(exec, date.utf8().data());
+    exec->globalData().cachedDateString = date;
+    exec->globalData().cachedDateStringValue = value;
+    return value;
+}
+
+} // namespace JSC

--- a/src/qt/src/3rdparty/webkit/Source/JavaScriptCore/runtime/JSDateMath.h
+++ b/src/qt/src/3rdparty/webkit/Source/JavaScriptCore/runtime/JSDateMath.h
@@ -2,6 +2,7 @@
  * Copyright (C) 1999-2000 Harri Porten (porten@kde.org)
  * Copyright (C) 2006, 2007 Apple Inc. All rights reserved.
  * Copyright (C) 2009 Google Inc. All rights reserved.
+ * Copyright (C) 2010 Research In Motion Limited. All rights reserved.
  *
  * Version: MPL 1.1/GPL 2.0/LGPL 2.1
  *
@@ -39,24 +40,19 @@
  *
  */
 
-#ifndef DateConversion_h
-#define DateConversion_h
+#ifndef JSDateMath_h
+#define JSDateMath_h
 
 #include "UString.h"
+#include <wtf/DateMath.h>
 
 namespace JSC {
 
 class ExecState;
-struct GregorianDateTime;
 
-static const unsigned DateConversionBufferSize = 100;
-typedef char DateConversionBuffer[DateConversionBufferSize];
-
-void formatDate(const GregorianDateTime&, DateConversionBuffer&);
-void formatDateUTCVariant(const GregorianDateTime&, DateConversionBuffer&);
-void formatTime(const GregorianDateTime&, DateConversionBuffer&);
-void formatTimeUTC(const GregorianDateTime&, DateConversionBuffer&);
+double parseDateFromNullTerminatedCharacters(ExecState*, const char* dateString);
+double parseDate(ExecState*, const UString&);
 
 } // namespace JSC
 
-#endif // DateConversion_h
+#endif // JSDateMath_h

--- a/src/qt/src/3rdparty/webkit/Source/JavaScriptCore/wtf/DateMath.cpp
+++ b/src/qt/src/3rdparty/webkit/Source/JavaScriptCore/wtf/DateMath.cpp
@@ -180,6 +180,14 @@ static inline double msToDays(double ms)
     return floor(ms / msPerDay);
 }
 
+static String twoDigitStringFromNumber(int number)
+{
+    ASSERT(number >= 0 && number < 100);
+    if (number > 9)
+        return String::number(number);
+    return makeString("0", String::number(number));
+}
+
 int msToYear(double ms)
 {
     int approxYear = static_cast<int>(floor(ms / (msPerDay * 365.2425)) + 1970);
@@ -565,91 +573,176 @@ static bool parseLong(const char* string, char** stopPosition, int base, long* r
     return true;
 }
 
+// Parses a date with the format YYYY[-MM[-DD]].
+// Year parsing is lenient, allows any number of digits, and +/-.
+// Returns 0 if a parse error occurs, else returns the end of the parsed portion of the string.
+static char* parseES5DatePortion(const char* currentPosition, long& year, long& month, long& day)
+{
+    char* postParsePosition;
+
+    // This is a bit more lenient on the year string than ES5 specifies:
+    // instead of restricting to 4 digits (or 6 digits with mandatory +/-),
+    // it accepts any integer value. Consider this an implementation fallback.
+    if (!parseLong(currentPosition, &postParsePosition, 10, &year))
+        return 0;
+
+    // Check for presence of -MM portion.
+    if (*postParsePosition != '-')
+        return postParsePosition;
+    currentPosition = postParsePosition + 1;
+
+    if (!isASCIIDigit(*currentPosition))
+        return 0;
+    if (!parseLong(currentPosition, &postParsePosition, 10, &month))
+        return 0;
+    if ((postParsePosition - currentPosition) != 2)
+        return 0;
+
+    // Check for presence of -DD portion.
+    if (*postParsePosition != '-')
+        return postParsePosition;
+    currentPosition = postParsePosition + 1;
+
+    if (!isASCIIDigit(*currentPosition))
+        return 0;
+    if (!parseLong(currentPosition, &postParsePosition, 10, &day))
+        return 0;
+    if ((postParsePosition - currentPosition) != 2)
+        return 0;
+    return postParsePosition;
+}
+
+// Parses a time with the format HH:mm[:ss[.sss]][Z|(+|-)00:00].
+// Fractional seconds parsing is lenient, allows any number of digits.
+// Returns 0 if a parse error occurs, else returns the end of the parsed portion of the string.
+static char* parseES5TimePortion(char* currentPosition, long& hours, long& minutes, double& seconds, long& timeZoneSeconds)
+{
+    char* postParsePosition;
+    if (!isASCIIDigit(*currentPosition))
+        return 0;
+    if (!parseLong(currentPosition, &postParsePosition, 10, &hours))
+        return 0;
+    if (*postParsePosition != ':' || (postParsePosition - currentPosition) != 2)
+        return 0;
+    currentPosition = postParsePosition + 1;
+
+    if (!isASCIIDigit(*currentPosition))
+        return 0;
+    if (!parseLong(currentPosition, &postParsePosition, 10, &minutes))
+        return 0;
+    if ((postParsePosition - currentPosition) != 2)
+        return 0;
+    currentPosition = postParsePosition;
+
+    // Seconds are optional.
+    if (*currentPosition == ':') {
+        ++currentPosition;
+
+        long intSeconds;
+        if (!isASCIIDigit(*currentPosition))
+            return 0;
+        if (!parseLong(currentPosition, &postParsePosition, 10, &intSeconds))
+            return 0;
+        if ((postParsePosition - currentPosition) != 2)
+            return 0;
+        seconds = intSeconds;
+        if (*postParsePosition == '.') {
+            currentPosition = postParsePosition + 1;
+
+            // In ECMA-262-5 it's a bit unclear if '.' can be present without milliseconds, but
+            // a reasonable interpretation guided by the given examples and RFC 3339 says "no".
+            // We check the next character to avoid reading +/- timezone hours after an invalid decimal.
+            if (!isASCIIDigit(*currentPosition))
+                return 0;
+
+            // We are more lenient than ES5 by accepting more or less than 3 fraction digits.
+            long fracSeconds;
+            if (!parseLong(currentPosition, &postParsePosition, 10, &fracSeconds))
+                return 0;
+
+            long numFracDigits = postParsePosition - currentPosition;
+            seconds += fracSeconds * pow(10.0, static_cast<double>(-numFracDigits));
+        }
+        currentPosition = postParsePosition;
+    }
+
+    if (*currentPosition == 'Z')
+        return currentPosition + 1;
+
+    bool tzNegative;
+    if (*currentPosition == '-')
+        tzNegative = true;
+    else if (*currentPosition == '+')
+        tzNegative = false;
+    else
+        return currentPosition; // no timezone
+    ++currentPosition;
+
+    long tzHours;
+    long tzHoursAbs;
+    long tzMinutes;
+
+    if (!isASCIIDigit(*currentPosition))
+        return 0;
+    if (!parseLong(currentPosition, &postParsePosition, 10, &tzHours))
+        return 0;
+    if (*postParsePosition != ':' || (postParsePosition - currentPosition) != 2)
+        return 0;
+    tzHoursAbs = labs(tzHours);
+    currentPosition = postParsePosition + 1;
+
+    if (!isASCIIDigit(*currentPosition))
+        return 0;
+    if (!parseLong(currentPosition, &postParsePosition, 10, &tzMinutes))
+        return 0;
+    if ((postParsePosition - currentPosition) != 2)
+        return 0;
+    currentPosition = postParsePosition;
+
+    if (tzHoursAbs > 24)
+        return 0;
+    if (tzMinutes < 0 || tzMinutes > 59)
+        return 0;
+
+    timeZoneSeconds = 60 * (tzMinutes + (60 * tzHoursAbs));
+    if (tzNegative)
+        timeZoneSeconds = -timeZoneSeconds;
+
+    return currentPosition;
+}
+
 double parseES5DateFromNullTerminatedCharacters(const char* dateString)
 {
     // This parses a date of the form defined in ECMA-262-5, section 15.9.1.15
     // (similar to RFC 3339 / ISO 8601: YYYY-MM-DDTHH:mm:ss[.sss]Z).
     // In most cases it is intentionally strict (e.g. correct field widths, no stray whitespace).
-    
+
     static const long daysPerMonth[12] = { 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
-    
-    const char* currentPosition = dateString;
-    char* postParsePosition;
-    
-    // This is a bit more lenient on the year string than ES5 specifies:
-    // instead of restricting to 4 digits (or 6 digits with mandatory +/-),
-    // it accepts any integer value. Consider this an implementation fallback.
-    long year;
-    if (!parseLong(currentPosition, &postParsePosition, 10, &year))
+
+    // The year must be present, but the other fields may be omitted - see ES5.1 15.9.1.15.
+    long year = 0;
+    long month = 1;
+    long day = 1;
+    long hours = 0;
+    long minutes = 0;
+    double seconds = 0;
+    long timeZoneSeconds = 0;
+
+    // Parse the date YYYY[-MM[-DD]]
+    char* currentPosition = parseES5DatePortion(dateString, year, month, day);
+    if (!currentPosition)
         return NaN;
-    if (*postParsePosition != '-')
-        return NaN;
-    currentPosition = postParsePosition + 1;
-    
-    long month;
-    if (!isASCIIDigit(*currentPosition))
-        return NaN;
-    if (!parseLong(currentPosition, &postParsePosition, 10, &month))
-        return NaN;
-    if (*postParsePosition != '-' || (postParsePosition - currentPosition) != 2)
-        return NaN;
-    currentPosition = postParsePosition + 1;
-    
-    long day;
-    if (!isASCIIDigit(*currentPosition))
-        return NaN;
-    if (!parseLong(currentPosition, &postParsePosition, 10, &day))
-        return NaN;
-    if (*postParsePosition != 'T' || (postParsePosition - currentPosition) != 2)
-        return NaN;
-    currentPosition = postParsePosition + 1;
-    
-    long hours;
-    if (!isASCIIDigit(*currentPosition))
-        return NaN;
-    if (!parseLong(currentPosition, &postParsePosition, 10, &hours))
-        return NaN;
-    if (*postParsePosition != ':' || (postParsePosition - currentPosition) != 2)
-        return NaN;
-    currentPosition = postParsePosition + 1;
-    
-    long minutes;
-    if (!isASCIIDigit(*currentPosition))
-        return NaN;
-    if (!parseLong(currentPosition, &postParsePosition, 10, &minutes))
-        return NaN;
-    if (*postParsePosition != ':' || (postParsePosition - currentPosition) != 2)
-        return NaN;
-    currentPosition = postParsePosition + 1;
-    
-    long intSeconds;
-    if (!isASCIIDigit(*currentPosition))
-        return NaN;
-    if (!parseLong(currentPosition, &postParsePosition, 10, &intSeconds))
-        return NaN;
-    if ((postParsePosition - currentPosition) != 2)
-        return NaN;
-    
-    double seconds = intSeconds;
-    if (*postParsePosition == '.') {
-        currentPosition = postParsePosition + 1;
-        
-        // In ECMA-262-5 it's a bit unclear if '.' can be present without milliseconds, but
-        // a reasonable interpretation guided by the given examples and RFC 3339 says "no".
-        // We check the next character to avoid reading +/- timezone hours after an invalid decimal.
-        if (!isASCIIDigit(*currentPosition))
+    // Look for a time portion.
+    if (*currentPosition == 'T') {
+        // Parse the time HH:mm[:ss[.sss]][Z|(+|-)00:00]
+        currentPosition = parseES5TimePortion(currentPosition + 1, hours, minutes, seconds, timeZoneSeconds);
+        if (!currentPosition)
             return NaN;
-        
-        // We are more lenient than ES5 by accepting more or less than 3 fraction digits.
-        long fracSeconds;
-        if (!parseLong(currentPosition, &postParsePosition, 10, &fracSeconds))
-            return NaN;
-        
-        long numFracDigits = postParsePosition - currentPosition;
-        seconds += fracSeconds * pow(10.0, static_cast<double>(-numFracDigits));
     }
-    currentPosition = postParsePosition;
-    
+    // Check that we have parsed all characters in the string.
+    if (*currentPosition)
+        return NaN;
+
     // A few of these checks could be done inline above, but since many of them are interrelated
     // we would be sacrificing readability to "optimize" the (presumably less common) failure path.
     if (month < 1 || month > 12)
@@ -670,59 +763,13 @@ double parseES5DateFromNullTerminatedCharacters(const char* dateString)
         // Discard leap seconds by clamping to the end of a minute.
         seconds = 60;
     }
-    
-    long timeZoneSeconds = 0;
-    if (*currentPosition != 'Z') {
-        bool tzNegative;
-        if (*currentPosition == '-')
-            tzNegative = true;
-        else if (*currentPosition == '+')
-            tzNegative = false;
-        else
-            return NaN;
-        currentPosition += 1;
-        
-        long tzHours;
-        long tzHoursAbs;
-        long tzMinutes;
-        
-        if (!isASCIIDigit(*currentPosition))
-            return NaN;
-        if (!parseLong(currentPosition, &postParsePosition, 10, &tzHours))
-            return NaN;
-        if (*postParsePosition != ':' || (postParsePosition - currentPosition) != 2)
-            return NaN;
-        tzHoursAbs = labs(tzHours);
-        currentPosition = postParsePosition + 1;
-        
-        if (!isASCIIDigit(*currentPosition))
-            return NaN;
-        if (!parseLong(currentPosition, &postParsePosition, 10, &tzMinutes))
-            return NaN;
-        if ((postParsePosition - currentPosition) != 2)
-            return NaN;
-        currentPosition = postParsePosition;
-        
-        if (tzHoursAbs > 24)
-            return NaN;
-        if (tzMinutes < 0 || tzMinutes > 59)
-            return NaN;
-        
-        timeZoneSeconds = 60 * (tzMinutes + (60 * tzHoursAbs));
-        if (tzNegative)
-            timeZoneSeconds = -timeZoneSeconds;
-    } else {
-        currentPosition += 1;
-    }
-    if (*currentPosition)
-        return NaN;
-    
+
     double dateSeconds = ymdhmsToSeconds(year, month, day, hours, minutes, seconds) - timeZoneSeconds;
     return dateSeconds * msPerSecond;
 }
 
 // Odd case where 'exec' is allowed to be 0, to accomodate a caller in WebCore.
-static double parseDateFromNullTerminatedCharacters(const char* dateString, bool& haveTZ, int& offset)
+double parseDateFromNullTerminatedCharacters(const char* dateString, bool& haveTZ, int& offset)
 {
     haveTZ = false;
     offset = 0;
@@ -974,9 +1021,8 @@ static double parseDateFromNullTerminatedCharacters(const char* dateString, bool
         if (!parseLong(dateString, &newPosStr, 10, &year))
             return NaN;
         dateString = newPosStr;
+		skipSpacesAndComments(dateString);
     }
-
-    skipSpacesAndComments(dateString);
 
     // Trailing garbage
     if (*dateString)
@@ -1125,36 +1171,18 @@ void msToGregorianDateTime(ExecState* exec, double ms, bool outputIsUTC, Gregori
     }
 
     const int year = msToYear(ms);
-    tm.second   =  msToSeconds(ms);
-    tm.minute   =  msToMinutes(ms);
-    tm.hour     =  msToHours(ms);
-    tm.weekDay  =  msToWeekDay(ms);
-    tm.yearDay  =  dayInYear(ms, year);
-    tm.monthDay =  dayInMonthFromDayInYear(tm.yearDay, isLeapYear(year));
-    tm.month    =  monthFromDayInYear(tm.yearDay, isLeapYear(year));
-    tm.year     =  year - 1900;
-    tm.isDST    =  dstOff != 0.0;
+	tm.second = msToSeconds(ms);    
+    tm.minute = msToMinutes(ms);
+    tm.hour = msToHours(ms);
+    tm.weekDay = msToWeekDay(ms);
+    tm.yearDay = dayInYear(ms, year);
+    tm.monthDay = dayInMonthFromDayInYear(tm.yearDay, isLeapYear(year));
+    tm.month = monthFromDayInYear(tm.yearDay, isLeapYear(year));
+    tm.year = year - 1900;
+    tm.isDST = dstOff != 0.0;
     tm.utcOffset = static_cast<long>((dstOff + utcOff) / WTF::msPerSecond);
-    tm.timeZone = nullptr;
 }
 
-double parseDateFromNullTerminatedCharacters(ExecState* exec, const char* dateString)
-{
-    ASSERT(exec);
-    bool haveTZ;
-    int offset;
-    double ms = WTF::parseDateFromNullTerminatedCharacters(dateString, haveTZ, offset);
-    if (isnan(ms))
-        return NaN;
-
-    // fall back to local timezone
-    if (!haveTZ) {
-        double utcOffset = getUTCOffset(exec);
-        double dstOffset = getDSTOffset(exec, ms, utcOffset);
-        offset = static_cast<int>((utcOffset + dstOffset) / WTF::msPerMinute);
-    }
-    return ms - (offset * WTF::msPerMinute);
-}
 
 } // namespace JSC
 #endif // USE(JSC)

--- a/src/qt/src/3rdparty/webkit/Source/JavaScriptCore/wtf/DateMath.h
+++ b/src/qt/src/3rdparty/webkit/Source/JavaScriptCore/wtf/DateMath.h
@@ -52,6 +52,8 @@
 #include <wtf/OwnArrayPtr.h>
 #include <wtf/PassOwnArrayPtr.h>
 #include <wtf/UnusedParam.h>
+#include <wtf/text/WTFString.h>
+#include <wtf/text/StringConcatenate.h>
 
 namespace WTF {
 void initializeDates();
@@ -59,7 +61,8 @@ int equivalentYearForDST(int year);
 
 // Not really math related, but this is currently the only shared place to put these.
 double parseES5DateFromNullTerminatedCharacters(const char* dateString);
-double parseDateFromNullTerminatedCharacters(const char* dateString);
+WTF_EXPORT_PRIVATE double parseDateFromNullTerminatedCharacters(const char* dateString);
+double parseDateFromNullTerminatedCharacters(const char* dateString, bool& haveTZ, int& offset);
 double timeClip(double);
 
 inline double jsCurrentTime()
@@ -117,7 +120,6 @@ struct GregorianDateTime;
 void msToGregorianDateTime(ExecState*, double, bool outputIsUTC, GregorianDateTime&);
 double gregorianDateTimeToMS(ExecState*, const GregorianDateTime&, double, bool inputIsUTC);
 double getUTCOffset(ExecState*);
-double parseDateFromNullTerminatedCharacters(ExecState*, const char* dateString);
 
 // Intentionally overridding the default tm of the system.
 // The members of tm differ on various operating systems.

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -70,6 +70,7 @@ phantom.injectJs("./fs-spec-02.js"); //< Filesystem Specs 02 (Attributes)
 phantom.injectJs("./fs-spec-03.js"); //< Filesystem Specs 03 (Paths)
 phantom.injectJs("./fs-spec-04.js"); //< Filesystem Specs 04 (Tests)
 phantom.injectJs("./system-spec.js");
+phantom.injectJs("./webkit-spec.js");
 require("./module_spec.js");
 require("./require/require_spec.js");
 

--- a/test/webkit-spec.js
+++ b/test/webkit-spec.js
@@ -1,0 +1,11 @@
+describe("WebKit", function() {
+  it("should construct date in mm-dd-yyyy format", function() {
+    var date = new Date('2012-09-07');    
+    expect(date.toString()).toNotEqual('Invalid Date');
+  });
+  
+  it("should parse date in ISO8601 format (yyyy-mm-dd)", function() {
+    var date = Date.parse("2012-01-01");
+    expect(date).toEqual(1325376000000);
+  });
+});


### PR DESCRIPTION
Allow construct and parse dates in ISO8601 format.
Example date formats:
- Year:
    YYYY (eg 1997)
- Year and month:
    YYYY-MM (eg 1997-07)
- Complete date:
    YYYY-MM-DD (eg 1997-07-16)
- Complete date plus hours and minutes:
    YYYY-MM-DDThh:mmTZD (eg 1997-07-16T19:20+01:00)
- Complete date plus hours, minutes and seconds:
    YYYY-MM-DDThh:mm:ssTZD (eg 1997-07-16T19:20:30+01:00)
- Complete date plus hours, minutes, seconds and a decimal fraction of a
  second
    YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45+01:00)

Issues: http://code.google.com/p/phantomjs/issues/detail?id=187
http://code.google.com/p/phantomjs/issues/detail?id=267

I tried to make only the necessary changes in the WebKit code for those issues.
