### PR TITLE
Properly use bottom margin to calculate the footer height.

### DIFF
--- a/src/qt/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebframe_printingaddons_p.h
+++ b/src/qt/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebframe_printingaddons_p.h
@@ -74,7 +74,7 @@ HeaderFooter::HeaderFooter(const QWebFrame* frame, QPrinter* printer, QWebFrame:
             // find existing margins
             printer->getPageMargins(&marginLeft, &marginTop, &marginRight, &marginBottom, QPrinter::DevicePixel);
             const qreal oldMarginTop = marginTop;
-            const qreal oldMarginBottom = marginTop;
+            const qreal oldMarginBottom = marginBottom;
 
             printer->getPageMargins(&marginLeft, &marginTop, &marginRight, &marginBottom, QPrinter::Point);
             // increase margins to hold header+footer


### PR DESCRIPTION
http://code.google.com/p/phantomjs/issues/detail?id=894

I think this is a no brainer, the stupid typo escaped me when I wrote this, and I only tested it with examples that used the same page margins for both, top and bottom edges.
