### PR TITLE
Fix date in rpm spec changelog

### DIFF
--- a/rpm/phantomjs.spec
+++ b/rpm/phantomjs.spec
@@ -142,7 +142,7 @@ cp README.md %{mybuilddir}%{prefix}/share/%{name}/
 %{prefix}/share/%{name}/examples/weather.js
 
 %changelog
-* Wed Apr 24 2012 Robin Helgelin <lobbin@gmail.com>
+* Wed Apr 24 2013 Robin Helgelin <lobbin@gmail.com>
 - updated to version 1.9
 
 * Thu Jan 24 2013 Matthew Barr <mbarr@snap-interactive.com>


### PR DESCRIPTION
Trivial fix to update from Issue #10939

rpmbuild was crapping out on the changelog not being in
reverse chronological order.
