### PR TITLE
Fix for issues in render_multi_url example

### DIFF
--- a/examples/render_multi_url.js
+++ b/examples/render_multi_url.js
@@ -1,13 +1,14 @@
 // Render Multiple URLs to file
 // FIXME: For now it is fine with pure domain names: don't think it would work with paths and stuff like that
 
-var system = require('system');
+var system = require('system'),
+    worker = 0;
 
 // Extend the Array Prototype with a 'foreach'
 Array.prototype.forEach = function (action) {
     var i, len;
     for ( i = 0, len = this.length; i < len; ++i ) {
-        action(i, this[i], len);
+        action(this[i]);
     }
 };
 
@@ -25,11 +26,15 @@ function renderUrlToFile(url, file, callback) {
     page.open(url, function(status){
        if ( status !== "success") {
            console.log("Unable to render '"+url+"'");
+           page.close();
+           callback(url, file);
        } else {
-           page.render(file);
+           window.setTimeout(function() {
+               page.render(file);
+               page.close();
+               callback(url, file);
+           });
        }
-       page.close();
-       callback(url, file);
     });
 }
 
@@ -47,14 +52,17 @@ if ( system.args.length > 1 ) {
     ];
 }
 
+worker += arrayOfUrls.length;
+
 // For each URL
-arrayOfUrls.forEach(function(pos, url, total){
+arrayOfUrls.forEach(function(url){
     var file_name = "./" + url + ".png";
 
     // Render to a file
     renderUrlToFile("http://"+url, file_name, function(url, file){
         console.log("Rendered '"+url+"' at '"+file+"'");
-        if ( pos === total-1 ) {
+		worker--;
+        if ( worker === 0) {
             // Close Phantom if it's the last URL
             phantom.exit();
         }


### PR DESCRIPTION
1) The example runs multiple page instances concurrently and terminated
after the last URL is rendered but the previous renders do not always
completed since they are running asynchonously. This fix so that it
terminates only after all jobs are done.

2) render() was run immediately after page callback which generates
empty screen. This fix changed it to run only after 200 ms.

Issue: http://code.google.com/p/phantomjs/issues/detail?id=1021
