### PR TITLE
Fixing sending of double-click events

### DIFF
--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -1073,7 +1073,7 @@ void WebPage::sendEvent(const QString &type, const QVariant &arg1, const QVarian
     if (eventType == "mousedown" ||
             eventType == "mouseup" ||
             eventType == "mousemove" ||
-            eventType == "doubleclick") {
+            eventType == "mousedoubleclick") {
         QMouseEvent::Type mouseEventType = QEvent::None;
 
         // Which mouse button (if it's a click)
@@ -1092,7 +1092,7 @@ void WebPage::sendEvent(const QString &type, const QVariant &arg1, const QVarian
             mouseEventType = QEvent::MouseButtonPress;
         } else if (eventType == "mouseup") {
             mouseEventType = QEvent::MouseButtonRelease;
-        } else if (eventType == "doubleclick") {
+        } else if (eventType == "mousedoubleclick") {
             mouseEventType = QEvent::MouseButtonDblClick;
         } else if (eventType == "mousemove") {
             mouseEventType = QEvent::MouseMove;
@@ -1119,9 +1119,16 @@ void WebPage::sendEvent(const QString &type, const QVariant &arg1, const QVarian
 
     // mouse click events: Qt doesn't provide this as a separate events,
     // so we compose it with a mousedown/mouseup sequence
-    if (type == "click") {
+    // mouse doubleclick events: It is not enough to simply send a
+    // MouseButtonDblClick event by itself; it must be accompanied
+    // by a preceding press-release, and a following release.
+    if (type == "click" || type == "doubleclick") {
         sendEvent("mousedown", arg1, arg2, mouseButton);
         sendEvent("mouseup", arg1, arg2, mouseButton);
+        if (type == "doubleclick") {
+            sendEvent("mousedoubleclick", arg1, arg2, mouseButton);
+            sendEvent("mouseup", arg1, arg2, mouseButton);
+        }
         return;
     }
 }

--- a/test/webpage-spec.js
+++ b/test/webpage-spec.js
@@ -313,8 +313,6 @@ describe("WebPage object", function() {
             page.sendEvent('mousedown', 42, 217);
         });
 
-        waits(50);
-
         runs(function() {
             var event = page.evaluate(function() {
                 return window.loggedEvent.mousedown;
@@ -397,6 +395,26 @@ describe("WebPage object", function() {
         });
     });
 
+    it("should handle doubleclick event", function () {
+        runs(function () {
+            page.content = '<input id="doubleClickField" type="text" onclick="document.getElementById(\'doubleClickField\').value=\'clicked\';" ondblclick="document.getElementById(\'doubleClickField\').value=\'doubleclicked\';" oncontextmenu="document.getElementById(\'doubleClickField\').value=\'rightclicked\'; return false;" value="hello"/>';
+            var point = page.evaluate(function () {
+                var el = document.querySelector('input');
+                var rect = el.getBoundingClientRect();
+                return { x: rect.left + Math.floor(rect.width / 2), y: rect.top + (rect.height / 2) };
+            });
+            page.sendEvent('doubleclick', point.x, point.y);
+        });
+
+        waits(50);
+
+        runs(function () {
+            var text = page.evaluate(function () {
+                return document.querySelector('input').value;
+            });
+            expect(text).toEqual("doubleclicked");
+        });
+    });
 
     it("should handle file uploads", function() {
         runs(function() {


### PR DESCRIPTION
Using sendEvent() for sending a double-click event to a page does not result in a double-click. Sending the QEvent::MouseButtonDblClick event by itself is insufficient for simulating a double-click. Rather, it must be preceded by a mousedown/mouseup and followed by another mouseup.

This pull request fixes issue #848 (http://code.google.com/p/phantomjs/issues/detail?id=848)
