### PR TITLE
Exit when unable to load the address in examples/rasterize.js 

### DIFF
--- a/examples/rasterize.js
+++ b/examples/rasterize.js
@@ -21,6 +21,7 @@ if (system.args.length < 3 || system.args.length > 5) {
     page.open(address, function (status) {
         if (status !== 'success') {
             console.log('Unable to load the address!');
+            phantom.exit();
         } else {
             window.setTimeout(function () {
                 page.render(output);


### PR DESCRIPTION
Missing the phatom.exit() in case when the address cannot be loaded.
