### PR TITLE
Fix crash when calling QObject::disconnect for QNetworkReplyWrapper

### DIFF
--- a/src/qt/src/3rdparty/webkit/Source/WebCore/platform/network/qt/QNetworkReplyHandler.h
+++ b/src/qt/src/3rdparty/webkit/Source/WebCore/platform/network/qt/QNetworkReplyHandler.h
@@ -90,9 +90,10 @@ private Q_SLOTS:
     void didReceiveReadyRead();
     void receiveSniffedMIMEType();
     void setFinished();
+    void replyDestroyed();
 
 private:
-    void resetConnections();
+    void stopForwarding();
     void emitMetaDataChanged();
 
     QNetworkReply* m_reply;


### PR DESCRIPTION
Fix it by watching the QNetworkReply's destroyed() signal and avoid the dangling pointer
instead. The QNetworkReply doesn't need to be aborted in this case anyway.

Issue: https://github.com/ariya/phantomjs/issues/11252
Upstream bug: https://bugs.webkit.org/show_bug.cgi?id=116035
