### PR TITLE
Adding 'WebPage#close' calls where appropriate in example scripts.

### DIFF
--- a/examples/follow.coffee
+++ b/examples/follow.coffee
@@ -1,11 +1,12 @@
 # List following and followers from several accounts
 
-users= [
+users = [
   'ariyahidayat'
   'detronizator'
   'KDABQt'
   'lfranchi'
   'jonleighton'
+  '_jamesgreene'
   ]
 
 follow = (user, callback) ->
@@ -16,6 +17,7 @@ follow = (user, callback) ->
     else
       data = page.evaluate -> document.querySelector('div.profile td.stat.stat-last div.statnum').innerText;
       console.log user + ': ' + data
+    page.close()
     callback.apply()
 
 process = () ->

--- a/examples/follow.js
+++ b/examples/follow.js
@@ -4,7 +4,8 @@ var users = ['ariyahidayat',
         'detronizator',
         'KDABQt',
         'lfranchi',
-        'jonleighton'];
+        'jonleighton',
+        '_jamesgreene'];
 
 function follow(user, callback) {
     var page = require('webpage').create();
@@ -17,6 +18,7 @@ function follow(user, callback) {
             });
             console.log(user + ': ' + data);
         }
+        page.close();
         callback.apply();
     });
 }

--- a/examples/render_multi_url.coffee
+++ b/examples/render_multi_url.coffee
@@ -23,7 +23,7 @@ renderUrlToFile = (url, file, callback) ->
        else
            page.render file
 
-       delete page
+       page.close()
        callback url, file
 
 # Read the passed args

--- a/examples/render_multi_url.js
+++ b/examples/render_multi_url.js
@@ -28,7 +28,7 @@ function renderUrlToFile(url, file, callback) {
        } else {
            page.render(file);
        }
-       delete page;
+       page.close();
        callback(url, file);
     });
 }


### PR DESCRIPTION
Adding 'WebPage#close' calls where appropriate in example scripts.

Fixes http://code.google.com/p/phantomjs/issues/detail?id=903
