### PR TITLE
API for changing the url of the network request.

### DIFF
--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -214,14 +214,14 @@ QNetworkReply *NetworkAccessManager::createRequest(Operation op, const QNetworkR
     data["headers"] = headers;
     data["time"] = QDateTime::currentDateTime();
 
-    JsNetworkRequest* jsNetworkRequest = new JsNetworkRequest(&req, this);
-    emit resourceRequested(data, jsNetworkRequest);
+    JsNetworkRequest jsNetworkRequest(&req, this);
+    emit resourceRequested(data, &jsNetworkRequest);
 
     // Pass duty to the superclass - Nothing special to do here (yet?)
     QNetworkReply *reply = QNetworkAccessManager::createRequest(op, req, outgoingData);
 
     // reparent jsNetworkRequest to make sure that it will be destroyed with QNetworkReply
-    jsNetworkRequest->setParent(reply);
+    jsNetworkRequest.setParent(reply);
 
     m_ids[reply] = m_idCounter;
 

--- a/src/networkaccessmanager.h
+++ b/src/networkaccessmanager.h
@@ -47,11 +47,11 @@ class JsNetworkRequest : public QObject
     Q_OBJECT
 
 public:
-    JsNetworkRequest(QNetworkReply* reply);
+    JsNetworkRequest(QNetworkRequest* request, QObject* parent = 0);
     Q_INVOKABLE void abort();
-
+    Q_INVOKABLE void changeUrl(const QString& url);
 private:
-    QNetworkReply* m_networkReply;
+    QNetworkRequest* m_networkRequest;
 };
 
 class NetworkAccessManager : public QNetworkAccessManager

--- a/test/webpage-spec.js
+++ b/test/webpage-spec.js
@@ -1112,6 +1112,41 @@ describe("WebPage object", function() {
             expect(handled).toEqual(true);
         });
     });
+    
+    it('should change the url of the request', function() {
+        var page = require('webpage').create();
+        var url = 'http://phantomjs.org';
+        var urlToChange = 'http://phantomjs.org/images/phantomjs-logo.png';
+        var fakeImageUrl = 'http://phantomjs.org/images/icon-release.png';
+
+        var handled = false;
+
+        runs(function() {
+            page.onResourceRequested = function(requestData, request) {
+                if (requestData['url'] == urlToChange) {
+                    expect(typeof request).toEqual('object');
+                    expect(typeof request.changeUrl).toEqual('function');
+                    request.changeUrl(fakeImageUrl);
+                }
+            };
+
+            page.onResourceReceived = function(data) {
+                if (data['stage'] === 'end' && data['url'] == fakeImageUrl) {
+                    handled = true;
+                }
+            };
+
+            page.open(url, function(status) {
+                expect(status).toEqual('success');
+            });
+        });
+        
+        waits(3000);
+        
+        runs(function() {
+            expect(handled).toBe(true);
+        });
+    });
 });
 
 describe("WebPage construction with options", function () {


### PR DESCRIPTION
Reworked API for canceling network requests.
Added experimental API for changing the url of the network request.

**Issue:**
http://code.google.com/p/phantomjs/issues/detail?id=539

**General**
This commit brings back 2 signals for `resourceReceived` event:
- at the beginning
- and at the end

(like it was before)

Also, it brings new API for operating on the request's url in `resourceRequested` event.
_Example:_

```
page.onResourceRequested = function(requestData, request) {
    if (requestData['url'] == urlToChange) {
         request.setUrl(fakeUrl);
    }
};
```
