### PR TITLE
Add Shim for Function.prototype.bind()

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -314,6 +314,32 @@ phantom.callback = function(callback) {
         if (!phantom.webdriverMode) {
             require('_coffee-script');
         }
+
+        // Add shim for Function.prototype.bind() from:
+        //    https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Function/bind#Compatibility
+        if (!Function.prototype.bind) {
+            Function.prototype.bind = function (oThis) {
+                if (typeof this !== "function") {
+                    // closest thing possible to the ECMAScript 5 internal IsCallable function
+                    throw new TypeError("Function.prototype.bind - what is trying to be bound is not callable");
+                }
+
+                var aArgs = Array.prototype.slice.call(arguments, 1),
+                    fToBind = this,
+                    fNOP = function () {},
+                    fBound = function () {
+                        return fToBind.apply(this instanceof fNOP && oThis
+                                               ? this
+                                               : oThis,
+                                             aArgs.concat(Array.prototype.slice.call(arguments)));
+                    };
+
+                fNOP.prototype = this.prototype;
+                fBound.prototype = new fNOP();
+
+                return fBound;
+            };
+        }
     }());
 }());
 

--- a/src/modules/webpage.js
+++ b/src/modules/webpage.js
@@ -381,6 +381,34 @@ function decorateNewPage(opts, page) {
         return this.evaluateJavaScript(str);
     };
 
+    // Add shim for Function.prototype.bind() from:
+    //    https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Function/bind#Compatibility
+    page.evaluate(function () {
+        if (!Function.prototype.bind) {
+            Function.prototype.bind = function (oThis) {
+                if (typeof this !== "function") {
+                    // closest thing possible to the ECMAScript 5 internal IsCallable function
+                    throw new TypeError("Function.prototype.bind - what is trying to be bound is not callable");
+                }
+
+                var aArgs = Array.prototype.slice.call(arguments, 1),
+                    fToBind = this,
+                    fNOP = function () {},
+                    fBound = function () {
+                        return fToBind.apply(this instanceof fNOP && oThis
+                                               ? this
+                                               : oThis,
+                                             aArgs.concat(Array.prototype.slice.call(arguments)));
+                    };
+
+                fNOP.prototype = this.prototype;
+                fBound.prototype = new fNOP();
+
+                return fBound;
+            };
+        }
+    });
+
     /**
      * evaluate a function in the page, asynchronously
      * NOTE: it won't return anything: the execution is asynchronous respect to the call.

--- a/test/Function.prototype.js
+++ b/test/Function.prototype.js
@@ -1,0 +1,35 @@
+describe("Function.prototype", function () {
+    it("should have bind() in phantom context", function () {
+        expect(typeof Function.prototype.bind).toEqual("function");
+    });
+
+    it("should have bind() in WebPage context", function () {
+        var s = require("webserver").create();
+        s.listen(12345, function(request, response) {
+            setTimeout(function() {
+                response.statusCode = 200;
+                response.write("<html><body>Loaded!</body></html>");
+                response.close();
+            }, 500);
+        });
+
+        var bind = -1;
+
+        var p = require("webpage").create();
+        p.open("http//localhost:12345", function (status) {
+            bind = p.evaluate(function () {
+                return typeof Function.prototype.bind;
+            });
+            p.close();
+        });
+
+        waitsFor(function () {
+            return -1 !== bind;
+        }, "Page was never opened", 3000);
+
+        runs(function () {
+            s.close();
+            expect(bind).toEqual("function");
+        });
+    });
+});

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -72,6 +72,7 @@ phantom.injectJs("./system-spec.js");
 phantom.injectJs("./webkit-spec.js");
 require("./module_spec.js");
 require("./require/require_spec.js");
+require("./Function.prototype.js");
 
 // Launch tests
 var jasmineEnv = jasmine.getEnv();


### PR DESCRIPTION
This change fixes #10522 by adding a shim for `Function.prototype.bind()`, which can be an intermediate step until we get the native implementation from a newer WebKit.
