### PR TITLE
Add stdin for spawned processes

### DIFF
--- a/src/childprocess.cpp
+++ b/src/childprocess.cpp
@@ -86,6 +86,26 @@ bool ChildProcessContext::_start(const QString &cmd, const QStringList &args)
     return m_proc.waitForStarted(1000);
 }
 
+qint64 ChildProcessContext::_write(const QString &chunk, const QString &encoding)
+{
+    // Try to get codec for encoding
+    QTextCodec *codec = QTextCodec::codecForName(encoding.toLatin1());
+
+    // If unavailable, attempt UTF-8 codec
+    if ((QTextCodec *)NULL == codec) {
+        codec = QTextCodec::codecForName("UTF-8");
+
+        // Don't even try to write if UTF-8 codec is unavailable
+        if ((QTextCodec *)NULL == codec) {
+            return -1;
+        }
+    }
+
+    qint64 bytesWritten = m_proc.write(codec->fromUnicode(chunk));
+
+    return bytesWritten;
+}
+
 // private slots:
 
 void ChildProcessContext::_readyReadStandardOutput()

--- a/src/childprocess.h
+++ b/src/childprocess.h
@@ -53,6 +53,8 @@ public:
     Q_INVOKABLE void _setEncoding(const QString &encoding);
     Q_INVOKABLE bool _start(const QString &cmd, const QStringList &args);
 
+    Q_INVOKABLE qint64 _write(const QString &chunk, const QString &encoding);
+
 signals:
     void exit(const int code) const;
 

--- a/src/modules/child_process.js
+++ b/src/modules/child_process.js
@@ -145,6 +145,30 @@ function newContext() {
     }
   }
 
+  ctx.stdin = new FakeWritableStream()
+
+  // Emulates `Writable Stream`
+  function FakeWritableStream() {
+    /**
+     * @param chunk String Data to write.
+     * @param encoding String Optional.  Defaults to "utf8".
+     * @returns Number Bytes written; `-1` for failure.
+     */
+    this.write = function write(chunk, encoding) {
+      if ("string" !== typeof encoding) {
+        encoding = "utf8"
+      }
+
+      var bytesWritten = ctx._write(chunk, encoding)
+
+      return bytesWritten
+    }
+
+    this.end = function () {
+      throw new Error("NotYetImplemented")
+    }
+  }
+
   return ctx
 }
 


### PR DESCRIPTION
This change adds simple write functionality to stdin of a `spawn`ed process.

[Issue #11446](https://github.com/ariya/phantomjs/issues/11446)

---

Note:  Since this is probably best considered a "new/experimental feature", I think it might best be part of the 2.0 release...
