### PR TITLE
Fix phantomjs.spec for 1.9 with backport patch

### DIFF
--- a/rpm/phantomjs.spec
+++ b/rpm/phantomjs.spec
@@ -142,7 +142,10 @@ cp README.md %{mybuilddir}%{prefix}/share/%{name}/
 %{prefix}/share/%{name}/examples/weather.js
 
 %changelog
-* Wed Apr 24 2012 Robin Helgelin <lobbin@gmail.com>
+* Tue Apr 30 2013 Eric Heydenberk <heydenberk@gmail.com>
+- add missing filenames for examples to files section
+
+* Wed Apr 24 2013 Robin Helgelin <lobbin@gmail.com>
 - updated to version 1.9
 
 * Thu Jan 24 2013 Matthew Barr <mbarr@snap-interactive.com>


### PR DESCRIPTION
I think that [1.9 branch](https://github.com/ariya/phantomjs/tree/1.9) is stable branch.
Also [Build Instructions](http://phantomjs.org/build.html) says that we should use [1.9 branch](https://github.com/ariya/phantomjs/tree/1.9).

``` sh
git checkout 1.9
```

But this branch couldn't build as a rpm package.

So I sent backport patch to fix #11262 on 1.9 branch.
