### PR TITLE
MINOR: Reorder initialisation order in NAM constr.

### DIFF
--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -104,10 +104,10 @@ NetworkAccessManager::NetworkAccessManager(QObject *parent, const Config *config
     , m_ignoreSslErrors(config->ignoreSslErrors())
     , m_authAttempts(0)
     , m_maxAuthAttempts(3)
+    , m_resourceTimeout(0)
     , m_idCounter(0)
     , m_networkDiskCache(0)
     , m_sslConfiguration(QSslConfiguration::defaultConfiguration())
-    , m_resourceTimeout(0)
 {
     setCookieJar(CookieJar::instance());
 


### PR DESCRIPTION
`m_resourceTimeout` is declared before of other
private variables, and the compiler was complaining
the initialisation order could not be respected.
This caused annoying (but innocuous) warnings at compile time.
