### PR TITLE
Fixed the CreationDate value format when creating PDFs.

### DIFF
--- a/src/qt/src/gui/painting/qprintengine_pdf.cpp
+++ b/src/qt/src/gui/painting/qprintengine_pdf.cpp
@@ -1186,10 +1186,10 @@ void QPdfEnginePrivate::writeInfo()
     printString(creator);
     xprintf("\n/Producer ");
     printString(QString::fromLatin1("Qt " QT_VERSION_STR " (C) 2011 Nokia Corporation and/or its subsidiary(-ies)"));
-    QDateTime now = QDateTime::currentDateTime().toUTC();
+    QDateTime now = QDateTime::currentDateTime();
     QTime t = now.time();
     QDate d = now.date();
-    xprintf("\n/CreationDate (D:%d%02d%02d%02d%02d%02d)",
+    xprintf("\n/CreationDate (D:%d%02d%02d%02d%02d%02d",
             d.year(),
             d.month(),
             d.day(),


### PR DESCRIPTION
This was confusing Adobe Reader and not allowing it to save PDFs.

This bug appears to have been introduced in commit 08fc50d149745b078c9fd73a213c8c83307beaa2 which was applying the patch from http://qt.gitorious.org/qt/qt/merge_requests/706 but missed two lines.

This should fix issue http://code.google.com/p/phantomjs/issues/detail?id=663 .
