### PR TITLE
Use UTF-8 encoding for std{in,out,err}

### DIFF
--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -123,6 +123,9 @@ bool File::write(const QString &data)
     if ( m_fileStream ) {
         // text file
         (*m_fileStream) << data;
+        if (_isUnbuffered()) {
+          m_fileStream->flush();
+        }
         return true;
     } else {
         // binary file
@@ -211,6 +214,13 @@ void File::close()
         m_file = NULL;
     }
     deleteLater();
+}
+
+// private:
+
+bool File::_isUnbuffered() const
+{
+    return m_file->openMode() & QIODevice::Unbuffered;
 }
 
 

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -65,6 +65,8 @@ public slots:
     void close();
 
 private:
+    bool _isUnbuffered() const;
+
     QFile *m_file;
     QTextStream *m_fileStream;
 };

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -34,6 +34,7 @@
 #include <QSslSocket>
 #include <QSysInfo>
 #include <QVariantMap>
+#include <QTextCodec>
 
 #include "../env.h"
 
@@ -176,7 +177,7 @@ QObject *System::_stdout() {
     if ((File *)NULL == m_stdout) {
         QFile *f = new QFile();
         f->open(stdout, QIODevice::WriteOnly | QIODevice::Unbuffered);
-        m_stdout = new File(f, (QTextCodec *)NULL, this);
+        m_stdout = createFileInstance(f);
     }
 
     return m_stdout;
@@ -186,7 +187,7 @@ QObject *System::_stderr() {
     if ((File *)NULL == m_stderr) {
         QFile *f = new QFile();
         f->open(stderr, QIODevice::WriteOnly | QIODevice::Unbuffered);
-        m_stderr = new File(f, (QTextCodec *)NULL, this);
+        m_stderr = createFileInstance(f);
     }
 
     return m_stderr;
@@ -196,8 +197,16 @@ QObject *System::_stdin() {
     if ((File *)NULL == m_stdin) {
         QFile *f = new QFile();
         f->open(stdin, QIODevice::ReadOnly | QIODevice::Unbuffered);
-        m_stdin = new File(f, (QTextCodec *)NULL, this);
+        m_stdin = createFileInstance(f);
     }
 
     return m_stdin;
+}
+
+// private:
+
+File *System::createFileInstance(QFile *f)
+{
+    QTextCodec *codec = QTextCodec::codecForName("UTF-8");
+    return new File(f, codec, this);
 }

--- a/src/system.h
+++ b/src/system.h
@@ -77,6 +77,8 @@ public:
     QObject *_stdin();
 
 private:
+    File *createFileInstance(QFile *f);
+
     QStringList m_args;
     QVariant m_env;
     QMap<QString, QVariant> m_os;


### PR DESCRIPTION
This fixes issue #11162.

`File` constructor takes a `QTextCodec *`, codec; but, if codec is `NULL`, then it assumes "binary" mode, which causes non-ASCII characters to be converted to NUL (`\0`) in `File::write`.

This change passes the codec for UTF-8 to the `File` constructor for the `std{in,out,err}` instances, thus opening them in _text mode_.
