### PR TITLE
Fix compilation with MSVC 2010

### DIFF
--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -207,7 +207,7 @@ QNetworkReply *NetworkAccessManager::createRequest(Operation op, const QNetworkR
 
     // http://code.google.com/p/phantomjs/issues/detail?id=337
     if (op == QNetworkAccessManager::PostOperation) {
-        if (outgoingData) postData = outgoingData->peek(std::numeric_limits < qint64 >::max());
+        if (outgoingData) postData = outgoingData->peek((std::numeric_limits<qint64>::max)());
         QString contentType = req.header(QNetworkRequest::ContentTypeHeader).toString();
         if (contentType.isEmpty()) {
             req.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");


### PR DESCRIPTION
Issue: https://github.com/ariya/phantomjs/issues/10158
This bug introduced by the macro max( ) defined in <windef.h>.
It replaces max( ) with another statement but still preceded by numeric_limits<Type>::
The workaround is to use the parentheses.
