### PR TITLE
Fix parsing the `proxy` and `proxy-host` command line option

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -283,25 +283,17 @@ void Config::setProxyType(const QString value)
 
 QString Config::proxy() const
 {
-    return proxyHost() + ":" + proxyPort();
+    return m_proxyHost + ":" + QString::number(m_proxyPort);
 }
 
 void Config::setProxy(const QString &value)
 {
-    QString proxyHost = value;
-    int proxyPort = 1080;
+    QUrl proxyUrl = QUrl::fromUserInput(value);
 
-    if (proxyHost.lastIndexOf(':') > 0) {
-        bool ok = true;
-        int port = proxyHost.mid(proxyHost.lastIndexOf(':') + 1).toInt(&ok);
-        if (ok) {
-            proxyHost = proxyHost.left(proxyHost.lastIndexOf(':')).trimmed();
-            proxyPort = port;
-        }
+    if (proxyUrl.isValid()) {
+        setProxyHost(proxyUrl.host());
+        setProxyPort(proxyUrl.port(1080));
     }
-
-    setProxyHost(proxyHost);
-    setProxyPort(proxyPort);
 }
 
 void Config::setProxyAuth(const QString &value)


### PR DESCRIPTION
**Fix including http:// in the proxy URL**
The proxy host parsed incorrectly, when it was typed with a scheme (http or https).
Now proxy can be specified with the scheme.

**Fix invalid type conversion**
`m_proxyPort` converts to its ASCII representation.
Use `QString::number` to include a proxy port properly.

**Issues:**
https://github.com/ariya/phantomjs/issues/11117
https://github.com/ariya/phantomjs/issues/10811
