### PR TITLE
Add command option to control enable/disable local storage

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -45,14 +45,20 @@
 
 static const struct QCommandLineConfigEntry flags[] =
 {
+    { QCommandLine::Option, '\0', "appcache", "Enables application cache: 'true' (default) or 'false'", QCommandLine::Optional },
+    { QCommandLine::Option, '\0', "appcache-path", "Specifies the location for application cache", QCommandLine::Optional },
+    { QCommandLine::Option, '\0', "appcache-quota", "Sets the maximum size of the application cache (in KB)", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "cookies-file", "Sets the file name to store the persistent cookies", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "config", "Specifies JSON-formatted configuration file", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "debug", "Prints additional warning and debug message: 'true' or 'false' (default)", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "disk-cache", "Enables disk cache: 'true' or 'false' (default)", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "ignore-ssl-errors", "Ignores SSL errors (expired/self-signed certificate errors): 'true' or 'false' (default)", QCommandLine::Optional },
+    { QCommandLine::Option, '\0', "indexed-db", "Enables IndexedDB: 'true' (default) or 'false'", QCommandLine::Optional },
+    { QCommandLine::Option, '\0', "indexed-db-path", "Specifies the location for indexed db storage", QCommandLine::Optional },
+    { QCommandLine::Option, '\0', "indexed-db-quota", "Sets the maximum size of the indexed db quota (in KB)", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "load-images", "Loads all inlined images: 'true' (default) or 'false'", QCommandLine::Optional },
+    { QCommandLine::Option, '\0', "local-storage", "Enables local storage: 'true' (default) or 'false'", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "local-storage-path", "Specifies the location for offline local storage", QCommandLine::Optional },
-    { QCommandLine::Option, '\0', "local-storage-quota", "Sets the maximum size of the offline local storage (in KB)", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "local-to-remote-url-access", "Allows local content to access remote URL: 'true' or 'false' (default)", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "max-disk-cache-size", "Limits the size of the disk cache (in KB)", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "output-encoding", "Sets the encoding for the terminal output, default is 'utf8'", QCommandLine::Optional },
@@ -175,25 +181,87 @@ void Config::setCookiesFile(const QString &value)
     m_cookiesFile = value;
 }
 
-QString Config::offlineStoragePath() const
+bool Config::appCacheEnabled() const
 {
-    return m_offlineStoragePath;
+    return m_appCacheEnabled;
 }
 
-void Config::setOfflineStoragePath(const QString &value)
+void Config::setAppCacheEnabled(const bool value)
+{
+    m_appCacheEnabled = value;
+}
+
+QString Config::appCachePath() const
+{
+    return m_appCachePath;
+}
+
+void Config::setAppCachePath(const QString &value)
 {
     QDir dir(value);
-    m_offlineStoragePath = dir.absolutePath();
+    m_appCachePath = dir.absolutePath();
 }
 
-int Config::offlineStorageDefaultQuota() const
+int Config::appCacheDefaultQuota() const
 {
-    return m_offlineStorageDefaultQuota;
+    return m_appCacheDefaultQuota;
 }
 
-void Config::setOfflineStorageDefaultQuota(int offlineStorageDefaultQuota)
+void Config::setAppCacheDefaultQuota(int appCacheDefaultQuota)
 {
-    m_offlineStorageDefaultQuota = offlineStorageDefaultQuota * 1024;
+    m_appCacheDefaultQuota = appCacheDefaultQuota * 1024;
+}
+
+bool Config::indexedDbEnabled() const
+{
+    return m_indexedDbEnabled;
+}
+
+void Config::setIndexedDbEnabled(const bool value)
+{
+    m_indexedDbEnabled = value;
+}
+
+QString Config::indexedDbPath() const
+{
+    return m_indexedDbPath;
+}
+
+void Config::setIndexedDbPath(const QString &value)
+{
+    QDir dir(value);
+    m_indexedDbPath = dir.absolutePath();
+}
+
+int Config::indexedDbDefaultQuota() const
+{
+    return m_indexedDbDefaultQuota;
+}
+
+void Config::setIndexedDbDefaultQuota(int indexedDbDefaultQuota)
+{
+    m_indexedDbDefaultQuota = indexedDbDefaultQuota * 1024;
+}
+
+bool Config::localStorageEnabled() const
+{
+    return m_localStorageEnabled;
+}
+
+void Config::setLocalStorageEnabled(const bool value)
+{
+    m_localStorageEnabled = value;
+}
+
+QString Config::localStoragePath() const
+{
+    return m_localStoragePath;
+}
+
+void Config::setLocalStoragePath(const QString &value)
+{
+    QDir dir(value);
+    m_localStoragePath = dir.absolutePath();
 }
 
 bool Config::diskCacheEnabled() const
