### PR TITLE
WebPage: new constants for modifiers keys

### DIFF
--- a/src/modules/webpage.js
+++ b/src/modules/webpage.js
@@ -467,6 +467,14 @@ function decorateNewPage(opts, page) {
     definePageCallbackHandler(page, handlers, "onPrompt", "_getJsPromptCallback");
 
     page.event = {};
+    page.event.modifiers = {
+        shift:  0x02000000,
+        ctrl:   0x04000000,
+        alt:    0x08000000,
+        meta:   0x10000000,
+        keypad: 0x20000000
+    };
+
     page.event.key = {
         '0': 48,
         '1': 49,


### PR DESCRIPTION
Declares in event.modifiers all constants needed for the fifth
parameter of sendEvent.

http://code.google.com/p/phantomjs/issues/detail?id=1056
