### PR TITLE
Limit the maximum request post size to 10 MB (megabytes).

### DIFF
--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -37,12 +37,14 @@
 #include <QSslSocket>
 #include <QSslCertificate>
 #include <QRegExp>
-#include <limits>
 
 #include "phantom.h"
 #include "config.h"
 #include "cookiejar.h"
 #include "networkaccessmanager.h"
+
+// 10 MB
+const qint64 MAX_REQUEST_POST_BODY_SIZE = 10 * 1000 * 1000;
 
 static const char *toString(QNetworkAccessManager::Operation op)
 {
@@ -208,7 +210,7 @@ QNetworkReply *NetworkAccessManager::createRequest(Operation op, const QNetworkR
 
     // http://code.google.com/p/phantomjs/issues/detail?id=337
     if (op == QNetworkAccessManager::PostOperation) {
-        if (outgoingData) postData = outgoingData->peek((std::numeric_limits<qint64>::max)());
+        if (outgoingData) postData = outgoingData->peek(MAX_REQUEST_POST_BODY_SIZE);
         QString contentType = req.header(QNetworkRequest::ContentTypeHeader).toString();
         if (contentType.isEmpty()) {
             req.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");


### PR DESCRIPTION
std::numeric_limits<qint64>::max is too big for QByteArray (throws Out of Memory exception).
Set up the limit like it was done in Google Chrome
Ref: https://code.google.com/p/chromium/codesearch#chromium/src/third_party/WebKit/Source/core/inspector/NetworkResourcesData.cpp
Discussion: https://github.com/ariya/phantomjs/commit/3edcabef9f36636adcf05926351a3fb09c781e0d
