### PR TITLE
Always link with CJK text codecs on Mac and linux*

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,9 +42,6 @@
 #include <QApplication>
 #include <QSslSocket>
 
-#ifdef Q_OS_WIN32
-using namespace google_breakpad;
-static google_breakpad::ExceptionHandler* eh;
 #if !defined(QT_SHARED) && !defined(QT_DLL)
 #include <QtPlugin>
 
@@ -52,6 +49,12 @@ Q_IMPORT_PLUGIN(qcncodecs)
 Q_IMPORT_PLUGIN(qjpcodecs)
 Q_IMPORT_PLUGIN(qkrcodecs)
 Q_IMPORT_PLUGIN(qtwcodecs)
+#endif
+
+#ifdef Q_OS_WIN32
+using namespace google_breakpad;
+static google_breakpad::ExceptionHandler* eh;
+#if !defined(QT_SHARED) && !defined(QT_DLL)
 Q_IMPORT_PLUGIN(qico)
 #endif
 #endif

--- a/src/phantomjs.pro
+++ b/src/phantomjs.pro
@@ -67,6 +67,12 @@ linux*|mac {
       breakpad/src/common/convert_UTF.c \
       breakpad/src/common/md5.cc \
       breakpad/src/common/string_conversion.cc 
+
+    QTPLUGIN += \
+        qcncodecs \
+        qjpcodecs \
+        qkrcodecs \
+        qtwcodecs
 }
 
 linux* {

--- a/src/qt/preconfig.sh
+++ b/src/qt/preconfig.sh
@@ -108,3 +108,8 @@ export MAKEFLAGS=-j$COMPILE_JOBS
 
 ./configure -prefix $PWD $QT_CFG
 make -j$COMPILE_JOBS
+
+# Build text codecs
+pushd src/plugins/codecs/
+make -j$COMPILE_JOBS
+popd

--- a/test/cjk-text-codecs.js
+++ b/test/cjk-text-codecs.js
@@ -1,0 +1,48 @@
+describe("WebPage CJK support", function () {
+    var texts = [
+        new Text("Shift_JIS", "g3SDQIOTg2eDgA==", "ファントム")
+    ,   new Text("EUC-JP", "pdWloaXzpcil4A0K", "ファントム")
+    ,   new Text("ISO-2022-JP", "GyRCJVUlISVzJUglYBsoQg0K", "ファントム")
+    ,   new Text("Big5", "pNu2SA0K", "幻象")
+    ,   new Text("GBK", "u8PP8w0K", "幻象")
+    ,   new Text("EUC-KR", "yK+/tQ==", "환영")
+    ];
+
+    texts.forEach(function (t) {
+        it(t.codec, function() {
+            var decodedText = -1;
+            var page = new WebPage();
+
+            page.open(t.dataUrl(), function(status) {
+                decodedText = page.evaluate(function() {
+                    return document.getElementsByTagName("pre")[0].innerText;
+                });
+                page.close();
+            });
+
+            waitsFor(function () {
+                return -1 !== decodedText;
+            }, "Text not decoded within three seconds", 3000);
+
+            runs(function () {
+                expect(t.check(decodedText)).toBeTruthy();
+            });
+        });
+    });
+
+    function Text(codec, base64, reference) {
+        this.codec = codec;
+        this.base64 = base64;
+        this.reference = reference;
+    }
+
+    Text.prototype.dataUrl = function () {
+        return "data:text/plain;charset=" + this.codec + ";base64," + this.base64;
+    };
+
+    Text.prototype.check = function (decodedText) {
+        return decodedText.match("^" + this.reference) == this.reference;
+    };
+});
+
+// vim:ts=4:sw=4:sts=4:et:

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -72,6 +72,7 @@ phantom.injectJs("./system-spec.js");
 phantom.injectJs("./webkit-spec.js");
 require("./module_spec.js");
 require("./require/require_spec.js");
+require("./cjk-text-codecs.js");
 
 // Launch tests
 var jasmineEnv = jasmine.getEnv();

--- a/test/webpage-spec.js
+++ b/test/webpage-spec.js
@@ -1330,31 +1330,6 @@ describe("WebPage construction with options", function () {
         };
         checkViewportSize(new WebPage(opts), opts.viewportSize);
     });
-
-    var texts = [
-        { codec: 'Shift_JIS', base64: 'g3SDQIOTg2eDgA==', reference: 'ファントム'},
-        { codec: 'EUC-JP', base64: 'pdWloaXzpcil4A0K', reference: 'ファントム'},
-        { codec: 'ISO-2022-JP', base64: 'GyRCJVUlISVzJUglYBsoQg0K', reference: 'ファントム'},
-        { codec: 'Big5', base64: 'pNu2SA0K', reference: '幻象'},
-        { codec: 'GBK', base64: 'u8PP8w0K', reference: '幻象'}
-    ];
-    for (var i = 0; i < texts.length; ++i) {
-        describe("Text codec support", function() {
-            var text = texts[i];
-            var dataUrl = 'data:text/plain;charset=' + text.codec + ';base64,' + text.base64;
-            var page = new WebPage();
-            var decodedText;
-            page.open(dataUrl, function(status) {
-                decodedText = page.evaluate(function() {
-                    return document.getElementsByTagName('pre')[0].innerText;
-                });
-                page.close();
-            });
-            it("Should support text codec " + text.codec, function() {
-                expect(decodedText.match("^" + text.reference) == text.reference).toEqual(true);
-            });
-        });
-    }
 });
 
 describe("WebPage switch frame of execution (deprecated API)", function(){


### PR DESCRIPTION
Fixes #10249 ("Japanese web pages not rendered properly by static Mac binary").

**NOTE**: While this should fix #10249, all supported build environments need to be tested with and without these modifications!
