### PR TITLE
Fix memory leak on linux

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,6 +40,7 @@
 #endif
 
 #include <QApplication>
+#include <QSslSocket>
 
 #ifdef Q_OS_WIN32
 using namespace google_breakpad;
@@ -101,6 +102,13 @@ int main(int argc, char** argv, const char** envp)
 
     // Registering an alternative Message Handler
     qInstallMsgHandler(Utils::messageHandler);
+
+#if defined(Q_OS_LINUX)
+    if (QSslSocket::supportsSsl()) {
+        // Don't perform on-demand loading of root certificates on Linux
+        QSslSocket::addDefaultCaCertificates(QSslSocket::systemCaCertificates());
+    }
+#endif
 
     // Get the Phantom singleton
     Phantom *phantom = Phantom::instance();

--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -90,11 +90,6 @@ NetworkAccessManager::NetworkAccessManager(QObject *parent, const Config *config
     if (QSslSocket::supportsSsl()) {
         m_sslConfiguration = QSslConfiguration::defaultConfiguration();
 
-#if QT_VERSION >= QT_VERSION_CHECK(4,8,0) && defined(Q_OS_LINUX)
-        // Don't perform on-demand loading of root certificates on Linux
-        QSslSocket::addDefaultCaCertificates(QSslSocket::systemCaCertificates());
-#endif
-
         // set the SSL protocol to SSLv3 by the default
         m_sslConfiguration.setProtocol(QSsl::SslV3);
 


### PR DESCRIPTION
We were previously adding the certificates on each instantiation of
NetworkAccessManager, causing memory consumption to grow unbounded.

I have also removed the Qt version check. It's unnecessary as we only
build against a fixed Qt version.

https://code.google.com/p/phantomjs/issues/detail?id=882
