### PR TITLE
Add frameName to onNavigationRequested.

### DIFF
--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -170,6 +170,7 @@ protected:
 
     bool acceptNavigationRequest(QWebFrame *frame, const QNetworkRequest &request, QWebPage::NavigationType type) {
         bool isMainFrame = (frame == m_webPage->m_mainFrame);
+        const QString frameName = frame->frameName();
 
         QString navigationType = "Undefined";
         switch (type) {
@@ -193,12 +194,13 @@ protected:
             break;
         }
         bool isNavigationLocked = m_webPage->navigationLocked();
-        
+
         emit m_webPage->navigationRequested(
                     request.url(),                   //< Requested URL
                     navigationType,                  //< Navigation Type
                     !isNavigationLocked,             //< Will navigate (not locked)?
-                    isMainFrame);                    //< Is main frame?
+                    isMainFrame,                     //< Is main frame?
+                    frameName);                      //< Frame that originated request
 
         return !isNavigationLocked;
     }

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -170,7 +170,13 @@ protected:
 
     bool acceptNavigationRequest(QWebFrame *frame, const QNetworkRequest &request, QWebPage::NavigationType type) {
         bool isMainFrame = (frame == m_webPage->m_mainFrame);
-        const QString frameName = frame->frameName();
+
+        QString frameName = "";
+
+        // only use frameName() on non-null frame
+        if (frame) {
+            frameName = frame->frameName();
+        }
 
         QString navigationType = "Undefined";
         switch (type) {

--- a/src/webpage.h
+++ b/src/webpage.h
@@ -471,7 +471,7 @@ signals:
     void resourceError(const QVariant &errorData);
     void resourceTimeout(const QVariant &errorData);
     void urlChanged(const QUrl &url);
-    void navigationRequested(const QUrl &url, const QString &navigationType, bool navigationLocked, bool isMainFrame);
+    void navigationRequested(const QUrl &url, const QString &navigationType, bool navigationLocked, bool isMainFrame, const QString &frameName);
     void rawPageCreated(QObject *page);
     void closing(QObject *page);
 

--- a/test/webpage-spec.js
+++ b/test/webpage-spec.js
@@ -1897,7 +1897,7 @@ describe('WebPage navigation events', function() {
         var isHandled = false;
 
         runs(function() {
-            page.onNavigationRequested = function(url, navigationType, navigationLocked, isMainFrame) {
+            page.onNavigationRequested = function(url, navigationType, navigationLocked, isMainFrame, frameName) {
                 if (!page.testStarted) {
                     return;
                 }


### PR DESCRIPTION
An additional parameter is now passed to onNavigationRequested with the
name of the frame that originated the navigation request.

isMainFrame can be emulated by checking if frameName is equal to an
empty string, but hasn't been removed from the function signature for 
backwards compatibility reasons.
