### PR TITLE
Correcting keycodes sent for lowercase characters

### DIFF
--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -1035,12 +1035,12 @@ void WebPage::sendEvent(const QString &type, const QVariant &arg1, const QVarian
         if (arg1.type() == QVariant::Char) {
             // a single char was given
             text = arg1.toChar();
-            key = text.at(0).unicode();
+            key = text.at(0).toUpper().unicode();
         } else if (arg1.type() == QVariant::String) {
             // javascript invokation of a single char
             text = arg1.toString();
             if (!text.isEmpty()) {
-                key = text.at(0).unicode();
+                key = text.at(0).toUpper().unicode();
             }
         } else {
             // assume a raw integer char code was given

--- a/test/webpage-spec.js
+++ b/test/webpage-spec.js
@@ -288,6 +288,29 @@ describe("WebPage object", function() {
         });
     });
 
+    it("should send proper key codes for text", function () {
+        runs(function() {
+            page.content = '<input type="text">';
+            page.evaluate(function() {
+                document.querySelector('input').focus();
+            });
+            page.sendEvent('keypress', "ABCD");
+            // 0x02000000 is the Shift modifier.
+            page.sendEvent('keypress', page.event.key.Home, null, null,  0x02000000);
+            // 0x04000000 is the Control modifier.
+            page.sendEvent('keypress', 'x', null, null, 0x04000000);
+            var text = page.evaluate(function() {
+                return document.querySelector('input').value;
+            });
+            expect(text).toEqual("");
+            page.sendEvent('keypress', 'v', null, null, 0x04000000);
+            text = page.evaluate(function() {
+                return document.querySelector('input').value;
+            });
+            expect(text).toEqual("ABCD");
+        });
+    });
+
     it("should handle keypress event of umlaut char with inputs", function() {
         runs(function() {
             page.content = '<input type="text">';


### PR DESCRIPTION
The current implementation of `WebPage::sendEvent` for keystrokes sends the Unicode value of the character. For uppercase characters, this matches to the value of the character in the `Qt::Key` enum; for lowercase characters, it does not. Thus, items like sending Control-x for cut or Control-v for paste do not work, as the keycodes are not what are expected.

The correct fix is to send the value of the uppercase character for the keycode, retaining the lowercase character in the "text" argument of the `QKeyEvent` constructor so that the proper actual character gets sent.

This pull request fixes issue #852 (http://code.google.com/p/phantomjs/issues/detail?id=852).
