### PR TITLE
Adding maxTimeout setting and onTimeoutError for webpage

### DIFF
--- a/src/consts.h
+++ b/src/consts.h
@@ -58,7 +58,7 @@
 #define PAGE_SETTINGS_USERNAME              "userName"
 #define PAGE_SETTINGS_PASSWORD              "password"
 #define PAGE_SETTINGS_MAX_AUTH_ATTEMPTS     "maxAuthAttempts"
-#define PAGE_SETTINGS_MAX_TIMEOUT           "maxTimeout"
+#define PAGE_SETTINGS_RESOURCE_TIMEOUT       "resourceTimeout"
 #define PAGE_SETTINGS_WEB_SECURITY_ENABLED  "webSecurityEnabled"
 #define PAGE_SETTINGS_JS_CAN_OPEN_WINDOWS   "javascriptCanOpenWindows"
 #define PAGE_SETTINGS_JS_CAN_CLOSE_WINDOWS  "javascriptCanCloseWindows"

--- a/src/consts.h
+++ b/src/consts.h
@@ -58,6 +58,7 @@
 #define PAGE_SETTINGS_USERNAME              "userName"
 #define PAGE_SETTINGS_PASSWORD              "password"
 #define PAGE_SETTINGS_MAX_AUTH_ATTEMPTS     "maxAuthAttempts"
+#define PAGE_SETTINGS_MAX_TIMEOUT           "maxTimeout"
 #define PAGE_SETTINGS_WEB_SECURITY_ENABLED  "webSecurityEnabled"
 #define PAGE_SETTINGS_JS_CAN_OPEN_WINDOWS   "javascriptCanOpenWindows"
 #define PAGE_SETTINGS_JS_CAN_CLOSE_WINDOWS  "javascriptCanCloseWindows"

