### PR TITLE
Handle websocket mismatch error when connecting through proxy

### DIFF
--- a/src/qt/src/3rdparty/webkit/Source/WebCore/websockets/WebSocketHandshake.cpp
+++ b/src/qt/src/3rdparty/webkit/Source/WebCore/websockets/WebSocketHandshake.cpp
@@ -597,10 +597,7 @@ bool WebSocketHandshake::checkResponseHeaders()
         m_context->addMessage(JSMessageSource, LogMessageType, ErrorMessageLevel, "Error during WebSocket handshake: origin mismatch: " + clientOrigin() + " != " + serverWebSocketOrigin, 0, clientOrigin(), 0);
         return false;
     }
-    if (clientLocation() != serverWebSocketLocation) {
-        m_context->addMessage(JSMessageSource, LogMessageType, ErrorMessageLevel, "Error during WebSocket handshake: location mismatch: " + clientLocation() + " != " + serverWebSocketLocation, 0, clientOrigin(), 0);
-        return false;
-    }
+    
     if (!m_clientProtocol.isEmpty() && m_clientProtocol != serverWebSocketProtocol) {
         m_context->addMessage(JSMessageSource, LogMessageType, ErrorMessageLevel, "Error during WebSocket handshake: protocol mismatch: " + m_clientProtocol + " != " + serverWebSocketProtocol, 0, clientOrigin(), 0);
         return false;


### PR DESCRIPTION
When connecting through a proxy, websocket handshake should complete if the server is CORS enabled.

https://github.com/ariya/phantomjs/issues/11419
