### PR TITLE
Allow to specify ssl protocol

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -62,7 +62,7 @@ static const struct QCommandLineConfigEntry flags[] =
     { QCommandLine::Option, '\0', "proxy-type", "Specifies the proxy type, 'http' (default), 'none' (disable completely), or 'socks5'", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "script-encoding", "Sets the encoding used for the starting script, default is 'utf8'", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "web-security", "Enables web security, 'yes' (default) or 'no'", QCommandLine::Optional },
-    { QCommandLine::Option, '\0', "ssl-protocol", "Sets the SSL protocol (supported protocols: 'SSLv3', 'SSLv2', 'TLSv1', 'TlsV1SslV3' (default))", QCommandLine::Optional },
+    { QCommandLine::Option, '\0', "ssl-protocol", "Sets the SSL protocol (supported protocols: 'SSLv3' (default), 'SSLv2', 'TLSv1', 'any')", QCommandLine::Optional },
     { QCommandLine::Param, '\0', "script", "Script", QCommandLine::Flags(QCommandLine::Optional|QCommandLine::ParameterFence)},
     { QCommandLine::Param, '\0', "argument", "Script argument", QCommandLine::OptionalMultiple },
     { QCommandLine::Switch, 'h', "help", "Shows this message and quits", QCommandLine::Optional },
@@ -454,6 +454,7 @@ void Config::resetToDefaults()
     m_javascriptCanCloseWindows = true;
     m_helpFlag = false;
     m_printDebugMessages = false;
+    m_sslProtocol = "sslv3";
 }
 
 void Config::setProxyAuthPass(const QString &value)
@@ -595,7 +596,7 @@ void Config::handleOption(const QString &option, const QVariant &value)
         setWebSecurityEnabled(boolValue);
     }
     if (option == "ssl-protocol") {
-        setSslProtocol(value.toString().toLower());
+        setSslProtocol(value.toString());
     }
 }
 
@@ -621,5 +622,5 @@ QString Config::sslProtocol() const
 
 void Config::setSslProtocol(const QString& sslProtocolName)
 {
-    m_sslProtocol = sslProtocolName;
+    m_sslProtocol = sslProtocolName.toLower();
 }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -62,6 +62,7 @@ static const struct QCommandLineConfigEntry flags[] =
     { QCommandLine::Option, '\0', "proxy-type", "Specifies the proxy type, 'http' (default), 'none' (disable completely), or 'socks5'", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "script-encoding", "Sets the encoding used for the starting script, default is 'utf8'", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "web-security", "Enables web security, 'yes' (default) or 'no'", QCommandLine::Optional },
+    { QCommandLine::Option, '\0', "ssl-protocol", "Sets the SSL protocol (supported protocols: 'SSLv3', 'SSLv2', 'TLSv1', 'TlsV1SslV3' (default))", QCommandLine::Optional },
     { QCommandLine::Param, '\0', "script", "Script", QCommandLine::Flags(QCommandLine::Optional|QCommandLine::ParameterFence)},
     { QCommandLine::Param, '\0', "argument", "Script argument", QCommandLine::OptionalMultiple },
     { QCommandLine::Switch, 'h', "help", "Shows this message and quits", QCommandLine::Optional },
@@ -593,6 +594,9 @@ void Config::handleOption(const QString &option, const QVariant &value)
     if (option == "web-security") {
         setWebSecurityEnabled(boolValue);
     }
+    if (option == "ssl-protocol") {
+        setSslProtocol(value.toString().toLower());
+    }
 }
 
 void Config::handleParam(const QString& param, const QVariant &value)
@@ -610,3 +614,12 @@ void Config::handleError(const QString &error)
     setUnknownOption(QString("Error: %1").arg(error));
 }
 
+QString Config::sslProtocol() const
+{
+    return m_sslProtocol;
+}
+
+void Config::setSslProtocol(const QString& sslProtocolName)
+{
+    m_sslProtocol = sslProtocolName;
+}

