### PR TITLE
added --ssl-certstore CLI option. 

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,4 +1,4 @@
-/*o
+/*
   This file is part of the PhantomJS project from Ofi Labs.
 
   Copyright (C) 2012 Ariya Hidayat <ariya.hidayat@gmail.com>

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,4 +1,4 @@
-/*
+/*o
   This file is part of the PhantomJS project from Ofi Labs.
 
   Copyright (C) 2012 Ariya Hidayat <ariya.hidayat@gmail.com>
@@ -63,6 +63,7 @@ static const struct QCommandLineConfigEntry flags[] =
     { QCommandLine::Option, '\0', "script-encoding", "Sets the encoding used for the starting script, default is 'utf8'", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "web-security", "Enables web security, 'yes' (default) or 'no'", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "ssl-protocol", "Sets the SSL protocol (supported protocols: 'SSLv3' (default), 'SSLv2', 'TLSv1', 'any')", QCommandLine::Optional },
+    { QCommandLine::Option, '\0', "ssl-certstore", "Sets the certificate store directory (if none set, uses system default)", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "webdriver", "Starts in 'Remote WebDriver mode' (embedded GhostDriver): '[[<IP>:]<PORT>]' (default '127.0.0.1:8910') ", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "webdriver-selenium-grid-hub", "URL to the Selenium Grid HUB: 'URL_TO_HUB' (default 'none') (NOTE: works only together with '--webdriver') ", QCommandLine::Optional },
     { QCommandLine::Param, '\0', "script", "Script", QCommandLine::Flags(QCommandLine::Optional|QCommandLine::ParameterFence)},
@@ -513,6 +514,7 @@ void Config::resetToDefaults()
     m_helpFlag = false;
     m_printDebugMessages = false;
     m_sslProtocol = "sslv3";
+    m_sslCertStore.clear();
     m_webdriver = QString();
     m_seleniumGridHub = QString();
 }
@@ -658,6 +660,9 @@ void Config::handleOption(const QString &option, const QVariant &value)
     if (option == "ssl-protocol") {
         setSslProtocol(value.toString());
     }
+    if (option == "ssl-certstore") {
+        setSslCertStore(value.toString());
+    }
     if (option == "webdriver") {
         setWebdriver(value.toString());
     }
@@ -689,4 +694,14 @@ QString Config::sslProtocol() const
 void Config::setSslProtocol(const QString& sslProtocolName)
 {
     m_sslProtocol = sslProtocolName.toLower();
+}
+
+QString Config::sslCertStore() const
+{
+    return m_sslCertStore;
+}
+
+void Config::setSslCertStore(const QString& sslCertStorePath)
+{
+    m_sslCertStore = sslCertStorePath;
 }

--- a/src/config.h
+++ b/src/config.h
@@ -58,6 +58,7 @@ class Config: public QObject
     Q_PROPERTY(bool javascriptCanOpenWindows READ javascriptCanOpenWindows WRITE setJavascriptCanOpenWindows)
     Q_PROPERTY(bool javascriptCanCloseWindows READ javascriptCanCloseWindows WRITE setJavascriptCanCloseWindows)
     Q_PROPERTY(QString sslProtocol READ sslProtocol WRITE setSslProtocol)
+    Q_PROPERTY(QString sslCertStore READ sslCertStore WRITE setSslCertStore)
     Q_PROPERTY(QString webdriver READ webdriver WRITE setWebdriver)
     Q_PROPERTY(QString seleniumGridHub READ seleniumGridHub WRITE setSeleniumGridHub)
 
@@ -154,6 +155,9 @@ public:
     void setSslProtocol(const QString& sslProtocolName);
     QString sslProtocol() const;
 
+    void setSslCertStore (const QString& sslCertStore);
+    QString sslCertStore () const;
+
     void setWebdriver(const QString& webdriverConfig);
     QString webdriver() const;
     bool isWebdriverMode() const;
@@ -205,6 +209,7 @@ private:
     bool m_javascriptCanOpenWindows;
     bool m_javascriptCanCloseWindows;
     QString m_sslProtocol;
+    QString m_sslCertStore;
     QString m_webdriver;
     QString m_seleniumGridHub;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -106,7 +106,13 @@ int main(int argc, char** argv, const char** envp)
 #if defined(Q_OS_LINUX)
     if (QSslSocket::supportsSsl()) {
         // Don't perform on-demand loading of root certificates on Linux
-        QSslSocket::addDefaultCaCertificates(QSslSocket::systemCaCertificates());
+        QByteArray envSslCertDir = qgetenv("SSL_CERT_DIR");
+        if (envSslCertDir != "") {
+            QList<QSslCertificate> caCerts = QSslCertificate::fromPath(envSslCertDir, QSsl::Pem, QRegExp::Wildcard);
+            QSslSocket::setCaCertificates(caCerts);
+        } else {
+            QSslSocket::addDefaultCaCertificates(QSslSocket::systemCaCertificates());
+        }
     }
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -109,7 +109,7 @@ int main(int argc, char** argv, const char** envp)
         QByteArray envSslCertDir = qgetenv("SSL_CERT_DIR");
         if (envSslCertDir != "") {
             QList<QSslCertificate> caCerts = QSslCertificate::fromPath(envSslCertDir, QSsl::Pem, QRegExp::Wildcard);
-            QSslSocket::setCaCertificates(caCerts);
+            QSslSocket::addDefaultCaCertificates(caCerts);
         } else {
             QSslSocket::addDefaultCaCertificates(QSslSocket::systemCaCertificates());
         }

--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -81,9 +81,6 @@ NetworkAccessManager::NetworkAccessManager(QObject *parent, const Config *config
 {
     setCookieJar(CookieJar::instance());
 
-    QList<QSslCertificate> caCerts = QSslCertificate::fromPath(
-        config->sslCertStore(), QSsl::Pem, QRegExp::Wildcard);
-
     if (config->diskCacheEnabled()) {
         m_networkDiskCache = new QNetworkDiskCache(this);
         m_networkDiskCache->setCacheDirectory(QDesktopServices::storageLocation(QDesktopServices::CacheLocation));
@@ -107,6 +104,9 @@ NetworkAccessManager::NetworkAccessManager(QObject *parent, const Config *config
         }
 
         if (config->sslCertStore() != "") {
+          QList<QSslCertificate> caCerts = QSslCertificate::fromPath(
+              config->sslCertStore(), QSsl::Pem, QRegExp::Wildcard);
+
             m_sslConfiguration.setCaCertificates(caCerts);
         }
     }

--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -35,6 +35,8 @@
 #include <QNetworkReply>
 #include <QNetworkRequest>
 #include <QSslSocket>
+#include <QSslCertificate>
+#include <QRegExp>
 
 #include "phantom.h"
 #include "config.h"
@@ -79,6 +81,9 @@ NetworkAccessManager::NetworkAccessManager(QObject *parent, const Config *config
 {
     setCookieJar(CookieJar::instance());
 
+    QList<QSslCertificate> caCerts = QSslCertificate::fromPath(
+        config->sslCertStore(), QSsl::Pem, QRegExp::Wildcard);
+
     if (config->diskCacheEnabled()) {
         m_networkDiskCache = new QNetworkDiskCache(this);
         m_networkDiskCache->setCacheDirectory(QDesktopServices::storageLocation(QDesktopServices::CacheLocation));
@@ -99,6 +104,10 @@ NetworkAccessManager::NetworkAccessManager(QObject *parent, const Config *config
             m_sslConfiguration.setProtocol(QSsl::TlsV1);
         } else if (config->sslProtocol() == "any") {
             m_sslConfiguration.setProtocol(QSsl::AnyProtocol);
+        }
+
+        if (config->sslCertStore() != "") {
+            m_sslConfiguration.setCaCertificates(caCerts);
         }
     }
 


### PR DESCRIPTION
Since my SSL_CERT_DIR environment variable patch needed upstream approval, I propose this alternative command line option patch.

eg: phantomjs --ssl-certstore='/tmp/certs/*.pem' ...
