### PR TITLE
Add require.paths support

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -45,7 +45,7 @@ phantom.__defineErrorSignalHandler__ = function(obj, page, handlers) {
             try { signal.disconnect(handlerObj.connector); }
             catch (e) {}
         }
-        
+
         // Delete the previous handler
         delete handlers[handlerName];
 
@@ -57,17 +57,17 @@ phantom.__defineErrorSignalHandler__ = function(obj, page, handlers) {
 
                 f(message, revisedStack);
             };
-            
+
             // Store the new handler for reference
             handlers[handlerName] = {
                 callback: f,
                 connector: connector
             };
-            
+
             signal.connect(connector);
         }
     });
-    
+
     obj.__defineGetter__(handlerName, function() {
         var handlerObj = handlers[handlerName];
         return (!!handlerObj && typeof handlerObj.callback === "function" && typeof handlerObj.connector === "function") ?
@@ -111,6 +111,7 @@ phantom.callback = function(callback) {
     // fs is loaded at the end, when everything is ready
     var fs;
     var cache = {};
+    var paths = [];
     // use getters to initialize lazily
     // (for future, now both fs and system are loaded anyway)
     var nativeExports = {
@@ -212,33 +213,37 @@ phantom.callback = function(callback) {
     }
 
     Module.prototype._getPaths = function(request) {
-        var paths = [], dir;
+        var _paths = [], dir;
 
         if (request[0] === '.') {
-            paths.push(fs.absolute(joinPath(phantom.webdriverMode ? ":/ghostdriver" : this.dirname, request)));
+            _paths.push(fs.absolute(joinPath(phantom.webdriverMode ? ":/ghostdriver" : this.dirname, request)));
         } else if (fs.isAbsolute(request)) {
-            paths.push(fs.absolute(request));
+            _paths.push(fs.absolute(request));
         } else {
             // first look in PhantomJS modules
-            paths.push(joinPath(':/modules', request));
+            _paths.push(joinPath(':/modules', request));
             // then look in node_modules directories
             if (!this._isNative()) {
                 dir = this.dirname;
                 while (dir) {
-                    paths.push(joinPath(dir, 'node_modules', request));
+                    _paths.push(joinPath(dir, 'node_modules', request));
                     dir = dirname(dir);
                 }
             }
         }
 
-        return paths;
+        for (var i=0; i<paths.length; ++i) {
+            _paths.push(fs.absolute(joinPath(paths[i], request)));
+        }
+
+        return _paths;
     };
 
     Module.prototype._getFilename = function(request) {
-        var path, filename = null, paths = this._getPaths(request);
+        var path, filename = null, _paths = this._getPaths(request);
 
-        for (var i=0; i<paths.length && !filename; ++i) {
-            path = paths[i];
+        for (var i=0; i<_paths.length && !filename; ++i) {
+            path = _paths[i];
             filename = tryFile(path) || tryExtensions(path) || tryPackage(path) ||
                 tryExtensions(joinPath(path, 'index'));
         }
@@ -254,6 +259,7 @@ phantom.callback = function(callback) {
         }
         require.cache = cache;
         require.extensions = extensions;
+        require.paths = paths;
         require.stub = function(request, exports) {
             self.stubs[request] = { exports: exports };
         };

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -233,7 +233,11 @@ phantom.callback = function(callback) {
         }
 
         for (var i=0; i<paths.length; ++i) {
-            _paths.push(fs.absolute(joinPath(paths[i], request)));
+            if(fs.isAbsolute(paths[i])) {
+                _paths.push(fs.absolute(joinPath(paths[i], request)));
+            } else {
+                _paths.push(fs.absolute(joinPath(this.dirname, paths[i], request)));
+            }
         }
 
         return _paths;

--- a/test/require/dir/subdir2/loader.js
+++ b/test/require/dir/subdir2/loader.js
@@ -1,0 +1,1 @@
+module.exports = 'require/subdir2/loader'

--- a/test/require/require_spec.js
+++ b/test/require/require_spec.js
@@ -154,10 +154,33 @@ describe("require()", function() {
             });
         });
     });
-    
+
     describe("when path is absolute", function() {
         it("loads modules from the absolute path", function() {
             require(fs.absolute('dummy')).should.equal('spec/dummy');
         });
+    });
+
+    describe("push dir/subdir", function() {
+        require.paths.push('./require/dir/subdir');
+
+        it("loads 'loader' module in dir/subdir", function() {
+            require('loader').dummyFile2.should.equal('spec/node_modules/dummy_file2');
+        });
+
+        it("loads 'loader' module in dir/subdir2 relative to require.paths", function() {
+            require('../subdir2/loader').should.equal('require/subdir2/loader');
+        });
+
+        it("loads 'dummy' module from the path that takes precedence", function() {
+            require('../dummy').should.equal('spec/dummy');
+        });
+
+        it("doesn't load 'loader' module in dir/subdir", function() {
+            (function() {
+                require.paths.pop();
+                require('loader');
+            }).should.Throw("Cannot find module 'loader'");
+        })
     });
 });