--- a/src/config.h
+++ b/src/config.h
@@ -57,6 +57,7 @@ class Config: QObject
     Q_PROPERTY(bool printDebugMessages READ printDebugMessages WRITE setPrintDebugMessages)
     Q_PROPERTY(bool javascriptCanOpenWindows READ javascriptCanOpenWindows WRITE setJavascriptCanOpenWindows)
     Q_PROPERTY(bool javascriptCanCloseWindows READ javascriptCanCloseWindows WRITE setJavascriptCanCloseWindows)
+    Q_PROPERTY(QString sslProtocol READ sslProtocol WRITE setSslProtocol)
 
 public:
     Config(QObject *parent = 0);
@@ -148,6 +149,9 @@ public:
     void setJavascriptCanCloseWindows(const bool value);
     bool javascriptCanCloseWindows() const;
 
+    void setSslProtocol(const QString& sslProtocolName);
+    QString sslProtocol() const;
+
 public slots:
     void handleSwitch(const QString &sw);
     void handleOption(const QString &option, const QVariant &value);
@@ -191,6 +195,7 @@ private:
     bool m_printDebugMessages;
     bool m_javascriptCanOpenWindows;
     bool m_javascriptCanCloseWindows;
+    QString m_sslProtocol;
 };
 
 #endif // CONFIG_H

--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -87,12 +87,16 @@ NetworkAccessManager::NetworkAccessManager(QObject *parent, const Config *config
 
     if (QSslSocket::supportsSsl()) {
         m_sslConfiguration = QSslConfiguration::defaultConfiguration();
-        if (config->sslProtocol() == "sslv3") {
-            m_sslConfiguration.setProtocol(QSsl::SslV3);
-        } else if (config->sslProtocol() == "sslv2") {
+
+        // set the SSL protocol to SSLv3 by the default
+        m_sslConfiguration.setProtocol(QSsl::SslV3);
+
+        if (config->sslProtocol() == "sslv2") {
             m_sslConfiguration.setProtocol(QSsl::SslV2);
         } else if (config->sslProtocol() == "tlsv1") {
             m_sslConfiguration.setProtocol(QSsl::TlsV1);
+        } else if (config->sslProtocol() == "any") {
+            m_sslConfiguration.setProtocol(QSsl::AnyProtocol);
         }
     }
 
@@ -260,7 +264,7 @@ void NetworkAccessManager::handleSslErrors(const QList<QSslError> &errors)
 {
     QNetworkReply *reply = qobject_cast<QNetworkReply*>(sender());
     foreach (QSslError e, errors) {
-        qDebug()<<"Network - SSL Error:" << e;
+        qDebug() << "Network - SSL Error:" << e;
     }
 
     if (m_ignoreSslErrors)

--- a/src/networkaccessmanager.h
+++ b/src/networkaccessmanager.h
@@ -36,9 +36,11 @@
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QSet>
+#include <QSslConfiguration>
 
 class Config;
 class QNetworkDiskCache;
+class QSslConfiguration;
 
 class NetworkAccessManager : public QNetworkAccessManager
 {
@@ -66,6 +68,7 @@ private slots:
     void handleStarted();
     void handleFinished(QNetworkReply *reply);
     void provideAuthentication(QNetworkReply *reply, QAuthenticator *authenticator);
+    void handleSslErrors(const QList<QSslError> &errors);
 
 private:
     QHash<QNetworkReply*, int> m_ids;
@@ -73,6 +76,7 @@ private:
     int m_idCounter;
     QNetworkDiskCache* m_networkDiskCache;
     QVariantMap m_customHeaders;
+    QSslConfiguration m_sslConfiguration;
 };
 
 #endif // NETWORKACCESSMANAGER_H


### PR DESCRIPTION
Allow user to specify the SSL protocol through command line option.
### General:

Some servers are accepting connection using one SSL protocol only (TLSv1 or SSL). This causing to unable to connect to these servers.
### Solution:

New command line option `--ssl-protocol` Using that option user can specify one of the SSL protocol to use: `SSLv3` (default), `SSLv2`, `TLSv1`, `any`.
### More info:

https://groups.google.com/forum/?fromgroups#!topic/phantomjs/QgwweHYv4HU
### Issues:

http://code.google.com/p/phantomjs/issues/detail?id=174

**Partially reviewed by Ivan De Marino (https://github.com/detro)**
