### PR TITLE
Improve Table Printing

### DIFF
--- a/src/qt/src/3rdparty/webkit/Source/WebCore/rendering/RenderBlockLineLayout.cpp
+++ b/src/qt/src/3rdparty/webkit/Source/WebCore/rendering/RenderBlockLineLayout.cpp
@@ -956,7 +956,8 @@ void RenderBlock::layoutRunsAndFloats(bool fullLayout, bool hasInlineChild, Vect
                     repaintLogicalBottom = max(repaintLogicalBottom, lineBox->logicalBottomVisualOverflow());
                 }
 
-                if (paginated) {
+                // table cell pagination is handled in RenderTableSection
+                if (paginated && !isTableCell()) {
                     int adjustment = 0;
                     adjustLinePositionForPagination(lineBox, adjustment);
                     if (adjustment) {

--- a/src/qt/src/3rdparty/webkit/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/src/qt/src/3rdparty/webkit/Source/WebCore/rendering/RenderTableSection.cpp
@@ -414,7 +414,7 @@ void RenderTableSection::layout()
     setNeedsLayout(false);
 }
 
-int RenderTableSection::layoutRows(int toAdd)
+int RenderTableSection::layoutRows(int toAdd, int headHeight, int footHeight)
 {
 #ifndef NDEBUG
     setNeedsLayoutIsForbidden(true);
@@ -506,13 +506,13 @@ int RenderTableSection::layoutRows(int toAdd)
             logicalHeightsForPrinting[r] = childLogicalHeight;
             LayoutState* layoutState = view()->layoutState();
             const int pageLogicalHeight = layoutState->m_pageLogicalHeight;
-            if (childLogicalHeight < pageLogicalHeight) {
+            if (childLogicalHeight < pageLogicalHeight - footHeight) {
                 const IntSize delta = layoutState->m_layoutOffset - layoutState->m_pageOffset;
                 const int logicalOffset = m_rowPos[r] + pageOffset;
                 const int offset = isHorizontalWritingMode() ? delta.height() : delta.width();
                 const int remainingLogicalHeight = (pageLogicalHeight - (offset + logicalOffset) % pageLogicalHeight) % pageLogicalHeight;
-                if (remainingLogicalHeight < childLogicalHeight) {
-                    pageOffset += remainingLogicalHeight;
+                if (remainingLogicalHeight - footHeight < childLogicalHeight) {
+                    pageOffset += remainingLogicalHeight + headHeight;
                 }
             }
             m_rowPos[r] += pageOffset;

--- a/src/qt/src/3rdparty/webkit/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/src/qt/src/3rdparty/webkit/Source/WebCore/rendering/RenderTableSection.cpp
@@ -496,12 +496,40 @@ int RenderTableSection::layoutRows(int toAdd)
 
     LayoutStateMaintainer statePusher(view(), this, IntSize(x(), y()), style()->isFlippedBlocksWritingMode());
 
+    WTF::Vector<int> logicalHeightsForPrinting;
+    // make sure that rows do not overlap a page break
+    if (view()->layoutState()->pageLogicalHeight()) {
+        logicalHeightsForPrinting.resize(totalRows);
+        int pageOffset = 0;
+        for(int r = 0; r < totalRows; ++r) {
+            const int childLogicalHeight = m_rowPos[r + 1] - m_rowPos[r] - (m_grid[r].rowRenderer ? vspacing : 0);
+            logicalHeightsForPrinting[r] = childLogicalHeight;
+            LayoutState* layoutState = view()->layoutState();
+            const int pageLogicalHeight = layoutState->m_pageLogicalHeight;
+            if (childLogicalHeight < pageLogicalHeight) {
+                const IntSize delta = layoutState->m_layoutOffset - layoutState->m_pageOffset;
+                const int logicalOffset = m_rowPos[r] + pageOffset;
+                const int offset = isHorizontalWritingMode() ? delta.height() : delta.width();
+                const int remainingLogicalHeight = (pageLogicalHeight - (offset + logicalOffset) % pageLogicalHeight) % pageLogicalHeight;
+                if (remainingLogicalHeight < childLogicalHeight) {
+                    pageOffset += remainingLogicalHeight;
+                }
+            }
+            m_rowPos[r] += pageOffset;
+        }
+        m_rowPos[totalRows] += pageOffset;
+    }
+
     for (int r = 0; r < totalRows; r++) {
         // Set the row's x/y position and width/height.
         if (RenderTableRow* rowRenderer = m_grid[r].rowRenderer) {
             rowRenderer->setLocation(0, m_rowPos[r]);
             rowRenderer->setLogicalWidth(logicalWidth());
-            rowRenderer->setLogicalHeight(m_rowPos[r + 1] - m_rowPos[r] - vspacing);
+            if (view()->layoutState()->pageLogicalHeight()) {
+                rowRenderer->setLogicalHeight(logicalHeightsForPrinting[r]);
+            } else {
+                rowRenderer->setLogicalHeight(m_rowPos[r + 1] - m_rowPos[r] - vspacing);
+            }
             rowRenderer->updateLayerTransform();
         }
 
@@ -513,7 +541,11 @@ int RenderTableSection::layoutRows(int toAdd)
                 continue;
 
             rindx = cell->row();
-            rHeight = m_rowPos[rindx + cell->rowSpan()] - m_rowPos[rindx] - vspacing;
+            if (view()->layoutState()->pageLogicalHeight() && cell->rowSpan() == 1) {
+                rHeight = logicalHeightsForPrinting[rindx];
+            } else {
+                rHeight = m_rowPos[rindx + cell->rowSpan()] - m_rowPos[rindx] - vspacing;
+            }
             
             // Force percent height children to lay themselves out again.
             // This will cause these children to grow to fill the cell.

--- a/src/qt/src/3rdparty/webkit/Source/WebCore/rendering/RenderTableSection.h
+++ b/src/qt/src/3rdparty/webkit/Source/WebCore/rendering/RenderTableSection.h
@@ -49,7 +49,7 @@ public:
 
     void setCellLogicalWidths();
     int calcRowLogicalHeight();
-    int layoutRows(int logicalHeight);
+    int layoutRows(int logicalHeight, int headHeight, int footHeight);
 
     RenderTable* table() const { return toRenderTable(parent()); }
 


### PR DESCRIPTION
Reapply the two table-printing related patches of https://github.com/ariya/phantomjs/pull/211 which apparently got lost when the Qt source tree was imported.

This solves the following two issues:

http://code.google.com/p/phantomjs/issues/detail?id=880
http://code.google.com/p/phantomjs/issues/detail?id=615

Example html page:

https://userpage.physik.fu-berlin.de/~milianw/phantomjs/printing/longtable.html

Example PDF output without patches:
https://userpage.physik.fu-berlin.de/~milianw/phantomjs/printing/longtable_vanilla.pdf

Example PDF output with both patches:
https://userpage.physik.fu-berlin.de/~milianw/phantomjs/printing/longtable_patched.pdf

Note: PDF output was created using the following command:

```
phantomjs examples/rasterize.js \
http://userpage.physik.fu-berlin.de/~milianw/phantomjs/printing/longtable.html \
longtable_patched.pdf A4
```
