### PR TITLE
Allow abort network requests

### DIFF
--- a/examples/loadurlwithoutcss.coffee
+++ b/examples/loadurlwithoutcss.coffee
@@ -1,0 +1,20 @@
+page = require("webpage").create()
+system = require("system")
+
+if system.args.length < 2
+  console.log "Usage: loadurlwithoutcss.js URL"
+  phantom.exit()
+
+address = system.args[1]
+
+page.onResourceRequested = (requestData, request) ->
+  if (/http:\/\/.+?\.css/g).test(requestData["url"]) or requestData["Content-Type"] is "text/css"
+    console.log "The url of the request is matching. Aborting: " + requestData["url"]
+    request.abort()
+
+page.open address, (status) ->
+  if status is "success"
+    phantom.exit()
+  else
+    console.log "Unable to load the address!"
+    phantom.exit()

--- a/examples/loadurlwithoutcss.js
+++ b/examples/loadurlwithoutcss.js
@@ -1,0 +1,25 @@
+var page = require('webpage').create(),
+    system = require('system');
+
+if (system.args.length < 2) {
+    console.log('Usage: loadurlwithoutcss.js URL');
+    phantom.exit();
+}
+
+var address = system.args[1];
+
+page.onResourceRequested = function(requestData, request) {
+    if ((/http:\/\/.+?\.css/gi).test(requestData['url']) || requestData['Content-Type'] == 'text/css') {
+        console.log('The url of the request is matching. Aborting: ' + requestData['url']);
+        request.abort();
+    }
+};
+
+page.open(address, function(status) {
+    if (status === 'success') {
+        phantom.exit();
+    } else {
+        console.log('Unable to load the address!');
+        phantom.exit();
+    }
+});

--- a/src/networkaccessmanager.h
+++ b/src/networkaccessmanager.h
@@ -42,6 +42,18 @@ class Config;
 class QNetworkDiskCache;
 class QSslConfiguration;
 
+class JsNetworkRequest : public QObject
+{
+    Q_OBJECT
+
+public:
+    JsNetworkRequest(QNetworkReply* reply);
+    Q_INVOKABLE void abort();
+
+private:
+    QNetworkReply* m_networkReply;
+};
+
 class NetworkAccessManager : public QNetworkAccessManager
 {
     Q_OBJECT
@@ -65,7 +77,7 @@ protected:
     void handleFinished(QNetworkReply *reply, const QVariant &status, const QVariant &statusText);
 
 signals:
-    void resourceRequested(const QVariant& data);
+    void resourceRequested(const QVariant& data, QObject *);
     void resourceReceived(const QVariant& data);
 
 private slots:

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -364,8 +364,8 @@ WebPage::WebPage(QObject *parent, const QUrl &baseUrl)
     // Custom network access manager to allow traffic monitoring.
     m_networkAccessManager = new NetworkAccessManager(this, phantomCfg);
     m_customWebPage->setNetworkAccessManager(m_networkAccessManager);
-    connect(m_networkAccessManager, SIGNAL(resourceRequested(QVariant)),
-            SIGNAL(resourceRequested(QVariant)));
+    connect(m_networkAccessManager, SIGNAL(resourceRequested(QVariant, QObject *)),
+            SIGNAL(resourceRequested(QVariant, QObject *)));
     connect(m_networkAccessManager, SIGNAL(resourceReceived(QVariant)),
             SIGNAL(resourceReceived(QVariant)));
 

--- a/src/webpage.h
+++ b/src/webpage.h
@@ -463,7 +463,7 @@ signals:
     void javaScriptAlertSent(const QString &msg);
     void javaScriptConsoleMessageSent(const QString &message);
     void javaScriptErrorSent(const QString &msg, const QString &stack);
-    void resourceRequested(const QVariant &req);
+    void resourceRequested(const QVariant &requestData, QObject *request);
     void resourceReceived(const QVariant &resource);
     void urlChanged(const QUrl &url);
     void navigationRequested(const QUrl &url, const QString &navigationType, bool navigationLocked, bool isMainFrame);

--- a/test/webpage-spec.js
+++ b/test/webpage-spec.js
@@ -1042,6 +1042,35 @@ describe("WebPage object", function() {
             expect(handled).toEqual(true);
         });
     });
+    
+    it('should able to abort a network request', function() {
+        var page = require('webpage').create();
+        var url = 'http://phantomjs.org';
+        var urlToBlock = 'http://phantomjs.org/images/phantomjs-logo.png';
+        
+        var handled = false;
+        
+        runs(function() {
+            page.onResourceRequested = function(requestData, request) {
+                if (requestData['url'] == urlToBlock) {
+                    expect(typeof request).toEqual('object');
+                    expect(typeof request.abort).toEqual('function');
+                    request.abort();
+                    handled = true;
+                }
+            };
+            
+            page.open(url, function(status) {
+                expect(status).toEqual('success');
+            });
+        });
+        
+        waits(3000);
+        
+        runs(function() {
+            expect(handled).toEqual(true);
+        });
+    });
 });
 
 describe("WebPage construction with options", function () {


### PR DESCRIPTION
Issue: http://code.google.com/p/phantomjs/issues/detail?id=230

This commit will introduce new argument in the `onResourceRequested` callback.
This new arg has type `JsNetworkRequest`. It has one public method - `abort`.
Using this arg user can abort the network request.

**Example:**

```
page.onResourceRequested(requestData, request) {
    // call request.abort(); to interrupt a network request
}
```
