### PR TITLE
Implement system.std{in,out,err}

### DIFF
--- a/examples/stdin-stdout-stderr.coffee
+++ b/examples/stdin-stdout-stderr.coffee
@@ -1,0 +1,18 @@
+system = require 'system'
+
+system.stdout.write 'Hello, system.stdout.write!'
+system.stdout.writeLine '\nHello, system.stdout.writeLine!'
+
+system.stderr.write 'Hello, system.stderr.write!'
+system.stderr.writeLine '\nHello, system.stderr.writeLine!'
+
+system.stdout.writeLine 'system.stdin.readLine(): '
+line = system.stdin.readLine()
+system.stdout.writeLine JSON.stringify line
+
+# This is essentially a `readAll`
+system.stdout.writeLine 'system.stdin.read(): (ctrl+D to end)'
+input = system.stdin.read()
+system.stdout.writeLine JSON.stringify input
+
+phantom.exit 0

--- a/examples/stdin-stdout-stderr.coffee
+++ b/examples/stdin-stdout-stderr.coffee
@@ -11,8 +11,8 @@ line = system.stdin.readLine()
 system.stdout.writeLine JSON.stringify line
 
 # This is essentially a `readAll`
-system.stdout.writeLine 'system.stdin.read(): (ctrl+D to end)'
-input = system.stdin.read()
+system.stdout.writeLine 'system.stdin.read(5): (ctrl+D to end)'
+input = system.stdin.read 5
 system.stdout.writeLine JSON.stringify input
 
 phantom.exit 0

--- a/examples/stdin-stdout-stderr.js
+++ b/examples/stdin-stdout-stderr.js
@@ -1,0 +1,18 @@
+var system = require('system');
+
+system.stdout.write('Hello, system.stdout.write!');
+system.stdout.writeLine('\nHello, system.stdout.writeLine!');
+
+system.stderr.write('Hello, system.stderr.write!');
+system.stderr.writeLine('\nHello, system.stderr.writeLine!');
+
+system.stdout.writeLine('system.stdin.readLine(): ');
+var line = system.stdin.readLine();
+system.stdout.writeLine(JSON.stringify(line));
+
+// This is essentially a `readAll`
+system.stdout.writeLine('system.stdin.read(): (ctrl+D to end)');
+var input = system.stdin.read();
+system.stdout.writeLine(JSON.stringify(input));
+
+phantom.exit(0);

--- a/examples/stdin-stdout-stderr.js
+++ b/examples/stdin-stdout-stderr.js
@@ -11,8 +11,8 @@ var line = system.stdin.readLine();
 system.stdout.writeLine(JSON.stringify(line));
 
 // This is essentially a `readAll`
-system.stdout.writeLine('system.stdin.read(): (ctrl+D to end)');
-var input = system.stdin.read();
+system.stdout.writeLine('system.stdin.read(5): (ctrl+D to end)');
+var input = system.stdin.read(5);
 system.stdout.writeLine(JSON.stringify(input));
 
 phantom.exit(0);

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -59,8 +59,18 @@ File::~File()
 //      encounters \0 or similar
 
 // public slots:
