### PR TITLE
Enable WOFF file support

### DIFF
--- a/src/qt/preconfig.cmd
+++ b/src/qt/preconfig.cmd
@@ -18,6 +18,7 @@ set QT_CFG=%QT_CFG% -no-declarative
 set QT_CFG=%QT_CFG% -no-script
 set QT_CFG=%QT_CFG% -no-multimedia
 
+set QT_CFG=%QT_CFG% -qt-zlib
 set QT_CFG=%QT_CFG% -qt-libpng
 set QT_CFG=%QT_CFG% -qt-libjpeg
 set QT_CFG=%QT_CFG% -no-libmng

--- a/src/qt/src/3rdparty/webkit/Source/WebCore/WebCore.pri
+++ b/src/qt/src/3rdparty/webkit/Source/WebCore/WebCore.pri
@@ -170,6 +170,10 @@ contains(DEFINES, ENABLE_XSLT=1) {
     QT *= xmlpatterns
 }
 
+contains(DEFINES, ENABLE_ZLIB=1) {
+    include($$QT_SOURCE_TREE/src/3rdparty/zlib_dependency.pri)
+}
+
 contains(DEFINES, ENABLE_SQLITE=1) {
     !system-sqlite:exists( $${SQLITE3SRCDIR}/sqlite3.c ) {
             INCLUDEPATH += $${SQLITE3SRCDIR}

--- a/src/qt/src/3rdparty/webkit/Source/WebCore/WebCore.pro
+++ b/src/qt/src/3rdparty/webkit/Source/WebCore/WebCore.pro
@@ -988,6 +988,7 @@ SOURCES += \
     platform/graphics/PathTraversalState.cpp \
     platform/graphics/Pattern.cpp \
     platform/graphics/RoundedIntRect.cpp \
+    platform/graphics/WOFFFileFormat.cpp \
     platform/graphics/SegmentedFontData.cpp \
     platform/graphics/ShadowBlur.cpp \
     platform/graphics/SVGGlyph.cpp \
@@ -1958,6 +1959,7 @@ HEADERS += \
     platform/graphics/PathTraversalState.h \
     platform/graphics/Pattern.h \
     platform/graphics/RoundedIntRect.h \
+    platform/graphics/WOFFFileFormat.h \
     platform/graphics/qt/FontCustomPlatformData.h \
     platform/graphics/qt/ImageDecoderQt.h \
     platform/graphics/qt/StillImageQt.h \

--- a/src/qt/src/3rdparty/webkit/Source/WebCore/features.pri
+++ b/src/qt/src/3rdparty/webkit/Source/WebCore/features.pri
@@ -45,6 +45,8 @@ contains(DEFINES, ENABLE_SINGLE_THREADED=1) {
 !contains(DEFINES, ENABLE_DIRECTORY_UPLOAD=.): DEFINES += ENABLE_DIRECTORY_UPLOAD=0
 !contains(DEFINES, ENABLE_FILE_SYSTEM=.): DEFINES += ENABLE_FILE_SYSTEM=0
 !contains(DEFINES, ENABLE_QUOTA=.): DEFINES += ENABLE_QUOTA=0 
+# enable zlib support for WOFF fonts
+!contains(DEFINES, ENABLE_ZLIB=.): DEFINES += ENABLE_ZLIB=1 
 
 # turn on SQLITE support if any of the dependent features are turned on
 !contains(DEFINES, ENABLE_SQLITE=.) {

--- a/src/qt/src/3rdparty/webkit/Source/WebCore/platform/graphics/qt/FontCustomPlatformDataQt.cpp
+++ b/src/qt/src/3rdparty/webkit/Source/WebCore/platform/graphics/qt/FontCustomPlatformDataQt.cpp
@@ -24,6 +24,7 @@
 
 #include "FontPlatformData.h"
 #include "SharedBuffer.h"
+#include "WOFFFileFormat.h"
 #include <QFontDatabase>
 #include <QStringList>
 
@@ -50,6 +51,15 @@ FontCustomPlatformData* createFontCustomPlatformData(SharedBuffer* buffer)
 {
     ASSERT_ARG(buffer, buffer);
 
+    RefPtr<SharedBuffer> sfntBuffer;
+    if (isWOFF(buffer)) {
+        Vector<char> sfnt;
+        if (!convertWOFFToSfnt(buffer, sfnt))
+            return 0;
+        sfntBuffer = SharedBuffer::adoptVector(sfnt);
+        buffer = sfntBuffer.get();
+    }
+
     int id = QFontDatabase::addApplicationFontFromData(QByteArray(buffer->data(), buffer->size()));
     if (id == -1)
         return 0;
@@ -63,7 +73,7 @@ FontCustomPlatformData* createFontCustomPlatformData(SharedBuffer* buffer)
 
 bool FontCustomPlatformData::supportsFormat(const String& format)
 {
-    return equalIgnoringCase(format, "truetype") || equalIgnoringCase(format, "opentype");
+    return equalIgnoringCase(format, "truetype") || equalIgnoringCase(format, "opentype") || equalIgnoringCase(format, "woff");
 }
 
 }


### PR DESCRIPTION
**Background:**
WOFF format requires that WebKit should be compiled with zlib.

**Related issues:**
http://code.google.com/p/phantomjs/issues/detail?id=592
http://code.google.com/p/phantomjs/issues/detail?id=247
