### PR TITLE
Pass the resource URL to the resourceError handler.

### DIFF
--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -318,13 +318,20 @@ void NetworkAccessManager::handleNetworkError()
     QNetworkReply *reply = qobject_cast<QNetworkReply*>(sender());
     qDebug() << "Network - Resource request error:"
              << reply->error()
-             << "(" << reply->errorString() << ")";
+             << "(" << reply->errorString() << ")"
+             << "URL:" << reply->url().toString();
 
     m_ids.remove(reply);
 
     if (m_started.contains(reply))
         m_started.remove(reply);
 
-    emit resourceError(reply->error(), reply->errorString());
+    QVariantMap data;
+    data["url"] = reply->url().toString();
+    data["errorCode"] = reply->error();
+    data["errorString"] = reply->errorString();
+
+    emit resourceError(data);
+
     reply->deleteLater();
 }

--- a/src/networkaccessmanager.h
+++ b/src/networkaccessmanager.h
@@ -79,7 +79,7 @@ protected:
 signals:
     void resourceRequested(const QVariant& data, QObject *);
     void resourceReceived(const QVariant& data);
-    void resourceError(const QVariant& errorCode, const QVariant& errorString);
+    void resourceError(const QVariant& data);
 
 private slots:
     void handleStarted();

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -368,8 +368,8 @@ WebPage::WebPage(QObject *parent, const QUrl &baseUrl)
             SIGNAL(resourceRequested(QVariant, QObject *)));
     connect(m_networkAccessManager, SIGNAL(resourceReceived(QVariant)),
             SIGNAL(resourceReceived(QVariant)));
-    connect(m_networkAccessManager, SIGNAL(resourceError(QVariant, QVariant)),
-            SIGNAL(resourceError(QVariant, QVariant)));
+    connect(m_networkAccessManager, SIGNAL(resourceError(QVariant)),
+            SIGNAL(resourceError(QVariant)));
 
     m_customWebPage->setViewportSize(QSize(400, 300));
 }

--- a/src/webpage.h
+++ b/src/webpage.h
@@ -463,7 +463,7 @@ signals:
     void javaScriptErrorSent(const QString &msg, const QString &stack);
     void resourceRequested(const QVariant &requestData, QObject *request);
     void resourceReceived(const QVariant &resource);
-    void resourceError(const QVariant &errorCode, const QVariant &errorString);
+    void resourceError(const QVariant &errorData);
     void urlChanged(const QUrl &url);
     void navigationRequested(const QUrl &url, const QString &navigationType, bool navigationLocked, bool isMainFrame);
     void rawPageCreated(QObject *page);

--- a/test/webpage-spec.js
+++ b/test/webpage-spec.js
@@ -1063,9 +1063,10 @@ describe("WebPage object", function() {
         var handled = false;
         
         runs(function() {
-            page.onResourceError = function(errorCode, errorString) {
-                expect(errorCode).toEqual(203);
-                expect(errorString).toContain('notExistResource.png - server replied: Not Found');
+            page.onResourceError = function(errorData) {
+                expect(errorData['url']).toEqual('http://localhost:12345/notExistResource.png');
+                expect(errorData['errorCode']).toEqual(203);
+                expect(errorData['errorString']).toContain('notExistResource.png - server replied: Not Found');
                 handled = true;
             };
 


### PR DESCRIPTION
**Description:**
The resourceError handler should have a resource URL, to allow the user to get the resource (URL, error code) which was unable to load.

**Issue:**
http://code.google.com/p/phantomjs/issues/detail?id=997
