### PR TITLE
Make some basic url shortcuts to the API docs.

### DIFF
--- a/api/child_process.html
+++ b/api/child_process.html
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0;https://github.com/ariya/phantomjs/wiki/API-Reference-ChildProcess" />

--- a/api/examples.html
+++ b/api/examples.html
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0;https://github.com/ariya/phantomjs/wiki/Examples" />

--- a/api/fs.html
+++ b/api/fs.html
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0;https://github.com/ariya/phantomjs/wiki/API-Reference-FileSystem" />

--- a/api/index.html
+++ b/api/index.html
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0;https://github.com/ariya/phantomjs/wiki/API-Reference" />

--- a/api/phantom.html
+++ b/api/phantom.html
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0;https://github.com/ariya/phantomjs/wiki/API-Reference-phantom" />

--- a/api/system.html
+++ b/api/system.html
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0;https://github.com/ariya/phantomjs/wiki/API-Reference-System" />

--- a/api/webpage.html
+++ b/api/webpage.html
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0;https://github.com/ariya/phantomjs/wiki/API-Reference-WebPage" />

--- a/api/webserver.html
+++ b/api/webserver.html
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0;https://github.com/ariya/phantomjs/wiki/API-Reference-WebServer" />


### PR DESCRIPTION
The following urls now redirect to the relevant documentation on the
wiki:

```
phantomjs.org/api
phantomjs.org/api/webpage
phantomjs.org/api/system
phantomjs.org/api/fs
phantomjs.org/api/webserver
phantomjs.org/api/child_process
```

I often find myself struggling to remember the exact url for each page of documentation. Hopefully this will help make the documentation more accessible.