--- a/src/modules/webpage.js
+++ b/src/modules/webpage.js
@@ -254,6 +254,8 @@ function decorateNewPage(opts, page) {
     
     definePageSignalHandler(page, handlers, "onResourceError", "resourceError");
 
+    definePageSignalHandler(page, handlers, "onTimeoutError", "timeoutError");
+
     definePageSignalHandler(page, handlers, "onAlert", "javaScriptAlertSent");
 
     definePageSignalHandler(page, handlers, "onConsoleMessage", "javaScriptConsoleMessageSent");

--- a/src/modules/webpage.js
+++ b/src/modules/webpage.js
@@ -254,7 +254,7 @@ function decorateNewPage(opts, page) {
     
     definePageSignalHandler(page, handlers, "onResourceError", "resourceError");
 
-    definePageSignalHandler(page, handlers, "onTimeoutError", "timeoutError");
+    definePageSignalHandler(page, handlers, "onResourceTimeout", "resourceTimeout");
 
     definePageSignalHandler(page, handlers, "onAlert", "javaScriptAlertSent");
 

--- a/src/networkaccessmanager.h
+++ b/src/networkaccessmanager.h
@@ -37,10 +37,20 @@
 #include <QNetworkReply>
 #include <QSet>
 #include <QSslConfiguration>
+#include <QTimer>
 
 class Config;
 class QNetworkDiskCache;
 class QSslConfiguration;
+
+class NetworkTimeout : public QTimer
+{
+    Q_OBJECT
+
+public:
+  NetworkTimeout(QObject *parent = 0);
+  QNetworkReply *reply;
+};
 
 class JsNetworkRequest : public QObject
 {
@@ -62,6 +72,7 @@ public:
     void setUserName(const QString &userName);
     void setPassword(const QString &password);
     void setMaxAuthAttempts(int maxAttempts);
+    void setMaxTimeout(int maxTimeout);
     void setCustomHeaders(const QVariantMap &headers);
     QVariantMap customHeaders() const;
 
@@ -71,6 +82,7 @@ protected:
     bool m_ignoreSslErrors;
     int m_authAttempts;
     int m_maxAuthAttempts;
+    int m_maxTimeout;
     QString m_userName;
     QString m_password;
     QNetworkReply *createRequest(Operation op, const QNetworkRequest & req, QIODevice * outgoingData = 0);
@@ -80,6 +92,7 @@ signals:
     void resourceRequested(const QVariant& data, QObject *);
     void resourceReceived(const QVariant& data);
     void resourceError(const QVariant& data);
+    void timeoutError(const QVariant& data);
 
 private slots:
     void handleStarted();
@@ -87,6 +100,7 @@ private slots:
     void provideAuthentication(QNetworkReply *reply, QAuthenticator *authenticator);
     void handleSslErrors(const QList<QSslError> &errors);
     void handleNetworkError();
+    void handleTimeout();
 
 private:
     QHash<QNetworkReply*, int> m_ids;

--- a/src/networkaccessmanager.h
+++ b/src/networkaccessmanager.h
@@ -43,13 +43,14 @@ class Config;
 class QNetworkDiskCache;
 class QSslConfiguration;
 
-class NetworkTimeout : public QTimer
+class TimeoutTimer : public QTimer
 {
     Q_OBJECT
 
 public:
-  NetworkTimeout(QObject *parent = 0);
+  TimeoutTimer(QObject *parent = 0);
   QNetworkReply *reply;
+  QVariantMap data;
 };
 
 class JsNetworkRequest : public QObject
@@ -72,7 +73,7 @@ public:
     void setUserName(const QString &userName);
     void setPassword(const QString &password);
     void setMaxAuthAttempts(int maxAttempts);
-    void setMaxTimeout(int maxTimeout);
+    void setResourceTimeout(int resourceTimeout);
     void setCustomHeaders(const QVariantMap &headers);
     QVariantMap customHeaders() const;
 
@@ -82,7 +83,7 @@ protected:
     bool m_ignoreSslErrors;
     int m_authAttempts;
     int m_maxAuthAttempts;
-    int m_maxTimeout;
+    int m_resourceTimeout;
     QString m_userName;
     QString m_password;
     QNetworkReply *createRequest(Operation op, const QNetworkRequest & req, QIODevice * outgoingData = 0);
@@ -92,7 +93,7 @@ signals:
     void resourceRequested(const QVariant& data, QObject *);
     void resourceReceived(const QVariant& data);
     void resourceError(const QVariant& data);
-    void timeoutError(const QVariant& data);
+    void resourceTimeout(const QVariant& data);
 
 private slots:
     void handleStarted();

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -384,8 +384,8 @@ WebPage::WebPage(QObject *parent, const QUrl &baseUrl)
             SIGNAL(resourceReceived(QVariant)));
     connect(m_networkAccessManager, SIGNAL(resourceError(QVariant)),
             SIGNAL(resourceError(QVariant)));
-    connect(m_networkAccessManager, SIGNAL(timeoutError(QVariant)),
-            SIGNAL(timeoutError(QVariant)));
+    connect(m_networkAccessManager, SIGNAL(resourceTimeout(QVariant)),
+            SIGNAL(resourceTimeout(QVariant)));
 
     m_customWebPage->setViewportSize(QSize(400, 300));
 }
@@ -573,8 +573,8 @@ void WebPage::applySettings(const QVariantMap &def)
     if (def.contains(PAGE_SETTINGS_MAX_AUTH_ATTEMPTS))
         m_networkAccessManager->setMaxAuthAttempts(def[PAGE_SETTINGS_MAX_AUTH_ATTEMPTS].toInt());
 
-    if (def.contains(PAGE_SETTINGS_MAX_TIMEOUT))
-        m_networkAccessManager->setMaxTimeout(def[PAGE_SETTINGS_MAX_TIMEOUT].toInt());
+    if (def.contains(PAGE_SETTINGS_RESOURCE_TIMEOUT))
+        m_networkAccessManager->setResourceTimeout(def[PAGE_SETTINGS_RESOURCE_TIMEOUT].toInt());
 
 }
 

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -384,6 +384,8 @@ WebPage::WebPage(QObject *parent, const QUrl &baseUrl)
             SIGNAL(resourceReceived(QVariant)));
     connect(m_networkAccessManager, SIGNAL(resourceError(QVariant)),
             SIGNAL(resourceError(QVariant)));
+    connect(m_networkAccessManager, SIGNAL(timeoutError(QVariant)),
+            SIGNAL(timeoutError(QVariant)));
 
     m_customWebPage->setViewportSize(QSize(400, 300));
 }
@@ -570,6 +572,10 @@ void WebPage::applySettings(const QVariantMap &def)
 
     if (def.contains(PAGE_SETTINGS_MAX_AUTH_ATTEMPTS))
         m_networkAccessManager->setMaxAuthAttempts(def[PAGE_SETTINGS_MAX_AUTH_ATTEMPTS].toInt());
+
+    if (def.contains(PAGE_SETTINGS_MAX_TIMEOUT))
+        m_networkAccessManager->setMaxTimeout(def[PAGE_SETTINGS_MAX_TIMEOUT].toInt());
+
 }
 
 QString WebPage::userAgent() const

