### PR TITLE
Use Qt::transparent to resolve graphical artifacts with images with transparent background.

### DIFF
--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -990,7 +990,7 @@ QImage WebPage::renderImage()
 #endif
 
     QImage buffer(frameRect.size(), format);
-    buffer.fill(qRgba(255, 255, 255, 0));
+    buffer.fill(Qt::transparent);
 
     QPainter painter;
 
@@ -1004,7 +1004,7 @@ QImage WebPage::renderImage()
         for (int y = 0; y < vtiles; ++y) {
 
             QImage tileBuffer(tileSize, tileSize, format);
-            tileBuffer.fill(qRgba(255, 255, 255, 0));
+            tileBuffer.fill(Qt::transparent);
 
             // Render the web page onto the small tile first
             painter.begin(&tileBuffer);


### PR DESCRIPTION
Use Qt::transparent to resolve graphical artifacts with images with transparent background.

We need to use `QImage::Format_ARGB32_Premultiplied` on Windows to preserve the text hinting and anti-aliasing. Using the function `qRgba()` leads to wrong pixel permutation values on a target image. Since, `QImage::fill(uint pixel)` doesn't handle the `QImage::Format_ARGB32_Premultiplied format`, so we need to use the another overload `QImage::fill(const QColor &color)`

Issues:
https://github.com/ariya/phantomjs/issues/11276
https://github.com/ariya/phantomjs/issues/11007
https://github.com/ariya/phantomjs/issues/11366
