### PR TITLE
Added a max authentication attempts option.

### DIFF
--- a/src/consts.h
+++ b/src/consts.h
@@ -58,6 +58,7 @@
 #define PAGE_SETTINGS_LOCAL_ACCESS_REMOTE   "localToRemoteUrlAccessEnabled"
 #define PAGE_SETTINGS_USERNAME              "userName"
 #define PAGE_SETTINGS_PASSWORD              "password"
+#define PAGE_SETTINGS_MAX_AUTH_ATTEMPTS     "maxAuthAttempts"
 #define PAGE_SETTINGS_WEB_SECURITY_ENABLED  "webSecurityEnabled"
 #define PAGE_SETTINGS_JS_CAN_OPEN_WINDOWS   "javascriptCanOpenWindows"
 #define PAGE_SETTINGS_JS_CAN_CLOSE_WINDOWS  "javascriptCanCloseWindows"

--- a/src/networkaccessmanager.h
+++ b/src/networkaccessmanager.h
@@ -47,6 +47,7 @@ public:
     NetworkAccessManager(QObject *parent, const Config *config);
     void setUserName(const QString &userName);
     void setPassword(const QString &password);
+    void setMaxAuthAttempts(int maxAttempts);
     void setCustomHeaders(const QVariantMap &headers);
     QVariantMap customHeaders() const;
 
@@ -54,9 +55,12 @@ public:
 
 protected:
     bool m_ignoreSslErrors;
+    int m_authAttempts;
+    int m_maxAuthAttempts;
     QString m_userName;
     QString m_password;
     QNetworkReply *createRequest(Operation op, const QNetworkRequest & req, QIODevice * outgoingData = 0);
+    void handleFinished(QNetworkReply *reply, const QVariant &status, const QVariant &statusText);
 
 signals:
     void resourceRequested(const QVariant& data);

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -434,6 +434,9 @@ void WebPage::applySettings(const QVariantMap &def)
 
     if (def.contains(PAGE_SETTINGS_PASSWORD))
         m_networkAccessManager->setPassword(def[PAGE_SETTINGS_PASSWORD].toString());
+
+    if (def.contains(PAGE_SETTINGS_MAX_AUTH_ATTEMPTS))
+        m_networkAccessManager->setMaxAuthAttempts(def[PAGE_SETTINGS_MAX_AUTH_ATTEMPTS].toInt());
 }
 
 QString WebPage::userAgent() const

--- a/test/webpage-spec.js
+++ b/test/webpage-spec.js
@@ -599,6 +599,39 @@ describe("WebPage object", function() {
 
     });
 
+    it("should return properly from a 401 status", function() {
+        var server = require('webserver').create();
+        server.listen(12345, function(request, response) {
+            response.statusCode = 401;
+            response.setHeader('WWW-Authenticate', 'Basic realm="PhantomJS test"');
+            response.write('Authentication Required');
+            response.close();
+        });
+
+        var url = "http://localhost:12345/foo";
+        var handled = 0;
+        runs(function() {
+            expect(handled).toEqual(0);
+            page.onResourceReceived = function(resource) {
+                expect(resource.status).toEqual(401);
+                handled++;
+            };
+            page.open(url, function(status) {
+                expect(status).toEqual('fail');
+                handled++;
+            });
+        });
+
+        waits(50);
+
+        runs(function() {
+            expect(handled).toEqual(2);
+            page.onResourceReceived = null;
+            server.close();
+        });
+
+    });
+
     it("should set valid cookie properly, then remove it", function() {
         var server = require('webserver').create();
         server.listen(12345, function(request, response) {


### PR DESCRIPTION
When QTWebKit receives a 401 code, it "loops" infinitely calling authenticationRequired until authentication succeeds (see [QNetworkAccessManager::authenticationRequired](http://doc.qt.digia.com/4.6/qnetworkaccessmanager.html#authenticationRequired)). This causes a problem with code such as the sample below, as neither callback is ever invoked.

``` coffeescript
page.onRequestReceived = (request) ->
  assert request.status is 401
page.open 'http://test.webdav.org/auth-basic/', (status) ->
  assert status is 'fail'
```

This pull request adds a page setting `maxAuthAttempts` (defaults to 3) that limits the amount of times authentication is attempted before the request is aborted and callbacks are invoked. 

Note that some special handling is included to set status to `401` and statusText to `Authorization Required` before handling the result. This since the status and statusText supplied to authorizationRequired are null.

Issue: https://code.google.com/p/phantomjs/issues/detail?id=826