--- a/test/require/require_spec.js
+++ b/test/require/require_spec.js
@@ -161,26 +161,52 @@ describe("require()", function() {
         });
     });
 
-    describe("push dir/subdir", function() {
-        require.paths.push('./require/dir/subdir');
+    describe("with require.paths", function() {
+        describe("when require.paths.push(relative)", function() {
+            require.paths.push('./dir/subdir');
 
-        it("loads 'loader' module in dir/subdir", function() {
-            require('loader').dummyFile2.should.equal('spec/node_modules/dummy_file2');
+            it("loads 'loader' module in dir/subdir", function() {
+                require('loader').dummyFile2.should.equal('spec/node_modules/dummy_file2');
+            });
+
+            it("loads 'loader' module in dir/subdir2 relative to require.paths", function() {
+                require('../subdir2/loader').should.equal('require/subdir2/loader');
+            });
+
+            it("loads 'dummy' module from the path that takes precedence", function() {
+                require('../dummy').should.equal('spec/dummy');
+            });
+
+            it("doesn't load 'loader' module in dir/subdir after require.paths.pop()", function() {
+                (function() {
+                    require.paths.pop();
+                    require('loader');
+                }).should.Throw("Cannot find module 'loader'");
+            })
         });
 
-        it("loads 'loader' module in dir/subdir2 relative to require.paths", function() {
-            require('../subdir2/loader').should.equal('require/subdir2/loader');
-        });
+        describe("when require.paths.push(absolute)", function() {
+            require.paths.push(fs.absolute('require/dir/subdir'));
 
-        it("loads 'dummy' module from the path that takes precedence", function() {
-            require('../dummy').should.equal('spec/dummy');
-        });
+            it("loads 'loader' module in dir/subdir", function() {
+                require('loader').dummyFile2.should.equal('spec/node_modules/dummy_file2');
+            });
 
-        it("doesn't load 'loader' module in dir/subdir", function() {
-            (function() {
-                require.paths.pop();
-                require('loader');
-            }).should.Throw("Cannot find module 'loader'");
-        })
+            it("loads 'loader' module in dir/subdir2 relative to require.paths", function() {
+                require('../subdir2/loader').should.equal('require/subdir2/loader');
+            });
+
+            it("loads 'dummy' module from the path that takes precedence", function() {
+                require('../dummy').should.equal('spec/dummy');
+            });
+
+            it("doesn't load 'loader' module in dir/subdir after require.paths.pop()", function() {
+                (function() {
+                    require.paths.pop();
+                    require('loader');
+                }).should.Throw("Cannot find module 'loader'");
+            })
+        }
+
     });
 });

--- a/test/require/require_spec.js
+++ b/test/require/require_spec.js
@@ -206,7 +206,6 @@ describe("require()", function() {
                     require('loader');
                 }).should.Throw("Cannot find module 'loader'");
             })
-        }
-
+        });
     });
 });

--- a/test/require/require_spec.js
+++ b/test/require/require_spec.js
@@ -163,7 +163,9 @@ describe("require()", function() {
 
     describe("with require.paths", function() {
         describe("when require.paths.push(relative)", function() {
-            require.paths.push('./dir/subdir');
+            it("add relative path to paths", function() {
+                require.paths.push('./dir/subdir');
+            });
 
             it("loads 'loader' module in dir/subdir", function() {
                 require('loader').dummyFile2.should.equal('spec/node_modules/dummy_file2');
@@ -182,11 +184,13 @@ describe("require()", function() {
                     require.paths.pop();
                     require('loader');
                 }).should.Throw("Cannot find module 'loader'");
-            })
+            });
         });
 
         describe("when require.paths.push(absolute)", function() {
-            require.paths.push(fs.absolute('require/dir/subdir'));
+            it("adds absolute path to paths", function() {
+                require.paths.push(fs.absolute('require/dir/subdir'));
+            });
 
             it("loads 'loader' module in dir/subdir", function() {
                 require('loader').dummyFile2.should.equal('spec/node_modules/dummy_file2');
@@ -205,7 +209,7 @@ describe("require()", function() {
                     require.paths.pop();
                     require('loader');
                 }).should.Throw("Cannot find module 'loader'");
-            })
+            });
         });
     });
 });


### PR DESCRIPTION
I've spent the past week or so trying to understand the code enough to provide a fix for this, and I feel as though I've finally got everything working the way it should.

The goal here is to try to achieve a better implementation of the CommonJS standard by adding the `require.paths` array so that custom paths can be allowed.

Ref: n1k0/casperjs#462 #11339 
