### PR TITLE
Implementing modifier keys in WebPage::sendEvent()

### DIFF
--- a/src/webpage.h
+++ b/src/webpage.h
@@ -248,7 +248,7 @@ public slots:
     QObject *_getJsConfirmCallback();
     QObject *_getJsPromptCallback();
     void uploadFile(const QString &selector, const QString &fileName);
-    void sendEvent(const QString &type, const QVariant &arg1 = QVariant(), const QVariant &arg2 = QVariant(), const QString &mouseButton = QString());
+    void sendEvent(const QString &type, const QVariant &arg1 = QVariant(), const QVariant &arg2 = QVariant(), const QString &mouseButton = QString(), const QVariant &modifierArg = QVariant());
 
     /**
      * Returns a Child Page that matches the given <code>"window.name"</code>.

--- a/test/webpage-spec.js
+++ b/test/webpage-spec.js
@@ -1,4 +1,4 @@
-function checkClipRect(page, clipRect) {
+﻿function checkClipRect(page, clipRect) {
     expectHasProperty(page, 'clipRect');
     it("should have clipRect with height "+clipRect.height, function () {
         expect(page.clipRect.height).toEqual(clipRect.height);
@@ -258,6 +258,23 @@ describe("WebPage object", function() {
     });
 
     it("should handle keypress event of string with inputs", function() {
+        runs(function() {
+            page.content = '<input type="text">';
+            page.evaluate(function() {
+                document.querySelector('input').focus();
+            });
+            page.sendEvent('keypress', "ABCD");
+            // 0x02000000 is the Shift modifier.
+            page.sendEvent('keypress', page.event.key.Home, null, null,  0x02000000);
+            page.sendEvent('keypress', page.event.key.Delete);
+            var text = page.evaluate(function() {
+                return document.querySelector('input').value;
+            });
+            expect(text).toEqual("");
+        });
+    });
+
+    it("should handle key events with modifier keys", function() {
         runs(function() {
             page.content = '<input type="text">';
             page.evaluate(function() {


### PR DESCRIPTION
This pull request implements modifier keys in WebPage::SendEvent().

When keyboard events were implemented in PhantomJS, the use of modifier keys (Shift, Control, Alt, etc.) was deliberately left as a TODO item. This pull request implements that feature. It adds a new optional argument to WebPage::sendEvent() to accept the passing in of the modifier keys as defined in the Qt::KeyboardModifier enum. If the argument is not passed, or is not an int, the modifier key for the event is equivalent to Qt::NoModifier.

Fixes PhantomJS issue #835 (http://code.google.com/p/phantomjs/issues/detail?id=835).