@@ -488,8 +556,14 @@ void Config::resetToDefaults()
 {
     m_autoLoadImages = true;
     m_cookiesFile = QString();
-    m_offlineStoragePath = QString();
-    m_offlineStorageDefaultQuota = -1;
+    m_appCacheEnabled = true;
+    m_appCachePath = QString();
+    m_appCacheDefaultQuota = -1;
+    m_indexedDbEnabled = true;
+    m_indexedDbPath = QString();
+    m_indexedDbDefaultQuota = -1;
+    m_localStorageEnabled = true;
+    m_localStoragePath = QString();
     m_diskCacheEnabled = false;
     m_maxDiskCacheSize = -1;
     m_ignoreSslErrors = false;
@@ -596,6 +670,18 @@ void Config::handleOption(const QString &option, const QVariant &value)
         setPrintDebugMessages(boolValue);
     }
 
+    if (option == "appcache") {
+        setAppCacheEnabled(boolValue);
+    }
+
+    if (option == "appcache-path") {
+        setAppCachePath(value.toString());
+    }
+
+    if (option == "appcache-quota") {
+        setAppCacheDefaultQuota(value.toInt());
+    }
+
     if (option == "disk-cache") {
         setDiskCacheEnabled(boolValue);
     }
@@ -604,16 +690,28 @@ void Config::handleOption(const QString &option, const QVariant &value)
         setIgnoreSslErrors(boolValue);
     }
 
+    if (option == "indexed-db") {
+        setIndexedDbEnabled(boolValue);
+    }
+
+    if (option == "indexed-db-path") {
+        setIndexedDbPath(value.toString());
+    }
+
+    if (option == "indexed-db-quota") {
+        setIndexedDbDefaultQuota(value.toInt());
+    }
+
     if (option == "load-images") {
         setAutoLoadImages(boolValue);
     }
 
