### PR TITLE
Fix quotes in proxyHost before connecting to proxy

### DIFF
--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -114,10 +114,10 @@ void Phantom::init()
             }
 
             if(!m_config.proxyAuthUser().isEmpty() && !m_config.proxyAuthPass().isEmpty()) {
-                QNetworkProxy proxy(networkProxyType, m_config.proxyHost(), m_config.proxyPort(), m_config.proxyAuthUser(), m_config.proxyAuthPass());
+                QNetworkProxy proxy(networkProxyType, qPrintable(m_config.proxyHost()), m_config.proxyPort(), m_config.proxyAuthUser(), m_config.proxyAuthPass());
                 QNetworkProxy::setApplicationProxy(proxy);
             } else {
-                QNetworkProxy proxy(networkProxyType, m_config.proxyHost(), m_config.proxyPort());
+                QNetworkProxy proxy(networkProxyType, qPrintable(m_config.proxyHost()), m_config.proxyPort());
                 QNetworkProxy::setApplicationProxy(proxy);
             }
         }


### PR DESCRIPTION
HTTP-based proxy connections are now working again. The proxyPort parser
was working correctly, but QNetworkProxy was receiving bad data.

Might be related to #11052 or #11229.

See also:
https://github.com/ariya/phantomjs/issues/11052#issuecomment-16383995
