### PR TITLE
Removed an invalid spec file and an invalid spec include.

### DIFF
--- a/test/process_spec.js
+++ b/test/process_spec.js
@@ -1,7 +1,0 @@
-describe("process", function() {
-  it("has argv containing script name and arguments", function() {
-    process.argv[0].should.equal('nodify');
-    process.argv[1].should.match(/.*\/support\/mocha.js$/);
-    process.argv[2].should.equal('dummy_arg');
-  });
-});

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -62,7 +62,6 @@ fs.changeWorkingDirectory(phantom.libraryPath);
 
 // Load specs
 phantom.injectJs("./phantom-spec.js");
-phantom.injectJs("./module-spec.js");
 phantom.injectJs("./webpage-spec.js");
 phantom.injectJs("./webserver-spec.js");
 phantom.injectJs("./fs-spec-01.js"); //< Filesystem Specs 01 (Basic)


### PR DESCRIPTION
There were invalid specs that should be removed:
1. "test/process_spec.js" is a spec for an object that does not exist (`process`) AND the spec is not being run within "run-tests.js".
2. Within "run-tests.js", there is a line to `injectJs` on "test/module-spec.js" (a non-existent file) as well as a `require` for "test/module_spec.js" (an existent file). The former should be removed.

Fixes http://code.google.com/p/phantomjs/issues/detail?id=906
