### PR TITLE
Define the new page callback for interrupting a long-running JavaScript

### DIFF
--- a/src/modules/webpage.js
+++ b/src/modules/webpage.js
@@ -468,6 +468,9 @@ function decorateNewPage(opts, page) {
     // @see https://developer.mozilla.org/en/DOM/window.prompt
     definePageCallbackHandler(page, handlers, "onPrompt", "_getJsPromptCallback");
 
+    // Calls from within the page when some javascript code running to long
+    definePageCallbackHandler(page, handlers, "onLongRunningScript", "_getJsInterruptCallback");
+
     page.event = {};
     page.event.modifier = {
         shift:  0x02000000,

--- a/src/webpage.h
+++ b/src/webpage.h
@@ -258,6 +258,7 @@ public slots:
     QObject *_getFilePickerCallback();
     QObject *_getJsConfirmCallback();
     QObject *_getJsPromptCallback();
+    QObject *_getJsInterruptCallback();
     void _uploadFile(const QString &selector, const QStringList &fileNames);
     void sendEvent(const QString &type, const QVariant &arg1 = QVariant(), const QVariant &arg2 = QVariant(), const QString &mouseButton = QString(), const QVariant &modifierArg = QVariant());
 
@@ -459,6 +460,8 @@ public slots:
      */
     void stop();
 
+    void stopJavaScript();
+
 signals:
     void initialized();
     void loadStarted();
@@ -497,6 +500,7 @@ private:
     QString filePicker(const QString &oldFile);
     bool javaScriptConfirm(const QString &msg);
     bool javaScriptPrompt(const QString &msg, const QString &defaultValue, QString *result);
+    void javascriptInterrupt();
 
 private:
     CustomPage *m_customWebPage;
@@ -513,6 +517,7 @@ private:
     QPoint m_mousePos;
     bool m_ownsPages;
     int m_loadingProgress;
+    bool m_shouldInterruptJs;
 
     friend class Phantom;
     friend class CustomPage;

--- a/test/webpage-spec-frames/forever.html
+++ b/test/webpage-spec-frames/forever.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+<script type="text/javascript">
+    function forever() {
+        while(true) {}
+    }
+</script>
+</head>
+<body onload="forever();">
+
+</body>
+</html>

--- a/test/webpage-spec.js
+++ b/test/webpage-spec.js
@@ -1207,6 +1207,18 @@ describe("WebPage object", function() {
             expect(handled).toBe(true);
         });
     });
+
+    it("should interrupt a long-running JavaScript code", function() {
+        var page = new WebPage();
+        
+        page.onLongRunningScript = function() {
+            page.stopJavaScript();
+        };
+        
+        page.open('../test/webpage-spec-frames/forever.html', function(status) {
+            expect(status).toEqual('success');
+        });
+    });
 });
 
 describe("WebPage construction with options", function () {


### PR DESCRIPTION
This pull request defines the new page callback `onShouldInterruptJs`. Using this callback user can interrupt a long running JavaScript code.

Usage:

```
page.onShouldInterruptJs = function() {
     return true; // return `true` to interrupt JavaScript code
};
```

Issues:
https://github.com/ariya/phantomjs/issues/11198
https://github.com/ariya/phantomjs/issues/11183
https://github.com/ariya/phantomjs/issues/11189
