### PR TITLE
-ldl is needed only on Linux, not on all Unices.

### DIFF
--- a/src/mongoose/mongoose.pri
+++ b/src/mongoose/mongoose.pri
@@ -3,5 +3,5 @@ INCLUDEPATH += $$PWD
 
 SOURCES += mongoose.c
 HEADERS += mongoose.h
-unix:LIBS += -ldl
+linux*:LIBS += -ldl
 win32:LIBS += -lWs2_32


### PR DESCRIPTION
In particular on FreeBSD there is no -ldl as the respective
functionality is in -lc.

http://code.google.com/p/phantomjs/issues/detail?id=597
