### PR TITLE
issue 916: add $SSL_CERT_DIR to systemCaCertificates() if set

### DIFF
--- a/src/qt/src/network/ssl/qsslsocket_openssl.cpp
+++ b/src/qt/src/network/ssl/qsslsocket_openssl.cpp
@@ -929,6 +929,9 @@ QList<QSslCertificate> QSslSocketPrivate::systemCaCertificates()
     QStringList nameFilters;
     nameFilters << QLatin1String("*.pem") << QLatin1String("*.crt");
     currentDir.setNameFilters(nameFilters);
+    QByteArray envSslCertDir = qgetenv("SSL_CERT_DIR");
+    if(envSslCertDir != "")
+      directories << envSslCertDir;
     for (int a = 0; a < directories.count(); a++) {
         currentDir.setPath(QLatin1String(directories.at(a)));
         QDirIterator it(currentDir);


### PR DESCRIPTION
http://code.google.com/p/phantomjs/issues/detail?id=916

Add the directory in $SSL_CERT_DIR to the list of directories scanned for certificates in src/qt/src/network/ssl/qsslsocket_openssl.cpp systemCaCertificate()
