### PR TITLE
Adding the whole 'bin' folder to '.gitignore'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 *.pro.user*
 *.xcodeproj
 Makefile*
-bin/phantomjs
 *~
 *.moc
 moc_*
@@ -55,3 +54,4 @@ tools/dump_syms.app/
 # Build results
 [Dd]ebug*/
 [Rr]elease/
+bin/


### PR DESCRIPTION
On Windows, there are 3 files produced in the 'bin' folder and none of them should be checked in.
