### PR TITLE
Network request header manipulation

### DIFF
--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -80,6 +80,15 @@ void JsNetworkRequest::abort()
     }
 }
 
+bool JsNetworkRequest::setHeader(const QString& name, const QVariant& value)
+{
+    if (!m_networkRequest)
+        return false;
+
+    // Pass `null` as the second argument to remove a HTTP header
+    m_networkRequest->setRawHeader(name.toAscii(), value.toByteArray());
+    return true;
+}
 
 void JsNetworkRequest::changeUrl(const QString& url)
 {

--- a/src/networkaccessmanager.h
+++ b/src/networkaccessmanager.h
@@ -50,6 +50,8 @@ public:
     JsNetworkRequest(QNetworkRequest* request, QObject* parent = 0);
     Q_INVOKABLE void abort();
     Q_INVOKABLE void changeUrl(const QString& url);
+    Q_INVOKABLE bool setHeader(const QString& name, const QVariant& value);
+
 private:
     QNetworkRequest* m_networkRequest;
 };

--- a/test/webpage-spec.js
+++ b/test/webpage-spec.js
@@ -1835,3 +1835,103 @@ describe("WebPage render image", function(){
     });
 
 });
+
+describe("WebPage network request headers handling", function() {
+    it("should add HTTP header to a network request", function() {
+        var page = require("webpage").create();
+        var server = require("webserver").create();
+        var isCustomHeaderPresented = false;
+
+        server.listen(12345, function(response) {
+            if (response.headers["CustomHeader"] && response.headers["CustomHeader"] === "CustomValue") {
+                isCustomHeaderPresented = true;
+            }
+        });
+
+        page.onResourceRequested = function(requestData, request) {
+            expect(typeof request.setHeader).toEqual("function");
+            request.setHeader("CustomHeader", "CustomValue");
+        };
+
+        runs(function() {
+            page.open("http://localhost:12345", function() {
+                expect(status).toEqual("success");
+            });
+        });
+
+        waits(3000);
+
+        runs(function() {
+            expect(isCustomHeaderPresented).toBeTruthy();
+            page.close();
+            server.close();
+        });
+    });
+
+    it("should remove HTTP header from a network request", function() {
+        var page = require("webpage").create();
+        page.customHeaders = {"CustomHeader": "CustomValue"};
+        
+        var server = require("webserver").create();
+        var handled = false;
+
+        server.listen(12345, function(request) {
+            if (request.headers["CustomHeader"] == null) {
+                handled = true;
+            }
+        });
+
+        page.onResourceRequested = function(requestData, request) {
+            expect(typeof request.setHeader).toEqual("function");
+            request.setHeader("CustomHeader", null);
+        };
+
+        runs(function() {
+            page.open("http://localhost:12345", function() {
+                expect(status).toEqual("success");
+            });
+        });
+
+        waits(3000);
+
+        runs(function() {
+            expect(handled).toBeTruthy();
+            page.close();
+            server.close();
+        });
+    });
+
+    it("should set HTTP header value for a network request", function() {
+        var page = require("webpage").create();
+        page.customHeaders = {"CustomHeader": "CustomValue"};
+        
+        var server = require("webserver").create();
+        var handled = false;
+
+        server.listen(12345, function(request) {
+            if (request.headers["CustomHeader"] && 
+                request.headers["CustomHeader"] === "ChangedCustomValue") {
+                handled = true;
+            }
+        });
+
+        page.onResourceRequested = function(requestData, request) {
+            expect(typeof request.setHeader).toEqual("function");
+            request.setHeader("CustomHeader", "ChangedCustomValue");
+        };
+
+        runs(function() {
+            page.open("http://localhost:12345", function() {
+                expect(status).toEqual("success");
+            });
+        });
+
+        waits(3000);
+
+        runs(function() {
+            expect(handled).toBeTruthy();
+            page.close();
+            server.close();
+        });
+    });
+});


### PR DESCRIPTION
Issue: https://github.com/ariya/phantomjs/issues/11299

User should be able  to manipulate HTTP headers per each network request, not only using global setting page.customHeaders.

Like this:

``` js
page.onResourceRequested = function(requestData, request) {
     // Passing `null` as the second argument will remove the HTTP header
     request.setHeader("CustomHeader", "ChangedCustomValue");
};
```
