### PR TITLE
Closes detectsniff example when a page could not be opened 

### DIFF
--- a/examples/detectsniff.coffee
+++ b/examples/detectsniff.coffee
@@ -28,6 +28,7 @@ else
   page.open address, (status) ->
     if status isnt 'success'
       console.log 'FAIL to load the address'
+      phantom.exit()
     else
       window.setTimeout ->
         sniffed = page.evaluate(->

--- a/examples/detectsniff.js
+++ b/examples/detectsniff.js
@@ -41,6 +41,7 @@ if (system.args.length === 1) {
     page.open(address, function (status) {
         if (status !== 'success') {
             console.log('FAIL to load the address');
+            phantom.exit();
         } else {
             window.setTimeout(function () {
                 sniffed = page.evaluate(function () {


### PR DESCRIPTION
when the status of the request failed, the script still running instead of closing.
