### PR TITLE
[WebKit] Restore dirty line logic in RenderInline::destroy.

### DIFF
--- a/src/qt/src/3rdparty/webkit/Source/WebCore/rendering/RenderInline.cpp
+++ b/src/qt/src/3rdparty/webkit/Source/WebCore/rendering/RenderInline.cpp
@@ -99,7 +99,8 @@ void RenderInline::destroy()
                 for (InlineFlowBox* box = firstLineBox(); box; box = box->nextLineBox())
                     box->remove();
             }
-        }
+        } else if (parent())
+            parent()->dirtyLinesFromChangedChild(this);
     }
 
     m_lineBoxes.deleteLineBoxes(renderArena());

--- a/test/webkit-spec.js
+++ b/test/webkit-spec.js
@@ -8,4 +8,10 @@ describe("WebKit", function() {
     var date = Date.parse("2012-01-01");
     expect(date).toEqual(1325376000000);
   });
+  
+  it("should not crash when failing to dirty lines while removing a inline.", function () {
+    var p = require("webpage").create();
+    p.open('../test/webkit-spec/inline-destroy-dirty-lines-crash.html');
+    waits(50);
+  });
 });

--- a/test/webkit-spec/inline-destroy-dirty-lines-crash.html
+++ b/test/webkit-spec/inline-destroy-dirty-lines-crash.html
@@ -1,0 +1,15 @@
+<html>
+<body onload="runTest()">
+Test passes if it does not crash.
+<script>
+    function runTest()
+    {
+        document.body.offsetTop;
+        child = document.getElementById('test');
+        child.parentNode.removeChild(child);
+    }
+</script>
+<br>
+<span id="test"></span>
+</body>
+</html>


### PR DESCRIPTION
PhantomJS crashes on loading some URLs.

**Reason**
WebCore crashes on removing a inline element on the page

WebKit upsteam bug: https://bugs.webkit.org/show_bug.cgi?id=60448
Related WebKit changeset: http://trac.webkit.org/changeset/86060

Main issue:
http://code.google.com/p/phantomjs/issues/detail?id=871

Issue:
http://code.google.com/p/phantomjs/issues/detail?id=704
http://code.google.com/p/phantomjs/issues/detail?id=703
http://code.google.com/p/phantomjs/issues/detail?id=675
http://code.google.com/p/phantomjs/issues/detail?id=689
http://code.google.com/p/phantomjs/issues/detail?id=532
http://code.google.com/p/phantomjs/issues/detail?id=851
