### PR TITLE
Fix loading modules from an absolute path on Windows.

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -216,7 +216,7 @@ phantom.callback = function(callback) {
 
         if (request[0] === '.') {
             paths.push(fs.absolute(joinPath(phantom.webdriverMode ? ":/ghostdriver" : this.dirname, request)));
-        } else if (request[0] === '/') {
+        } else if (fs.isAbsolute(request)) {
             paths.push(fs.absolute(request));
         } else {
             // first look in PhantomJS modules

--- a/test/require/require_spec.js
+++ b/test/require/require_spec.js
@@ -154,4 +154,10 @@ describe("require()", function() {
             });
         });
     });
+    
+    describe("when path is absolute", function() {
+        it("loads modules from the absolute path", function() {
+            require(fs.absolute('dummy')).should.equal('spec/dummy');
+        });
+    });
 });


### PR DESCRIPTION
Don't check the module path using Linux-style path checking.

Issue: https://github.com/ariya/phantomjs/issues/11165
