### PR TITLE
Sync std{in,out,err} Encodings with `Terminal`

### DIFF
--- a/src/encoding.h
+++ b/src/encoding.h
@@ -46,11 +46,11 @@ public:
     QString getName() const;
     void setEncoding(const QString &encoding);
 
+    QTextCodec *getCodec() const;
+
     static const Encoding UTF8;
 
 private:
-    QTextCodec *getCodec() const;
-
     QTextCodec *m_codec;
     static const QByteArray DEFAULT_CODEC_NAME;
 };

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -216,6 +216,49 @@ void File::close()
     deleteLater();
 }
 
+bool File::setEncoding(const QString &encoding) {
+    if (encoding.isEmpty() || encoding.isNull()) {
+        return false;
+    }
+
+    // "Binary" mode doesn't use/need text codecs
+    if ((QTextStream *)NULL == m_fileStream) {
+        // TODO: Should we switch to "text" mode?
+        return false;
+    }
+
+    // Since there can be multiple names for the same codec (i.e., "utf8" and
+    // "utf-8"), we need to get the codec in the system first and use its
+    // canonical name
+    QTextCodec *codec = QTextCodec::codecForName(encoding.toAscii());
+    if ((QTextCodec *)NULL == codec) {
+      return false;
+    }
+
+    // Check whether encoding actually needs to be changed
+    const QString encodingBeforeUpdate(m_fileStream->codec()->name());
+    if (0 == encodingBeforeUpdate.compare(QString(codec->name()), Qt::CaseInsensitive)) {
+        return false;
+    }
+
+    m_fileStream->setCodec(codec);
+
+    // Return whether update was successful
+    const QString encodingAfterUpdate(m_fileStream->codec()->name());
+    return 0 != encodingBeforeUpdate.compare(encodingAfterUpdate, Qt::CaseInsensitive);
+}
+
+QString File::getEncoding() const
+{
+    QString encoding;
+
+    if ((QTextStream *)NULL != m_fileStream) {
+        encoding = QString(m_fileStream->codec()->name());
+    }
+
+    return encoding;
+}
+
 // private:
 
 bool File::_isUnbuffered() const

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -64,6 +64,9 @@ public slots:
     void flush();
     void close();
 
+    QString getEncoding() const;
+    bool setEncoding(const QString &encoding);
+
 private:
     bool _isUnbuffered() const;
 

--- a/src/system.h
+++ b/src/system.h
@@ -76,6 +76,9 @@ public:
     // system.stdin
     QObject *_stdin();
 
+private slots:
+    void _onTerminalEncodingChanged(const QString &encoding);
+
 private:
     File *createFileInstance(QFile *f);
 

--- a/src/terminal.h
+++ b/src/terminal.h
@@ -39,14 +39,19 @@
 
 class Terminal: public QObject
 {
+    Q_OBJECT
+
 public:
     static Terminal *instance();
 
     QString getEncoding() const;
-    void setEncoding(const QString &encoding);
+    bool setEncoding(const QString &encoding);
 
     void cout(const QString &string, const bool newline = true) const;
     void cerr(const QString &string, const bool newline = true) const;
+
+signals:
+    void encodingChanged(const QString &encoding);
 
 private:
     void output(std::ostream &out, const QString &string, const bool newline) const;

--- a/test/fs-spec-01.js
+++ b/test/fs-spec-01.js
@@ -59,6 +59,74 @@ describe("Basic Files API (read, write, remove, ...)", function() {
         expect(content).toEqual("hello\nworld\nasdf\n");
     });
 
+    it("should be able to get the encoding (default: UTF-8)", function() {
+        var encoding = "";
+        try {
+            var f = fs.open(FILENAME, "r");
+            encoding = f.getEncoding();
+            f.close();
+        } catch (e) {
+            console.log(e);
+        }
+        expect(encoding).toEqual("UTF-8");
+    });
+
+    it("should be able to set the encoding via options", function() {
+        var encoding = "";
+        try {
+            var f = fs.open(FILENAME, {
+              charset: "UTF-8"
+            , mode: "r"
+            });
+            encoding = f.getEncoding();
+            f.close();
+        } catch (e) {
+            console.log(e);
+        }
+        expect(encoding).toEqual("UTF-8");
+
+        try {
+            var f = fs.open(FILENAME, {
+              charset: "SJIS"
+            , mode: "r"
+            });
+            encoding = f.getEncoding();
+            f.close();
+        } catch (e) {
+            console.log(e);
+        }
+        expect(encoding).toEqual("Shift_JIS");
+    });
+
+    it("should be able to change the encoding", function() {
+        var encoding = "";
+        try {
+            var f = fs.open(FILENAME, {
+              charset: "UTF-8"
+            , mode: "r"
+            });
+            f.setEncoding("utf8");
+            encoding = f.getEncoding();
+            f.close();
+        } catch (e) {
+            console.log(e);
+        }
+        expect(encoding).toEqual("UTF-8");
+
+        try {
+            var f = fs.open(FILENAME, {
+              charset: "SJIS"
+            , mode: "r"
+            });
+            f.setEncoding("eucjp");
+            encoding = f.getEncoding();
+            f.close();
+        } catch (e) {
+            console.log(e);
+        }
+        expect(encoding).toEqual("EUC-JP");
+    });
+
     it("should be able to copy a file", function() {
         expect(fs.exists(FILENAME_COPY)).toBeFalsy();
         fs.copy(FILENAME, FILENAME_COPY);


### PR DESCRIPTION
This is a spin off from [#11168](https://github.com/ariya/phantomjs/pull/11168#issuecomment-15792650).

This modification keeps the `system.std{in,out,err}` encodings in sync with the `Terminal`.  That is, whenever the `Terminal` encoding gets changed, that update will now be propagated to the `System` module.

_SIDE NOTE:_  Should the reverse case (propagate `system.std{in,out,err}` encoding change to `Terminal`) be handled?
