### PR TITLE
Increase maximum number of redirections

### DIFF
--- a/src/qt/src/3rdparty/webkit/Source/WebCore/platform/network/qt/QNetworkReplyHandler.cpp
+++ b/src/qt/src/3rdparty/webkit/Source/WebCore/platform/network/qt/QNetworkReplyHandler.cpp
@@ -45,7 +45,7 @@
 // for now, use this hackish solution for setting the internal attribute.
 const QNetworkRequest::Attribute gSynchronousNetworkRequestAttribute = static_cast<QNetworkRequest::Attribute>(QNetworkRequest::HttpPipeliningWasUsedAttribute + 7);
 
-static const int gMaxRedirections = 10;
+static const int gMaxRedirections = 20;
 
 namespace WebCore {
 

--- a/src/qt/src/3rdparty/webkit/Source/WebCore/platform/network/qt/QNetworkReplyHandler.cpp
+++ b/src/qt/src/3rdparty/webkit/Source/WebCore/platform/network/qt/QNetworkReplyHandler.cpp
@@ -45,7 +45,7 @@
 // for now, use this hackish solution for setting the internal attribute.
 const QNetworkRequest::Attribute gSynchronousNetworkRequestAttribute = static_cast<QNetworkRequest::Attribute>(QNetworkRequest::HttpPipeliningWasUsedAttribute + 7);
 
-static const int gMaxRedirections = 20; 
+static const int gMaxRedirections = 20;
 
 namespace WebCore {
 

--- a/src/qt/src/3rdparty/webkit/Source/WebCore/platform/network/qt/QNetworkReplyHandler.cpp
+++ b/src/qt/src/3rdparty/webkit/Source/WebCore/platform/network/qt/QNetworkReplyHandler.cpp
@@ -45,7 +45,7 @@
 // for now, use this hackish solution for setting the internal attribute.
 const QNetworkRequest::Attribute gSynchronousNetworkRequestAttribute = static_cast<QNetworkRequest::Attribute>(QNetworkRequest::HttpPipeliningWasUsedAttribute + 7);
 
-static const int gMaxRedirections = 20;
+static const int gMaxRedirections = 20; 
 
 namespace WebCore {
 


### PR DESCRIPTION
Modern browsers permit up to 20 redirections, this pull request brings Phantom JS in line with that limit. 

The is the 'smallest change that could possible work', there s a issue open to make this configurable here http://code.google.com/p/phantomjs/issues/detail?id=849 if this is preferable feel free to reject.
