### PR TITLE
fix navigation locked flag reporting to navigationRequested event

### DIFF
--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -174,7 +174,7 @@ protected:
         emit m_webPage->navigationRequested(
                     request.url(),                   //< Requested URL
                     navigationType,                  //< Navigation Type
-                    !m_webPage->navigationLocked(),  //< Is navigation locked?
+                    m_webPage->navigationLocked(),   //< Is navigation locked?
                     isMainFrame);                    //< Is main frame?
 
         return !m_webPage->navigationLocked();


### PR DESCRIPTION
I noticed the lock flag is reported backwards. This fixes it.
