### PR TITLE
Fix for #11160 (Wrong PNG/JPEG resolution on linux)

### DIFF
--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -972,6 +972,8 @@ QString WebPage::renderBase64(const QByteArray &format)
     return "";
 }
 
+#define PHANTOMJS_PDF_DPI 72            // Different defaults. OSX: 72, X11: 75(?), Windows: 96
+
 QImage WebPage::renderImage()
 {
     QSize contentsSize = m_mainFrame->contentsSize();
@@ -990,6 +992,11 @@ QImage WebPage::renderImage()
 #endif
 
     QImage buffer(frameRect.size(), format);
+    
+    int dpm = PHANTOMJS_PDF_DPI / 0.0254;
+    buffer.setDotsPerMeterX(dpm);
+    buffer.setDotsPerMeterY(dpm);
+    
     buffer.fill(qRgba(255, 255, 255, 0));
 
     QPainter painter;
@@ -1027,8 +1034,6 @@ QImage WebPage::renderImage()
     m_customWebPage->setViewportSize(viewportSize);
     return buffer;
 }
-
-#define PHANTOMJS_PDF_DPI 72            // Different defaults. OSX: 72, X11: 75(?), Windows: 96
 
 qreal stringToPointSize(const QString &string)
 {


### PR DESCRIPTION
Fix png/jpg resolution metadata which caused the images to render stretched.