--- a/src/webpage.h
+++ b/src/webpage.h
@@ -464,6 +464,7 @@ signals:
     void resourceRequested(const QVariant &requestData, QObject *request);
     void resourceReceived(const QVariant &resource);
     void resourceError(const QVariant &errorData);
+    void timeoutError(const QVariant &errorData);
     void urlChanged(const QUrl &url);
     void navigationRequested(const QUrl &url, const QString &navigationType, bool navigationLocked, bool isMainFrame);
     void rawPageCreated(QObject *page);

--- a/src/webpage.h
+++ b/src/webpage.h
@@ -464,7 +464,7 @@ signals:
     void resourceRequested(const QVariant &requestData, QObject *request);
     void resourceReceived(const QVariant &resource);
     void resourceError(const QVariant &errorData);
-    void timeoutError(const QVariant &errorData);
+    void resourceTimeout(const QVariant &errorData);
     void urlChanged(const QUrl &url);
     void navigationRequested(const QUrl &url, const QString &navigationType, bool navigationLocked, bool isMainFrame);
     void rawPageCreated(QObject *page);

--- a/test/webpage-spec.js
+++ b/test/webpage-spec.js
@@ -1554,15 +1554,15 @@ describe("WebPage opening and closing of windows/child-pages", function(){
 });
 
 describe("WebPage timeout handling", function(){
-    it("should call 'onTimeoutError' on timeout", function(){
+    it("should call 'onResourceTimeout' on timeout", function(){
         var p = require("webpage").create(),
             spy;
 
         // assume that requesting a web page will take longer than a millisecond
-        p.settings.maxTimeout = 1;
+        p.settings.resourceTimeout = 1;
 
-        spy = jasmine.createSpy("onTimeoutError spy");
-        p.onTimeoutError = spy;
+        spy = jasmine.createSpy("onResourceTimeout spy");
+        p.onResourceTimeout = spy;
 
         expect(spy.calls.length).toEqual(0);
 
@@ -1570,7 +1570,7 @@ describe("WebPage timeout handling", function(){
 
         waitsFor(function() {
             return spy.calls.length==1;
-        }, "after 1+ milliseconds 'onTimeoutError' should have been invoked", 10);
+        }, "after 1+ milliseconds 'onResourceTimeout' should have been invoked", 10);
 
         runs(function() {
             expect(spy).toHaveBeenCalled();         //< called

--- a/test/webpage-spec.js
+++ b/test/webpage-spec.js
@@ -1237,6 +1237,18 @@ describe("WebPage construction with options", function () {
         checkScrollPosition(new WebPage(opts), opts.scrollPosition);
     });
 
+    describe("specifying timeout", function () {
+        var opts = {
+            settings: {
+                timeout: 100 // time in ms
+            }
+        };
+        var page = new WebPage(opts);
+        it("should have timeout as "+opts.settings.timeout,function () {
+            expect(page.settings.timeout).toEqual(opts.settings.timeout);
+        });
+    });
+
     describe("specifying userAgent", function () {
         var opts = {
             settings: {
@@ -1538,6 +1550,34 @@ describe("WebPage opening and closing of windows/child-pages", function(){
             expect(p.pagesWindowName).toEqual(["bing"]);
             p.close();
         });
+    });
+});
+
+describe("WebPage timeout handling", function(){
+    it("should call 'onTimeoutError' on timeout", function(){
+        var p = require("webpage").create(),
+            spy;
+
+        // assume that requesting a web page will take longer than a millisecond
+        p.settings.maxTimeout = 1;
+
+        spy = jasmine.createSpy("onTimeoutError spy");
+        p.onTimeoutError = spy;
+
+        expect(spy.calls.length).toEqual(0);
+
+        p.open("http://www.google.com:81/");
+
+        waitsFor(function() {
+            return spy.calls.length==1;
+        }, "after 1+ milliseconds 'onTimeoutError' should have been invoked", 10);
+
+        runs(function() {
+            expect(spy).toHaveBeenCalled();         //< called
+            expect(spy.calls.length).toEqual(1);    //< only once
+            expect(1).toEqual(1);
+        });
+
     });
 });
 


### PR DESCRIPTION
When requesting a page using page.open() there is no way of setting a maximum timeout.

I added a setting so you can use page.settings.maxTimeout = _integer_ ms. If the request times out it is aborted. The event can be caught using page.onTimeoutError.

This was discussed here: https://code.google.com/p/phantomjs/issues/detail?id=1129
