### PR TITLE
Allow writing binary content in WebServerResponse::write

### DIFF
--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -399,13 +399,11 @@ void WebServerResponse::writeHead(int statusCode, const QVariantMap &headers)
     mg_write(m_conn, "\r\n", 2);
 }
 
-void WebServerResponse::write(const QString &body)
+void WebServerResponse::write(const QByteArray &data)
 {
     if (!m_headersSent) {
         writeHead(m_statusCode, m_headers);
     }
-    ///TODO: encoding?!
-    const QByteArray data = body.toLocal8Bit();
     mg_write(m_conn, data.constData(), data.size());
 }
 

--- a/src/webserver.h
+++ b/src/webserver.h
@@ -112,7 +112,7 @@ public slots:
     /// send @p headers to client with status code @p statusCode
     void writeHead(int statusCode, const QVariantMap &headers);
     /// sends @p data to client and makes sure the headers are send beforehand
-    void write(const QString &data);
+    void write(const QByteArray &data);
 
     /**
      * Closes the request once all data has been written to the client.


### PR DESCRIPTION
write() now takes QByteArray instead of taking QString and converting it manually to QByteArray in bad way.
This change is transparent to JavaScript - types are converted automatically by QVariant class.

Fixes issue 505: http://code.google.com/p/phantomjs/issues/detail?id=505

This is generally just implemented suggestion by @detro from https://github.com/ariya/phantomjs/pull/288#issuecomment-6698415
After compiling and testing, test case from that pull request was working correctly.
