### PR TITLE
Updated help output to prefer true/false to yes/no

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -4,6 +4,7 @@
   Copyright (C) 2012 Ariya Hidayat <ariya.hidayat@gmail.com>
   Copyright (C) 2011 Ariya Hidayat <ariya.hidayat@gmail.com>
   Copyright (C) 2011 execjosh, http://execjosh.blogspot.com
+  Copyright (C) 2013 James M. Greene <james.m.greene@gmail.com>
 
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
@@ -46,22 +47,22 @@ static const struct QCommandLineConfigEntry flags[] =
 {
     { QCommandLine::Option, '\0', "cookies-file", "Sets the file name to store the persistent cookies", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "config", "Specifies JSON-formatted configuration file", QCommandLine::Optional },
-    { QCommandLine::Option, '\0', "debug", "Prints additional warning and debug message: 'yes' or 'no' (default)", QCommandLine::Optional },
-    { QCommandLine::Option, '\0', "disk-cache", "Enables disk cache: 'yes' (default) or 'no'", QCommandLine::Optional },
-    { QCommandLine::Option, '\0', "ignore-ssl-errors", "Ignores SSL errors (expired/self-signed certificate errors): 'yes' or 'no' (default)", QCommandLine::Optional },
-    { QCommandLine::Option, '\0', "load-images", "Loads all inlined images: 'yes' (default) or 'no'", QCommandLine::Optional },
+    { QCommandLine::Option, '\0', "debug", "Prints additional warning and debug message: 'true' or 'false' (default). Also accepted: 'yes' or 'no'", QCommandLine::Optional },
+    { QCommandLine::Option, '\0', "disk-cache", "Enables disk cache: 'true' or 'false' (default). Also accepted: 'yes' or 'no'", QCommandLine::Optional },
+    { QCommandLine::Option, '\0', "ignore-ssl-errors", "Ignores SSL errors (expired/self-signed certificate errors): 'true' or 'false' (default). Also accepted: 'yes' or 'no'", QCommandLine::Optional },
+    { QCommandLine::Option, '\0', "load-images", "Loads all inlined images: 'true' (default) or 'false'. Also accepted: 'yes' or 'no'", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "local-storage-path", "Specifies the location for offline local storage", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "local-storage-quota", "Sets the maximum size of the offline local storage (in KB)", QCommandLine::Optional },
-    { QCommandLine::Option, '\0', "local-to-remote-url-access", "Allows local content to access remote URL: 'yes' or 'no' (default)", QCommandLine::Optional },
+    { QCommandLine::Option, '\0', "local-to-remote-url-access", "Allows local content to access remote URL: 'true' or 'false' (default). Also accepted: 'yes' or 'no'", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "max-disk-cache-size", "Limits the size of the disk cache (in KB)", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "output-encoding", "Sets the encoding for the terminal output, default is 'utf8'", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "remote-debugger-port", "Starts the script in a debug harness and listens on the specified port", QCommandLine::Optional },
-    { QCommandLine::Option, '\0', "remote-debugger-autorun", "Runs the script in the debugger immediately: 'yes' or 'no' (default)", QCommandLine::Optional },
+    { QCommandLine::Option, '\0', "remote-debugger-autorun", "Runs the script in the debugger immediately: 'true' or 'false' (default). Also accepted: 'yes' or 'no'", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "proxy", "Sets the proxy server, e.g. '--proxy=http://proxy.company.com:8080'", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "proxy-auth", "Provides authentication information for the proxy, e.g. ''-proxy-auth=username:password'", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "proxy-type", "Specifies the proxy type, 'http' (default), 'none' (disable completely), or 'socks5'", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "script-encoding", "Sets the encoding used for the starting script, default is 'utf8'", QCommandLine::Optional },
-    { QCommandLine::Option, '\0', "web-security", "Enables web security, 'yes' (default) or 'no'", QCommandLine::Optional },
+    { QCommandLine::Option, '\0', "web-security", "Enables web security, 'true' (default) or 'false'. Also accepted: 'yes' or 'no'", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "ssl-protocol", "Sets the SSL protocol (supported protocols: 'SSLv3' (default), 'SSLv2', 'TLSv1', 'any')", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "webdriver", "Starts in 'Remote WebDriver mode' (embedded GhostDriver): '[[<IP>:]<PORT>]' (default '127.0.0.1:8910') ", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "webdriver-selenium-grid-hub", "URL to the Selenium Grid HUB: 'URL_TO_HUB' (default 'none') (NOTE: works only together with '--webdriver') ", QCommandLine::Optional },


### PR DESCRIPTION
Similarly, I updated the API Reference too:
https://github.com/ariya/phantomjs/wiki/API-Reference/7cddd19676a917535b74d386c3974da00fbbe793

This arguably makes more sense to PhantomJS's typical audience of web developers.

Discussed this with @detro earlier, too:

> **me:** Is using 'yes'/'no' on the command line that much more typical than 'true'/'false'?
> **Ivan:** typical?
> well, we give the option to choose
> they both work
> **me:** like in other applications run from the command line
> Our code handles both... but I feel like, given our audience, 'true'/'false' might be better choice (i.e. for the docs)
> **Ivan:** I see what you mean
> **Ivan:** well, I personally prefer true/false
> **Ivan:** and probably Ariya too
> **me:** But to a web developer, 'yes'/'no' is less natural than 'true'/'false'
> **me:** Also, if you were generating it from code, you have to code for that translation rather just converting your boolean to a string
> **Ivan:** good point

Also includes my changes for PR #387, which hopefully makes it easier to merge...?
