### PR TITLE
Allow specify disk-cache location

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -58,6 +58,7 @@ static const struct QCommandLineConfigEntry flags[] =
     { QCommandLine::Option, '\0', "local-storage-quota", "Sets the maximum size of the offline local storage (in KB)", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "local-to-remote-url-access", "Allows local content to access remote URL: 'true' or 'false' (default)", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "max-disk-cache-size", "Limits the size of the disk cache (in KB)", QCommandLine::Optional },
+    { QCommandLine::Option, '\0', "disk-cache-path", "Specifies the location for disk cache", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "output-encoding", "Sets the encoding for the terminal output, default is 'utf8'", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "remote-debugger-port", "Starts the script in a debug harness and listens on the specified port", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "remote-debugger-autorun", "Runs the script in the debugger immediately: 'true' or 'false' (default)", QCommandLine::Optional },
@@ -235,6 +236,17 @@ int Config::maxDiskCacheSize() const
 void Config::setMaxDiskCacheSize(int maxDiskCacheSize)
 {
     m_maxDiskCacheSize = maxDiskCacheSize;
+}
+
+void Config::setDiskCachePath(const QString &value)
+{
+    QDir dir(value);
+    m_diskCachePath = dir.absolutePath();
+}
+
+QString Config::diskCachePath() const
+{
+    return m_diskCachePath;
 }
 
 bool Config::ignoreSslErrors() const
@@ -526,6 +538,7 @@ void Config::resetToDefaults()
     m_offlineStorageDefaultQuota = -1;
     m_diskCacheEnabled = false;
     m_maxDiskCacheSize = -1;
+    m_diskCachePath = QString();
     m_ignoreSslErrors = false;
     m_localToRemoteUrlAccessEnabled = false;
     m_outputEncoding = "UTF-8";
@@ -664,6 +677,10 @@ void Config::handleOption(const QString &option, const QVariant &value)
 
     if (option == "max-disk-cache-size") {
         setMaxDiskCacheSize(value.toInt());
+    }
+
+    if (option == "disk-cache-path") {
+        setDiskCachePath(value.toString());
     }
 
     if (option == "output-encoding") {

--- a/src/config.h
+++ b/src/config.h
@@ -91,6 +91,9 @@ public:
     int maxDiskCacheSize() const;
     void setMaxDiskCacheSize(int maxDiskCacheSize);
 
+    QString diskCachePath() const;
+    void setDiskCachePath(const QString &value);
+
     bool ignoreSslErrors() const;
     void setIgnoreSslErrors(const bool value);
 
@@ -193,6 +196,7 @@ private:
     int m_offlineStorageDefaultQuota;
     bool m_diskCacheEnabled;
     int m_maxDiskCacheSize;
+    QString m_diskCachePath;
     bool m_ignoreSslErrors;
     bool m_localToRemoteUrlAccessEnabled;
     QString m_outputEncoding;

--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -112,7 +112,12 @@ NetworkAccessManager::NetworkAccessManager(QObject *parent, const Config *config
 
     if (config->diskCacheEnabled()) {
         m_networkDiskCache = new QNetworkDiskCache(this);
-        m_networkDiskCache->setCacheDirectory(QDesktopServices::storageLocation(QDesktopServices::CacheLocation));
+        if (config->diskCachePath().isEmpty()) {
+            m_networkDiskCache->setCacheDirectory(QDesktopServices::storageLocation(QDesktopServices::CacheLocation));
+        } else {
+            m_networkDiskCache->setCacheDirectory(config->diskCachePath());
+        }
+
         if (config->maxDiskCacheSize() >= 0)
             m_networkDiskCache->setMaximumCacheSize(config->maxDiskCacheSize() * 1024);
         setCache(m_networkDiskCache);


### PR DESCRIPTION
I added command-line option to specify disk-cache location
`phantomjs --disk-cache=true --disk-cache-path=./tmp/cache`
