### PR TITLE
Exposing the Process ID (PID) via the System module.

### DIFF
--- a/src/system.cpp
+++ b/src/system.cpp
@@ -2,6 +2,7 @@
   This file is part of the PhantomJS project from Ofi Labs.
 
   Copyright (C) 2012 execjosh, http://execjosh.blogspot.com
+  Copyright (C) 2012 James M. Greene <james.m.greene@gmail.com>
 
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
@@ -29,6 +30,7 @@
 
 #include "system.h"
 
+#include <QApplication>
 #include <QSslSocket>
 #include <QSysInfo>
 #include <QVariantMap>
@@ -120,6 +122,11 @@ System::System(QObject *parent) :
 #endif
 }
 
+qint64 System::pid() const
+{
+    return QApplication::applicationPid();
+}
+
 void System::setArgs(const QStringList &args)
 {
     m_args = args;
@@ -147,6 +154,7 @@ bool System::isSSLSupported() const
 
 void System::initCompletions()
 {
+    addCompletion("pid");
     addCompletion("args");
     addCompletion("env");
     addCompletion("platform");

--- a/src/system.h
+++ b/src/system.h
@@ -2,6 +2,7 @@
   This file is part of the PhantomJS project from Ofi Labs.
 
   Copyright (C) 2012 execjosh, http://execjosh.blogspot.com
+  Copyright (C) 2012 James M. Greene <james.m.greene@gmail.com>
 
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
@@ -42,6 +43,7 @@
 class System : public REPLCompletable
 {
     Q_OBJECT
+    Q_PROPERTY(qint64 pid READ pid)
     Q_PROPERTY(QStringList args READ args)
     Q_PROPERTY(QVariant env READ env)
     Q_PROPERTY(QVariant os READ os)
@@ -49,6 +51,8 @@ class System : public REPLCompletable
 
 public:
     explicit System(QObject *parent = 0);
+
+    qint64 pid() const;
 
     void setArgs(const QStringList& args);
     QStringList args() const;

--- a/test/system-spec.js
+++ b/test/system-spec.js
@@ -6,6 +6,22 @@ describe("System object", function() {
         expect(system).toNotEqual(null);
     });
 
+    it("should have pid property", function() {
+        expect(system.hasOwnProperty('pid')).toBeTruthy();
+    });
+
+    it("should have pid as a number", function() {
+        expect(typeof system.pid).toEqual('number');
+    });
+
+    it("should have pid that is an integer", function() {
+        expect(system.pid).toMatch(/^\d+$/);
+    });
+
+    it("should have pid greater than 0", function() {
+        expect(system.pid).toBeGreaterThan(0);
+    });
+
     it("should have platform as string", function() {
         expect(typeof system.platform).toEqual('string');
     });


### PR DESCRIPTION
`require('system').pid` should return your PhantomJS instance's Process ID.

http://code.google.com/p/phantomjs/issues/detail?id=769