-QString File::read()
+QString File::read(const QVariant &n)
 {
+    // Default to 1024 (used when n is "null")
+    qint64 bytesToRead = 1024;
+
+    // If parameter can be converted to a qint64, do so and use that value instead
+    if (n.canConvert(QVariant::LongLong)) {
+        bytesToRead = n.toLongLong();
+    }
+
+    const bool isReadAll = 0 > bytesToRead;
+
     if ( !m_file->isReadable() ) {
         qDebug() << "File::read - " << "Couldn't read:" << m_file->fileName();
         return QString();
@@ -71,17 +81,31 @@ QString File::read()
     }
     if ( m_fileStream ) {
         // text file
-        const qint64 pos = m_fileStream->pos();
-        m_fileStream->seek(0);
-        const QString ret = m_fileStream->readAll();
-        m_fileStream->seek(pos);
+        QString ret;
+        if (isReadAll) {
+            // This code, for some reason, reads the whole file from 0 to EOF,
+            // and then resets to the position the file was at prior to reading
+            const qint64 pos = m_fileStream->pos();
+            m_fileStream->seek(0);
+            ret = m_fileStream->readAll();
+            m_fileStream->seek(pos);
+        } else {
+            ret = m_fileStream->read(bytesToRead);
+        }
         return ret;
     } else {
         // binary file
-        const qint64 pos = m_file->pos();
-        m_file->seek(0);
-        const QByteArray data = m_file->readAll();
-        m_file->seek(pos);
+        QByteArray data;
+        if (isReadAll) {
+            // This code, for some reason, reads the whole file from 0 to EOF,
+            // and then resets to the position the file was at prior to reading
+            const qint64 pos = m_file->pos();
+            m_file->seek(0);
+            data = m_file->readAll();
+            m_file->seek(pos);
+        } else {
+            data = m_file->read(bytesToRead);
+        }
         QString ret(data.size());
         for(int i = 0; i < data.size(); ++i) {
             ret[i] = data.at(i);

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -110,6 +110,15 @@ bool File::write(const QString &data)
     }
 }
 
+bool File::seek(const qint64 pos)
+{
+    if (m_fileStream) {
+        return m_fileStream->seek(pos);
+    } else {
+        return m_file->seek(pos);
+    }
+}
+
 QString File::readLine()
 {
     if ( !m_file->isReadable() ) {

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -52,6 +52,8 @@ public slots:
     QString read();
     bool write(const QString &data);
 
+    bool seek(const qint64 pos);
+
     QString readLine();
     bool writeLine(const QString &data);
 

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -49,7 +49,12 @@ public:
     virtual ~File();
 
 public slots:
-    QString read();
+    /**
+     * @param n Number of bytes to read (a negative value means read up to EOF)
+     * NOTE: The use of QVariant here is necessary to catch JavaScript `null`.
+     * @see <a href="http://wiki.commonjs.org/wiki/IO/A#Instance_Methods">IO/A spec</a>
+     */
+    QString read(const QVariant &n = -1);
     bool write(const QString &data);
 
     bool seek(const qint64 pos);

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -39,6 +39,9 @@
 
 System::System(QObject *parent) :
     REPLCompletable(parent)
+  , m_stdout((File *)NULL)
+  , m_stderr((File *)NULL)
+  , m_stdin((File *)NULL)
 {
     // Populate "env"
     m_env = Env::instance()->asVariantMap();
@@ -122,6 +125,23 @@ System::System(QObject *parent) :
 #endif
 }
 
+System::~System()
+{
+    // Clean-up standard streams
+    if ((File *)NULL != m_stdout) {
+        delete m_stdout;
+        m_stdout = (File *)NULL;
+    }
+    if ((File *)NULL != m_stderr) {
+        delete m_stderr;
+        m_stderr = (File *)NULL;
+    }
+    if ((File *)NULL != m_stdin) {
+        delete m_stdin;
+        m_stdin = (File *)NULL;
+    }
+}
+
 qint64 System::pid() const
 {
     return QApplication::applicationPid();
@@ -152,6 +172,36 @@ bool System::isSSLSupported() const
     return QSslSocket::supportsSsl();
 }
 
+QObject *System::_stdout() {
+    if ((File *)NULL == m_stdout) {
+        QFile *f = new QFile();
+        f->open(stdout, QIODevice::WriteOnly | QIODevice::Unbuffered);
+        m_stdout = new File(f, (QTextCodec *)NULL, this);
+    }
+
+    return m_stdout;
+}
+
+QObject *System::_stderr() {
+    if ((File *)NULL == m_stderr) {
+        QFile *f = new QFile();
+        f->open(stderr, QIODevice::WriteOnly | QIODevice::Unbuffered);
+        m_stderr = new File(f, (QTextCodec *)NULL, this);
+    }
+
+    return m_stderr;
+}
+
+QObject *System::_stdin() {
+    if ((File *)NULL == m_stdin) {
+        QFile *f = new QFile();
+        f->open(stdin, QIODevice::ReadOnly | QIODevice::Unbuffered);
+        m_stdin = new File(f, (QTextCodec *)NULL, this);
+    }
+
+    return m_stdin;
+}
+
 void System::initCompletions()
 {
     addCompletion("pid");
@@ -160,4 +210,7 @@ void System::initCompletions()
     addCompletion("platform");
     addCompletion("os");
     addCompletion("isSSLSupported");
+    addCompletion("stdin");
+    addCompletion("stdout");
+    addCompletion("stderr");
 }

--- a/src/system.h
+++ b/src/system.h
@@ -36,6 +36,7 @@
 #include <QMap>
 #include <QVariant>
 
+#include "filesystem.h"
 #include "replcompletable.h"
 
 // This class implements the CommonJS System/1.0 spec.
@@ -48,9 +49,13 @@ class System : public REPLCompletable
     Q_PROPERTY(QVariant env READ env)
     Q_PROPERTY(QVariant os READ os)
     Q_PROPERTY(bool isSSLSupported READ isSSLSupported)
+    Q_PROPERTY(QObject *stdout READ _stdout)
+    Q_PROPERTY(QObject *stderr READ _stderr)
+    Q_PROPERTY(QObject *stdin READ _stdin)
 
 public:
     explicit System(QObject *parent = 0);
+    virtual ~System();
 
     qint64 pid() const;
 
@@ -63,11 +68,23 @@ public:
 
     bool isSSLSupported() const;
 
+    // system.stdout
+    QObject *_stdout();
+
+    // system.stderr
+    QObject *_stderr();
+
+    // system.stdin
+    QObject *_stdin();
+
 private:
     QStringList m_args;
     QVariant m_env;
     QMap<QString, QVariant> m_os;
     virtual void initCompletions();
+    File *m_stdout;
+    File *m_stderr;
+    File *m_stdin;
 };
 
 #endif // SYSTEM_H

--- a/test/fs-spec-01.js
+++ b/test/fs-spec-01.js
@@ -37,6 +37,17 @@ describe("Basic Files API (read, write, remove, ...)", function() {
         expect(content).toEqual("hello\nworld\n");
     });
 
+    it("should be able to read specific number of bytes from a specific position in a file", function() {
+        var content = "";
+        try{
+            var f = fs.open(FILENAME, "r");
+            f.seek(3);
+            content = f.read(5);
+            f.close();
+        } catch (e) { }
+        expect(content).toEqual("lo\nwo");
+    });
+
     it("should be able to read/write/append content from a file", function() {
         var content = "";
         try{

--- a/test/system-spec.js
+++ b/test/system-spec.js
@@ -54,4 +54,19 @@ describe("System object", function() {
         expect(typeof system.isSSLSupported).toEqual('boolean');
     });
 
+    it("should have stdout as object", function() {
+        expect(typeof system.stdout).toEqual('object');
+        expect(null == system.stdout).toBeFalsy();
+    });
+
+    it("should have stderr as object", function() {
+        expect(typeof system.stderr).toEqual('object');
+        expect(null == system.stderr).toBeFalsy();
+    });
+
+    it("should have stdin as object", function() {
+        expect(typeof system.stdin).toEqual('object');
+        expect(null == system.stdin).toBeFalsy();
+    });
+
 });


### PR DESCRIPTION
Implementing `system.std{in,out,err}` as per [issue 333](http://code.google.com/p/phantomjs/issues/detail?id=333) and pull request #192.

---

**UPDATE 1** (2012-12-18)

`read` has been implemented to [spec](http://wiki.commonjs.org/wiki/IO/A#Instance_Methods) and now takes an optional parameter `n`, which, when specified, should be a `Number` or `null`.

---

**UPDATE 2** (2012-12-20)

Refactored `read` code after code review from @detro.

---

**UPDATE 3** (2012-12-21)

Added REPL completions.

---

**UPDATE 4** (2012-12-25)
-  Reorganized commits
-  Rewrote commit messages
-  Added pointer clean-up logic in `System` module deconstructor
