### PR TITLE
Support for specifying request body encoding for WebPage::openUrl

### DIFF
--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -771,10 +771,13 @@ void WebPage::openUrl(const QString &address, const QVariant &op, const QVariant
         operation = op.toString();
 
     if (op.type() == QVariant::Map) {
-        operation = op.toMap().value("operation").toString();
-        body = op.toMap().value("data").toByteArray();
-        if (op.toMap().contains("headers")) {
-            QMapIterator<QString, QVariant> i(op.toMap().value("headers").toMap());
+        QVariantMap settingsMap = op.toMap();
+        operation = settingsMap.value("operation").toString();
+        QString bodyString = settingsMap.value("data").toString();
+        QString encoding = settingsMap.value("encoding").toString().toLower();
+        body = encoding == "utf-8" || encoding == "utf8" ? bodyString.toUtf8() : bodyString.toAscii();
+        if (settingsMap.contains("headers")) {
+            QMapIterator<QString, QVariant> i(settingsMap.value("headers").toMap());
             while (i.hasNext()) {
                 i.next();
                 request.setRawHeader(i.key().toUtf8(), i.value().toString().toUtf8());

--- a/test/webpage-spec.js
+++ b/test/webpage-spec.js
@@ -739,6 +739,49 @@ describe("WebPage object", function() {
 
     });
 
+    it("should process request body properly for POST", function() {
+        var server = require('webserver').create();
+        server.listen(12345, function(request, response) {
+            // echo received request body in response body;
+            response.setHeader('Content-Type', 'text/html; charset=utf-8');
+            response.write(Object.keys(request.post)[0]);
+            response.close();
+        });
+
+        var url = "http://localhost:12345/foo/body";
+
+        var handled = false;
+        runs(function() {
+            expect(handled).toEqual(false);
+            var utfString = '안녕';
+            var openOptions = {
+                operation: 'POST',
+                data:       utfString,
+                encoding:  'utf8'
+            };
+            var pageOptions = {
+                onLoadFinished: function(status) {
+                    expect(status == 'success').toEqual(true);
+                    handled = true;
+
+                    expect(page.plainText).toEqual(utfString);
+                }
+            };
+
+            var page = new WebPage(pageOptions);
+
+            page.openUrl(url, openOptions, {});
+        });
+
+        waits(50);
+
+        runs(function() {
+            expect(handled).toEqual(true);
+            server.close();
+        });
+
+    });
+
     it("should return properly from a 401 status", function() {
         var server = require('webserver').create();
         server.listen(12345, function(request, response) {


### PR DESCRIPTION
doesn't break existing functionality and currently supports only
"utf-8" and "utf8" encodings

Fixes http://code.google.com/p/phantomjs/issues/detail?id=1043