-    if (option == "local-storage-path") {
-        setOfflineStoragePath(value.toString());
+    if (option == "local-storage") {
+        setLocalStorageEnabled(boolValue);
     }
 
-    if (option == "local-storage-quota") {
-        setOfflineStorageDefaultQuota(value.toInt());
+    if (option == "local-storage-path") {
+        setLocalStoragePath(value.toString());
     }
 
     if (option == "local-to-remote-url-access") {

--- a/src/config.h
+++ b/src/config.h
@@ -41,10 +41,16 @@ class QCommandLine;
 class Config: public QObject
 {
     Q_OBJECT
+    Q_PROPERTY(bool appCacheEnabled READ appCacheEnabled WRITE setAppCacheEnabled)
+    Q_PROPERTY(QString appCachePath READ appCachePath WRITE setAppCachePath)
+    Q_PROPERTY(int appCacheDefaultQuota READ appCacheDefaultQuota WRITE setAppCacheDefaultQuota)
     Q_PROPERTY(QString cookiesFile READ cookiesFile WRITE setCookiesFile)
     Q_PROPERTY(bool diskCacheEnabled READ diskCacheEnabled WRITE setDiskCacheEnabled)
     Q_PROPERTY(int maxDiskCacheSize READ maxDiskCacheSize WRITE setMaxDiskCacheSize)
     Q_PROPERTY(bool ignoreSslErrors READ ignoreSslErrors WRITE setIgnoreSslErrors)
+    Q_PROPERTY(bool indexedDbEnabled READ indexedDbEnabled WRITE setIndexedDbEnabled)
+    Q_PROPERTY(QString indexedDbPath READ indexedDbPath WRITE setIndexedDbPath)
+    Q_PROPERTY(int indexedDbDefaultQuota READ indexedDbDefaultQuota WRITE setIndexedDbDefaultQuota)
     Q_PROPERTY(bool localToRemoteUrlAccessEnabled READ localToRemoteUrlAccessEnabled WRITE setLocalToRemoteUrlAccessEnabled)
     Q_PROPERTY(QString outputEncoding READ outputEncoding WRITE setOutputEncoding)
     Q_PROPERTY(QString proxyType READ proxyType WRITE setProxyType)
@@ -52,8 +58,8 @@ class Config: public QObject
     Q_PROPERTY(QString proxyAuth READ proxyAuth WRITE setProxyAuth)
     Q_PROPERTY(QString scriptEncoding READ scriptEncoding WRITE setScriptEncoding)
     Q_PROPERTY(bool webSecurityEnabled READ webSecurityEnabled WRITE setWebSecurityEnabled)
-    Q_PROPERTY(QString offlineStoragePath READ offlineStoragePath WRITE setOfflineStoragePath)
-    Q_PROPERTY(int offlineStorageDefaultQuota READ offlineStorageDefaultQuota WRITE setOfflineStorageDefaultQuota)
+    Q_PROPERTY(bool localStorageEnabled READ localStorageEnabled WRITE setLocalStorageEnabled)
+    Q_PROPERTY(QString localStoragePath READ localStoragePath WRITE setLocalStoragePath)
     Q_PROPERTY(bool printDebugMessages READ printDebugMessages WRITE setPrintDebugMessages)
     Q_PROPERTY(bool javascriptCanOpenWindows READ javascriptCanOpenWindows WRITE setJavascriptCanOpenWindows)
     Q_PROPERTY(bool javascriptCanCloseWindows READ javascriptCanCloseWindows WRITE setJavascriptCanCloseWindows)
@@ -73,14 +79,32 @@ public:
     bool autoLoadImages() const;
     void setAutoLoadImages(const bool value);
 
+    bool appCacheEnabled() const;
+    void setAppCacheEnabled(const bool value);
+
+    QString appCachePath() const;
+    void setAppCachePath(const QString &value);
+
+    int appCacheDefaultQuota() const;
+    void setAppCacheDefaultQuota(int appCacheDefaultQuota);
+
     QString cookiesFile() const;
     void setCookiesFile(const QString &cookiesFile);
 
-    QString offlineStoragePath() const;
-    void setOfflineStoragePath(const QString &value);
+    bool indexedDbEnabled() const;
+    void setIndexedDbEnabled(const bool value);
 
-    int offlineStorageDefaultQuota() const;
-    void setOfflineStorageDefaultQuota(int offlineStorageDefaultQuota);
+    QString indexedDbPath() const;
+    void setIndexedDbPath(const QString &value);
+
+    int indexedDbDefaultQuota() const;
+    void setIndexedDbDefaultQuota(int indexedDbDefaultQuota);
+
+    bool localStorageEnabled() const;
+    void setLocalStorageEnabled(const bool value);
+
+    QString localStoragePath() const;
+    void setLocalStoragePath(const QString &value);
 
     bool diskCacheEnabled() const;
     void setDiskCacheEnabled(const bool value);
@@ -177,8 +201,14 @@ private:
     QCommandLine *m_cmdLine;
     bool m_autoLoadImages;
     QString m_cookiesFile;
-    QString m_offlineStoragePath;
-    int m_offlineStorageDefaultQuota;
+    bool m_appCacheEnabled;
+    QString m_appCachePath;
+    int m_appCacheDefaultQuota;
+    bool m_indexedDbEnabled;
+    QString m_indexedDbPath;
+    int m_indexedDbDefaultQuota;
+    bool m_localStorageEnabled;
+    QString m_localStoragePath;
     bool m_diskCacheEnabled;
     int m_maxDiskCacheSize;
     bool m_ignoreSslErrors;

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -357,23 +357,40 @@ WebPage::WebPage(QObject *parent, const QUrl &baseUrl)
     m_mainFrame->setScrollBarPolicy(Qt::Horizontal, Qt::ScrollBarAlwaysOff);
     m_mainFrame->setScrollBarPolicy(Qt::Vertical, Qt::ScrollBarAlwaysOff);
 
-    m_customWebPage->settings()->setAttribute(QWebSettings::OfflineStorageDatabaseEnabled, true);
-    if (phantomCfg->offlineStoragePath().isEmpty()) {
-        m_customWebPage->settings()->setOfflineStoragePath(QDesktopServices::storageLocation(QDesktopServices::DataLocation));
-    } else {
-        m_customWebPage->settings()->setOfflineStoragePath(phantomCfg->offlineStoragePath());
-    }
-    if (phantomCfg->offlineStorageDefaultQuota() > 0) {
-        m_customWebPage->settings()->setOfflineStorageDefaultQuota(phantomCfg->offlineStorageDefaultQuota());
+    m_customWebPage->settings()->setAttribute(QWebSettings::OfflineStorageDatabaseEnabled, phantomCfg->indexedDbEnabled());
+    if (phantomCfg->indexedDbEnabled()) {
+        if (phantomCfg->indexedDbPath().isEmpty()) {
+            m_customWebPage->settings()->setOfflineStoragePath(QDesktopServices::storageLocation(QDesktopServices::DataLocation));
+        } else {
+            m_customWebPage->settings()->setOfflineStoragePath(phantomCfg->indexedDbPath());
+        }
+        if (phantomCfg->indexedDbDefaultQuota() > 0) {
+            m_customWebPage->settings()->setOfflineStorageDefaultQuota(phantomCfg->indexedDbDefaultQuota());
+        }
     }
 
-    m_customWebPage->settings()->setAttribute(QWebSettings::OfflineWebApplicationCacheEnabled, true);
-    m_customWebPage->settings()->setOfflineWebApplicationCachePath(QDesktopServices::storageLocation(QDesktopServices::DataLocation));
+    m_customWebPage->settings()->setAttribute(QWebSettings::LocalStorageEnabled, phantomCfg->localStorageEnabled());
+    if (phantomCfg->localStorageEnabled()) {
+        if (phantomCfg->localStoragePath().isEmpty()) {
+            m_customWebPage->settings()->setLocalStoragePath(QDesktopServices::storageLocation(QDesktopServices::DataLocation));
+        } else {
+	    m_customWebPage->settings()->setLocalStoragePath(phantomCfg->localStoragePath());
+        }
+    }
+
+    m_customWebPage->settings()->setAttribute(QWebSettings::OfflineWebApplicationCacheEnabled, phantomCfg->appCacheEnabled());
+    if (phantomCfg->appCacheEnabled()) {
+        if (phantomCfg->appCachePath().isEmpty()) {
+            m_customWebPage->settings()->setOfflineWebApplicationCachePath(QDesktopServices::storageLocation(QDesktopServices::DataLocation));
+        } else {
+            m_customWebPage->settings()->setOfflineWebApplicationCachePath(phantomCfg->appCachePath());
+        }
+	if (phantomCfg->appCacheDefaultQuota()) {
+	  m_customWebPage->settings()->setOfflineWebApplicationCacheQuota(phantomCfg->appCacheDefaultQuota());
+        }
+    }
 
     m_customWebPage->settings()->setAttribute(QWebSettings::FrameFlatteningEnabled, true);
-
-    m_customWebPage->settings()->setAttribute(QWebSettings::LocalStorageEnabled, true);
-    m_customWebPage->settings()->setLocalStoragePath(QDesktopServices::storageLocation(QDesktopServices::DataLocation));
 
     // Custom network access manager to allow traffic monitoring.
     m_networkAccessManager = new NetworkAccessManager(this, phantomCfg);


### PR DESCRIPTION
Issue link: #11055
Sometimes we need the ability to control whether to enable the local storage or not, especially when we want to build a large scraping system.
