### PR TITLE
Showing postData in onResourceRequested callback

### DIFF
--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -37,6 +37,7 @@
 #include <QSslSocket>
 #include <QSslCertificate>
 #include <QRegExp>
+#include <limits>
 
 #include "phantom.h"
 #include "config.h"
@@ -202,9 +203,11 @@ QNetworkReply *NetworkAccessManager::createRequest(Operation op, const QNetworkR
     // Get the URL string before calling the superclass. Seems to work around
     // segfaults in Qt 4.8: https://gist.github.com/1430393
     QByteArray url = req.url().toEncoded();
+    QByteArray postData;
 
     // http://code.google.com/p/phantomjs/issues/detail?id=337
     if (op == QNetworkAccessManager::PostOperation) {
+        if (outgoingData) postData = outgoingData->peek(std::numeric_limits < qint64 >::max());
         QString contentType = req.header(QNetworkRequest::ContentTypeHeader).toString();
         if (contentType.isEmpty()) {
             req.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
@@ -233,6 +236,7 @@ QNetworkReply *NetworkAccessManager::createRequest(Operation op, const QNetworkR
     data["url"] = url.data();
     data["method"] = toString(op);
     data["headers"] = headers;
+    if (op == QNetworkAccessManager::PostOperation) data["postData"] = postData.data();
     data["time"] = QDateTime::currentDateTime();
 
     JsNetworkRequest jsNetworkRequest(&req, this);

--- a/test/webpage-spec.js
+++ b/test/webpage-spec.js
@@ -782,6 +782,30 @@ describe("WebPage object", function() {
 
     });
 
+    it("should include post data to request object", function() {
+      var server = require('webserver').create();
+      server.listen(12345, function(request, response) {
+          response.write(JSON.stringify(request.headers));
+          response.close();
+      });
+
+      runs(function() {
+          var pageOptions = {
+            onResourceRequested: function (request) {
+              expect(request.postData).toEqual("ab=cd");
+            }
+          };
+          var page = new WebPage(pageOptions);
+          page.open("http://localhost:12345/", 'post', "ab=cd");
+      });
+
+      waits(50);
+
+      runs(function() {
+          server.close();
+      });
+    });
+
     it("should return properly from a 401 status", function() {
         var server = require('webserver').create();
         server.listen(12345, function(request, response) {


### PR DESCRIPTION
This is same commit as in #246 but with fresh source tree

This code add property `postData` to request object, so we can see outgoing POST data. It's useful when filling and submitting forms in others' websites

Issue #10158
