### PR TITLE
Fix WOFF files support

### DIFF
--- a/src/qt/src/3rdparty/webkit/Source/WebCore/css/CSSFontFaceSource.cpp
+++ b/src/qt/src/3rdparty/webkit/Source/WebCore/css/CSSFontFaceSource.cpp
@@ -44,6 +44,10 @@
 #include "SVGURIReference.h"
 #endif
 
+#if PLATFORM(QT)
+#include <QFontInfo>
+#endif
+
 namespace WebCore {
 
 CSSFontFaceSource::CSSFontFaceSource(const String& str, CachedFont* font)

--- a/src/qt/src/3rdparty/webkit/Source/WebCore/css/CSSParser.h
+++ b/src/qt/src/3rdparty/webkit/Source/WebCore/css/CSSParser.h
@@ -140,7 +140,6 @@ namespace WebCore {
 
         static bool parseColor(const String&, RGBA32& rgb, bool strict);
 
-        bool parseFontStyle(bool important);
         bool parseFontVariant(bool important);
         bool parseFontWeight(bool important);
         bool parseFontFaceSrc();

--- a/src/qt/src/3rdparty/webkit/Source/WebCore/platform/graphics/qt/FontCacheQt.cpp
+++ b/src/qt/src/3rdparty/webkit/Source/WebCore/platform/graphics/qt/FontCacheQt.cpp
@@ -35,6 +35,7 @@
 #include <wtf/text/StringHash.h>
 
 #include <QFont>
+#include <QFontDatabase>
 #if HAVE(QRAWFONT)
 #include <QTextLayout>
 #endif
@@ -106,6 +107,10 @@ void FontCache::getTraitsInFamily(const AtomicString&, Vector<unsigned>&)
 
 FontPlatformData* FontCache::createFontPlatformData(const FontDescription& fontDescription, const AtomicString& familyName)
 {
+    QFontDatabase db;
+    if (!db.hasFamily(familyName))
+        return 0;
+
     return new FontPlatformData(fontDescription, familyName);
 }
 

--- a/src/qt/src/3rdparty/webkit/Source/WebCore/platform/graphics/qt/FontCustomPlatformData.h
+++ b/src/qt/src/3rdparty/webkit/Source/WebCore/platform/graphics/qt/FontCustomPlatformData.h
@@ -43,9 +43,11 @@ public:
 
     // for use with QFontDatabase::addApplicationFont/removeApplicationFont
     int m_handle;
+    bool m_italic;
+    bool m_bold;
 
-    FontPlatformData fontPlatformData(int size, bool bold, bool italic, FontOrientation = Horizontal, TextOrientation = TextOrientationVerticalRight,
-                                      FontWidthVariant = RegularWidth, FontRenderingMode = NormalRenderingMode);
+    FontPlatformData fontPlatformData(int size, bool syntheticBold, bool syntheticItalic, FontOrientation = Horizontal, 
+        TextOrientation = TextOrientationVerticalRight, FontWidthVariant = RegularWidth, FontRenderingMode = NormalRenderingMode);
 
     static bool supportsFormat(const String&);
 };

--- a/src/qt/src/3rdparty/webkit/Source/WebCore/platform/graphics/qt/FontCustomPlatformDataQt.cpp
+++ b/src/qt/src/3rdparty/webkit/Source/WebCore/platform/graphics/qt/FontCustomPlatformDataQt.cpp
@@ -26,6 +26,7 @@
 #include "SharedBuffer.h"
 #include "WOFFFileFormat.h"
 #include <QFontDatabase>
+#include <QMap>
 #include <QStringList>
 
 namespace WebCore {
@@ -39,21 +40,75 @@ FontCustomPlatformData::~FontCustomPlatformData()
 #endif
 }
 
-FontPlatformData FontCustomPlatformData::fontPlatformData(int size, bool bold, bool italic, FontOrientation, TextOrientation, FontWidthVariant, FontRenderingMode)
+FontPlatformData FontCustomPlatformData::fontPlatformData(int size, bool syntheticBold, bool syntheticItalic, FontOrientation, TextOrientation, FontWidthVariant, FontRenderingMode)
 {
+    // Note that syntheticBold and syntheticItalic are only set by CSSFontSelector
+    // (the sole user of this class) if the markup has requested bold or italic
+    // (e.g. <i>text</i>) but the @font-face rule for the font does not specify support
+    // for it (e.g. @font-face { font-family: "font"; font-style: normal;).
+
     QFont font;
-    font.setFamily(QFontDatabase::applicationFontFamilies(m_handle)[0]);
+    QFontDatabase db;
+    
+    QString family = QFontDatabase::applicationFontFamilies(m_handle)[0];
+    font.setFamily(family);
     font.setPixelSize(size);
-    if (bold)
+    if (m_bold || syntheticBold)
         font.setWeight(QFont::Bold);
-    font.setItalic(italic);
+    font.setItalic(m_italic || syntheticItalic);
 
     return FontPlatformData(font);
+}
+
+static QMap<QString, QStringList> currentStyles(const QStringList& families, const QFontDatabase& db)
+{
+    QMap<QString, QStringList> styles;
+    for (int i = 0; i < families.size(); ++i)
+        styles[families.at(i)].append(db.styles(families.at(i)));
+    return styles;
+}
+
+static QStringList stylesAddedByFont(const QString& familyAdded, const QStringList& stylesAdded, const QMap<QString, QStringList>& styles)
+{
+    QStringList newStyles = stylesAdded;
+    for (int i = 0; i < styles[familyAdded].size(); ++i)
+        newStyles.removeAll(styles[familyAdded].at(i));
+    return newStyles;
+}
+
+static bool strictlyItalicAddedByFont(const QString& familyAdded, const QStringList& stylesAdded, const QFontDatabase& db)
+{
+    bool italic = false;
+    for (int i = 0; i < stylesAdded.size(); ++i) {
+        if (db.italic(familyAdded, stylesAdded.at(i))) {
+            italic = true;
+        } else if (!db.bold(familyAdded, stylesAdded.at(i)))
+            return false;
+    }
+    return italic;
+}
+
+static bool strictlyBoldAddedByFont(const QString& familyAdded, const QStringList& stylesAdded, const QFontDatabase& db)
+{
+    bool bold = false;
+    for (int i = 0; i < stylesAdded.size(); ++i) {
+        if (db.bold(familyAdded, stylesAdded.at(i))) {
+            bold = true;
+        } else if (!db.italic(familyAdded, stylesAdded.at(i)))
+            return false;
+    }
+    return bold;
 }
 
 FontCustomPlatformData* createFontCustomPlatformData(SharedBuffer* buffer)
 {
     ASSERT_ARG(buffer, buffer);
+    QFontDatabase db;
+
+    // The font families in the font database, and the styles in each,
+    // before we load the new font in buffer.
+    QStringList families = db.families();
+    QMap<QString, QStringList> styles = currentStyles(families, db);
 
     RefPtr<SharedBuffer> sfntBuffer;
     if (isWOFF(buffer)) {
@@ -68,10 +123,24 @@ FontCustomPlatformData* createFontCustomPlatformData(SharedBuffer* buffer)
     if (id == -1)
         return 0;
 
+    QString familyAdded = QFontDatabase::applicationFontFamilies(id)[0];
+    QStringList stylesAdded = db.styles(QFontDatabase::applicationFontFamilies(id)[0]);
+
+    // If we already had the family of which this font is a member then
+    // get the styles it added to the family
+    if (families.contains(familyAdded))
+        stylesAdded = stylesAddedByFont(familyAdded, stylesAdded, styles);
+
     Q_ASSERT(QFontDatabase::applicationFontFamilies(id).size() > 0);
 
     FontCustomPlatformData *data = new FontCustomPlatformData;
     data->m_handle = id;
+
+    // If we have created a font that only has bold or italic styles (or both)
+    // then we need to respect it's style(s) when we pass it back as
+    // FontPlatformData above.
+    data->m_italic = strictlyItalicAddedByFont(familyAdded, stylesAdded, db);
+    data->m_bold = strictlyBoldAddedByFont(familyAdded, stylesAdded, db);
     return data;
 }
 

--- a/src/qt/src/3rdparty/webkit/Source/WebCore/platform/graphics/qt/FontPlatformData.h
+++ b/src/qt/src/3rdparty/webkit/Source/WebCore/platform/graphics/qt/FontPlatformData.h
@@ -36,6 +36,27 @@
 
 namespace WebCore {
 
+static inline QFont::Weight toQFontWeight(FontWeight fontWeight)
+{
+    switch (fontWeight) {
+    case FontWeight100:
+    case FontWeight200:
+        return QFont::Light; // QFont::Light == Weight of 25
+    case FontWeight600:
+        return QFont::DemiBold; // QFont::DemiBold == Weight of 63
+    case FontWeight700:
+    case FontWeight800:
+        return QFont::Bold; // QFont::Bold == Weight of 75
+    case FontWeight900:
+        return QFont::Black; // QFont::Black == Weight of 87
+    case FontWeight300:
+    case FontWeight400:
+    case FontWeight500:
+    default:
+        return QFont::Normal; // QFont::Normal == Weight of 50
+    }
+}
+
 class FontPlatformDataPrivate : public RefCounted<FontPlatformDataPrivate> {
     WTF_MAKE_NONCOPYABLE(FontPlatformDataPrivate); WTF_MAKE_FAST_ALLOCATED;
 public:

--- a/src/qt/src/3rdparty/webkit/Source/WebCore/platform/graphics/qt/FontPlatformDataQt.cpp
+++ b/src/qt/src/3rdparty/webkit/Source/WebCore/platform/graphics/qt/FontPlatformDataQt.cpp
@@ -27,27 +27,6 @@
 
 namespace WebCore {
 
-static inline QFont::Weight toQFontWeight(FontWeight fontWeight)
-{
-    switch (fontWeight) {
-    case FontWeight100:
-    case FontWeight200:
-        return QFont::Light; // QFont::Light == Weight of 25
-    case FontWeight600:
-        return QFont::DemiBold; // QFont::DemiBold == Weight of 63
-    case FontWeight700:
-    case FontWeight800:
-        return QFont::Bold; // QFont::Bold == Weight of 75
-    case FontWeight900:
-        return QFont::Black; // QFont::Black == Weight of 87
-    case FontWeight300:
-    case FontWeight400:
-    case FontWeight500:
-    default:
-        return QFont::Normal; // QFont::Normal == Weight of 50
-    }
-}
-
 static inline bool isEmptyValue(const float size, const bool bold, const bool oblique)
 {
      // this is the empty value by definition of the trait FontDataCacheKeyTraits

--- a/src/qt/src/3rdparty/webkit/Source/WebCore/platform/graphics/qt/FontQt.cpp
+++ b/src/qt/src/3rdparty/webkit/Source/WebCore/platform/graphics/qt/FontQt.cpp
@@ -27,6 +27,7 @@
 #include "FontDescription.h"
 #include "FontFallbackList.h"
 #include "FontSelector.h"
+#include "FontPlatformData.h"
 #if HAVE(QRAWFONT)
 #include "GlyphBuffer.h"
 #endif
@@ -471,6 +472,8 @@ void Font::drawEmphasisMarksForSimpleText(GraphicsContext* /* context */, const 
 QFont Font::font() const
 {
     QFont f = primaryFont()->getQtFont();
+    f.setWeight(toQFontWeight(weight()));
+    f.setItalic(italic());
     if (m_letterSpacing != 0)
         f.setLetterSpacing(QFont::AbsoluteSpacing, m_letterSpacing);
     if (m_wordSpacing != 0)


### PR DESCRIPTION
**This commit resolves:**
- 'src' and 'local' attributes in 'font-face' CSS values
- invalid font weights and styles

**Upstream bug:**
https://bugs.webkit.org/show_bug.cgi?id=36351 (WOFF files)
https://bugs.webkit.org/show_bug.cgi?id=93853 (Invalid font weights and styles)

**Issues:**
http://code.google.com/p/phantomjs/issues/detail?id=592
http://code.google.com/p/phantomjs/issues/detail?id=247
http://code.google.com/p/phantomjs/issues/detail?id=713
