### PR TITLE
unified SSL_CERT_DIR and --ssl-certstore features

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -32,6 +32,7 @@
 #include "config.h"
 
 #include <QDir>
+#include <QFileInfo>
 #include <QWebPage>
 #include <QWebFrame>
 #include <QNetworkProxy>
@@ -63,6 +64,7 @@ static const struct QCommandLineConfigEntry flags[] =
     { QCommandLine::Option, '\0', "script-encoding", "Sets the encoding used for the starting script, default is 'utf8'", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "web-security", "Enables web security, 'yes' (default) or 'no'", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "ssl-protocol", "Sets the SSL protocol (supported protocols: 'SSLv3' (default), 'SSLv2', 'TLSv1', 'any')", QCommandLine::Optional },
+    { QCommandLine::Option, '\0', "ssl-certstore", "Sets the certificate store directory (if none set, uses system default)", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "webdriver", "Starts in 'Remote WebDriver mode' (embedded GhostDriver): '[[<IP>:]<PORT>]' (default '127.0.0.1:8910') ", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "webdriver-selenium-grid-hub", "URL to the Selenium Grid HUB: 'URL_TO_HUB' (default 'none') (NOTE: works only together with '--webdriver') ", QCommandLine::Optional },
     { QCommandLine::Param, '\0', "script", "Script", QCommandLine::Flags(QCommandLine::Optional|QCommandLine::ParameterFence)},
@@ -87,6 +89,10 @@ Config::Config(QObject *parent)
 void Config::init(const QStringList *const args)
 {
     resetToDefaults();
+
+    QByteArray envSslCertDir = qgetenv("SSL_CERT_DIR");
+    if (envSslCertDir != "")
+        setSslCertStore(envSslCertDir);
 
     processArgs(*args);
 }
@@ -513,8 +519,10 @@ void Config::resetToDefaults()
     m_helpFlag = false;
     m_printDebugMessages = false;
     m_sslProtocol = "sslv3";
+    m_sslCertStore.clear();
     m_webdriver = QString();
     m_seleniumGridHub = QString();
+
 }
 
 void Config::setProxyAuthPass(const QString &value)
@@ -658,6 +666,9 @@ void Config::handleOption(const QString &option, const QVariant &value)
     if (option == "ssl-protocol") {
         setSslProtocol(value.toString());
     }
+    if (option == "ssl-certstore") {
+        setSslCertStore(value.toString());
+    }
     if (option == "webdriver") {
         setWebdriver(value.toString());
     }
@@ -689,4 +700,22 @@ QString Config::sslProtocol() const
 void Config::setSslProtocol(const QString& sslProtocolName)
 {
     m_sslProtocol = sslProtocolName.toLower();
+}
+
+QString Config::sslCertStore() const
+{
+    return m_sslCertStore;
+}
+
+void Config::setSslCertStore(const QString& sslCertStorePath)
+{
+    QFileInfo sslPathInfo = QFileInfo(sslCertStorePath);
+    if (sslPathInfo.isDir()) {
+        if (sslCertStorePath.endsWith('/'))
+            m_sslCertStore = sslCertStorePath + "*";
+        else
+            m_sslCertStore = sslCertStorePath + "/*";
+    } else {
+        m_sslCertStore = sslCertStorePath;
+    }
 }

--- a/src/config.h
+++ b/src/config.h
@@ -58,6 +58,7 @@ class Config: public QObject
     Q_PROPERTY(bool javascriptCanOpenWindows READ javascriptCanOpenWindows WRITE setJavascriptCanOpenWindows)
     Q_PROPERTY(bool javascriptCanCloseWindows READ javascriptCanCloseWindows WRITE setJavascriptCanCloseWindows)
     Q_PROPERTY(QString sslProtocol READ sslProtocol WRITE setSslProtocol)
+    Q_PROPERTY(QString sslCertStore READ sslCertStore WRITE setSslCertStore)
     Q_PROPERTY(QString webdriver READ webdriver WRITE setWebdriver)
     Q_PROPERTY(QString seleniumGridHub READ seleniumGridHub WRITE setSeleniumGridHub)
 
@@ -154,6 +155,9 @@ public:
     void setSslProtocol(const QString& sslProtocolName);
     QString sslProtocol() const;
 
+    void setSslCertStore(const QString& sslCertStore);
+    QString sslCertStore() const;
+
     void setWebdriver(const QString& webdriverConfig);
     QString webdriver() const;
     bool isWebdriverMode() const;
@@ -205,6 +209,7 @@ private:
     bool m_javascriptCanOpenWindows;
     bool m_javascriptCanCloseWindows;
     QString m_sslProtocol;
+    QString m_sslCertStore;
     QString m_webdriver;
     QString m_seleniumGridHub;
 };

--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -35,6 +35,8 @@
 #include <QNetworkReply>
 #include <QNetworkRequest>
 #include <QSslSocket>
+#include <QSslCertificate>
+#include <QRegExp>
 
 #include "phantom.h"
 #include "config.h"
@@ -99,6 +101,13 @@ NetworkAccessManager::NetworkAccessManager(QObject *parent, const Config *config
             m_sslConfiguration.setProtocol(QSsl::TlsV1);
         } else if (config->sslProtocol() == "any") {
             m_sslConfiguration.setProtocol(QSsl::AnyProtocol);
+        }
+
+        if (config->sslCertStore() != "") {
+          QList<QSslCertificate> caCerts = QSslCertificate::fromPath(
+              config->sslCertStore(), QSsl::Pem, QRegExp::Wildcard);
+
+            m_sslConfiguration.setCaCertificates(caCerts);
         }
     }
 

--- a/test/webpage-spec.js
+++ b/test/webpage-spec.js
@@ -1025,6 +1025,29 @@ describe("WebPage object", function() {
             expect(handled).toEqual(true);
         });
     });
+
+    it('should fail on secure connection to url with bad cert', function() {
+        var page = require('webpage').create();
+        var url = 'https://tv.eurosport.com/';
+        /* example from:
+         * https://onlinessl.netlock.hu/en/test-center/bad-ssl-certificate-usage.html
+         */
+      
+        var handled = false;
+      
+        runs(function() {
+            page.open(url, function(status) {
+                expect(status == 'success').toEqual(false);
+                handled = true;
+            });
+        });
+          
+        waits(3000);
+        
+        runs(function() {
+            expect(handled).toEqual(true);
+        });
+    });
 });
 
 describe("WebPage construction with options", function () {


### PR DESCRIPTION
As requested, unified the two methods of setting an alternative ssl certificate store and squashed down into one commit.  Neither option messes with the embedded qt build.
