### PR TITLE
Draw SVG lines with stroke-opacity in PDF output.

### DIFF
--- a/src/qt/src/gui/painting/qpdf.cpp
+++ b/src/qt/src/gui/painting/qpdf.cpp
@@ -1143,13 +1143,15 @@ void QPdfBaseEngine::updateState(const QPaintEngineState &state)
     if (flags & DirtyTransform)
         d->stroker.matrix = state.transform();
 
-    if (flags & DirtyPen) {
+    if (flags & DirtyOpacity)
+        d->opacity = state.opacity();
+    if (flags & (DirtyPen|DirtyOpacity)) {
         d->pen = state.pen();
         d->hasPen = d->pen.style() != Qt::NoPen;
         d->stroker.setPen(d->pen);
         QBrush penBrush = d->pen.brush();
         bool oldSimple = d->simplePen;
-        d->simplePen = (d->hasPen && (penBrush.style() == Qt::SolidPattern) && penBrush.isOpaque());
+        d->simplePen = (d->hasPen && (penBrush.style() == Qt::SolidPattern) && penBrush.isOpaque() && d->opacity == 1.0);
         if (oldSimple != d->simplePen)
             flags |= DirtyTransform;
     }
@@ -1163,8 +1165,6 @@ void QPdfBaseEngine::updateState(const QPaintEngineState &state)
         d->brushOrigin = state.brushOrigin();
         flags |= DirtyBrush;
     }
-    if (flags & DirtyOpacity)
-        d->opacity = state.opacity();
 
     bool ce = d->clipEnabled;
     if (flags & DirtyClipPath) {


### PR DESCRIPTION
Webkit tells the PDF painter about SVG stroke opacity by setting the
global painter opacity state, _not_ the pen (line drawer)'s color's
alpha.  So if the pen was opaque, but the painter-global opacity was
not, line drawing would choose the wrong path (one of the "simplePen"
paths) in QPdfBaseEngine.

We simply ensure that global opacity is considered when choosing
whether the "simplePen" path is appropriate or not.

This rev is based on 1.9.0.
#11381
