### PR TITLE
Don't perform on-demand loading of root certificates on Linux

### DIFF
--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -90,6 +90,11 @@ NetworkAccessManager::NetworkAccessManager(QObject *parent, const Config *config
     if (QSslSocket::supportsSsl()) {
         m_sslConfiguration = QSslConfiguration::defaultConfiguration();
 
+#if QT_VERSION >= QT_VERSION_CHECK(4,8,0) && defined(Q_OS_LINUX)
+        // Don't perform on-demand loading of root certificates on Linux
+        QSslSocket::addDefaultCaCertificates(QSslSocket::systemCaCertificates());
+#endif
+
         // set the SSL protocol to SSLv3 by the default
         m_sslConfiguration.setProtocol(QSsl::SslV3);
 

--- a/test/webpage-spec.js
+++ b/test/webpage-spec.js
@@ -941,6 +941,26 @@ describe("WebPage object", function() {
             expect(message).toEqual("PASS");
         });
     });
+    
+    it('should open url using secure connection', function() {
+        var page = require('webpage').create();
+        var url = 'https://en.wikipedia.org';
+      
+        var handled = false;
+      
+        runs(function() {
+            page.open(url, function(status) {
+                expect(status == 'success').toEqual(true);
+                handled = true;
+            });
+        });
+          
+        waits(3000);
+        
+        runs(function() {
+            expect(handled).toEqual(true);
+        });
+    });
 });
 
 describe("WebPage construction with options", function () {


### PR DESCRIPTION
**Description:**
Qt is performing loading on-demand of root certificates on Linux, which causing SSL errors.

**Read more:**
https://bugreports.qt-project.org/browse/QTBUG-14016
https://bugreports.qt-project.org/browse/QTBUG-7200

**Issue:**
http://code.google.com/p/phantomjs/issues/detail?id=882
