### PR TITLE
Fix compilation on Windows for child_process module

### DIFF
--- a/src/childprocess.h
+++ b/src/childprocess.h
@@ -33,6 +33,10 @@
 #include <QObject>
 #include <QProcess>
 
+#ifdef Q_OS_WIN32
+#include <QtCore/qt_windows.h>
+#endif
+
 #include "encoding.h"
 
 /**


### PR DESCRIPTION
**Issue:**
http://code.google.com/p/phantomjs/issues/detail?id=219

**Info:**
We need to include `QtCore/qt_windows.h` on Windows since `Q_PID` [mapped](https://github.com/ariya/phantomjs/blob/f52044cd3106266aa8efc1fae05e8c923315a5e5/src/qt/src/corelib/io/qprocess.h#L57) to `_PROCESS_INFORMATION`, but `_PROCESS_INFORMATION` not defined.
