### PR TITLE
Proposal for issue on Data URI in HAR file with netsniff.hs

### DIFF
--- a/examples/netsniff.js
+++ b/examples/netsniff.js
@@ -25,6 +25,11 @@ function createHAR(address, title, startTime, resources)
             return;
         }
 
+		// fix issue with Data URI reported in HAR file
+		if (request.url.match(/(^data:image\/.*)/i)) {
+			return;
+		}
+
         entries.push({
             startedDateTime: request.time.toISOString(),
             time: endReply.time - request.time,

--- a/examples/netsniff.js
+++ b/examples/netsniff.js
@@ -25,10 +25,11 @@ function createHAR(address, title, startTime, resources)
             return;
         }
 
-		// fix issue with Data URI reported in HAR file
-		if (request.url.match(/(^data:image\/.*)/i)) {
-			return;
-		}
+        // Exclude Data URI from HAR file because
+        // they aren't included in specification
+        if (request.url.match(/(^data:image\/.*)/i)) {
+            return;
+	}
 
         entries.push({
             startedDateTime: request.time.toISOString(),


### PR DESCRIPTION
Proposal for this issue: https://github.com/ariya/phantomjs/issues/10740

I think Data URI resources aren't part of information useful for HAR file.

At this time, it's impossible to parse HAR file with "HARViewer" without this fix.
