### PR TITLE
Fix ignoring ssl errors on synchronous xhrs (issue 985)

### DIFF
--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -105,6 +105,10 @@ NetworkAccessManager::NetworkAccessManager(QObject *parent, const Config *config
     if (QSslSocket::supportsSsl()) {
         m_sslConfiguration = QSslConfiguration::defaultConfiguration();
 
+        if (config->ignoreSslErrors()) {
+            m_sslConfiguration.setPeerVerifyMode(QSslSocket::VerifyNone);
+        }
+
         // set the SSL protocol to SSLv3 by the default
         m_sslConfiguration.setProtocol(QSsl::SslV3);
 


### PR DESCRIPTION
disabling peer verify in ssl configuration when ignore-ssl-errors is set

issue http://code.google.com/p/phantomjs/issues/detail?id=985

please include it also in 1.8 as fix
