### PR TITLE
Fix Clang compilation

### DIFF
--- a/src/qt/src/gui/kernel/qt_cocoa_helpers_mac_p.h
+++ b/src/qt/src/gui/kernel/qt_cocoa_helpers_mac_p.h
@@ -110,6 +110,7 @@
 #include "private/qt_mac_p.h"
 
 struct HIContentBorderMetrics;
+struct TabletProximityRec;
 
 #ifdef Q_WS_MAC32
 typedef struct _NSPoint NSPoint; // Just redefine here so I don't have to pull in all of Cocoa.
@@ -155,7 +156,6 @@ bool qt_dispatchKeyEvent(void * /*NSEvent * */ keyEvent, QWidget *widgetToGetEve
 void qt_dispatchModifiersChanged(void * /*NSEvent * */flagsChangedEvent, QWidget *widgetToGetEvent);
 bool qt_mac_handleTabletEvent(void * /*QCocoaView * */view, void * /*NSEvent * */event);
 inline QApplication *qAppInstance() { return static_cast<QApplication *>(QCoreApplication::instance()); }
-struct ::TabletProximityRec;
 void qt_dispatchTabletProximityEvent(const ::TabletProximityRec &proxRec);
 Qt::KeyboardModifiers qt_cocoaModifiers2QtModifiers(ulong modifierFlags);
 Qt::KeyboardModifiers qt_cocoaDragOperation2QtModifiers(uint dragOperations);


### PR DESCRIPTION
Already merged in Qt: https://qt.gitorious.org/qt/qt/commit/b82b8bfa811adcf11cb8d07d662fd2b9642deebc

As of OSX 10.9 Clang will be the only compiler installed by default by Xcode or the CLT so we'll need this.
