### PR TITLE
Implement the webpage setting "clearMemoryCaches"

### DIFF
--- a/src/consts.h
+++ b/src/consts.h
@@ -54,6 +54,7 @@
     "document.body.appendChild(el);"
 
 #define PAGE_SETTINGS_LOAD_IMAGES           "loadImages"
+#define PAGE_SETTINGS_CLEAR_MEMORY_CACHES   "clearMemoryCaches"
 #define PAGE_SETTINGS_JS_ENABLED            "javascriptEnabled"
 #define PAGE_SETTINGS_XSS_AUDITING          "XSSAuditingEnabled"
 #define PAGE_SETTINGS_USER_AGENT            "userAgent"

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -135,6 +135,7 @@ void Phantom::init()
             SLOT(onInitialized()));
 
     m_defaultPageSettings[PAGE_SETTINGS_LOAD_IMAGES] = QVariant::fromValue(m_config.autoLoadImages());
+    m_defaultPageSettings[PAGE_SETTINGS_CLEAR_MEMORY_CACHES] = QVariant::fromValue(false);
     m_defaultPageSettings[PAGE_SETTINGS_JS_ENABLED] = QVariant::fromValue(true);
     m_defaultPageSettings[PAGE_SETTINGS_XSS_AUDITING] = QVariant::fromValue(false);
     m_defaultPageSettings[PAGE_SETTINGS_USER_AGENT] = QVariant::fromValue(m_page->userAgent());

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -574,6 +574,10 @@ void WebPage::applySettings(const QVariantMap &def)
     opt->setAttribute(QWebSettings::JavascriptCanOpenWindows, def[PAGE_SETTINGS_JS_CAN_OPEN_WINDOWS].toBool());
     opt->setAttribute(QWebSettings::JavascriptCanCloseWindows, def[PAGE_SETTINGS_JS_CAN_CLOSE_WINDOWS].toBool());
 
+    if (def[PAGE_SETTINGS_CLEAR_MEMORY_CACHES].toBool()) {
+        QWebSettings::clearMemoryCaches();
+    }
+
     if (def.contains(PAGE_SETTINGS_USER_AGENT))
         m_customWebPage->m_userAgent = def[PAGE_SETTINGS_USER_AGENT].toString();
 


### PR DESCRIPTION
Fix issue #10357
(Reported by many users trying to use PhamtomJS for load testing purpose)

This changeset introduces a new webpage setting:
    page.settings.clearMemoryCaches

It defaults to false, and triggers the call to
    QWebSettings::clearMemoryCaches();
when set to true.
