### PR TITLE
Fix for PDF text not being selectable on Mac OSX

### DIFF
--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -1067,6 +1067,14 @@ bool WebPage::renderPdf(const QString &fileName)
     QPrinter printer;
     printer.setOutputFormat(QPrinter::PdfFormat);
     printer.setOutputFileName(fileName);
+
+    // Fix for PDF prints on Mac OSX. Produces selectable text
+    #ifdef Q_WS_MACX
+        if(fileName.endsWith(".pdf")) {
+            printer.setOutputFormat(QPrinter::NativeFormat);
+        }
+    #endif
+
     printer.setResolution(PHANTOMJS_PDF_DPI);
     QVariantMap paperSize = m_paperSize;
 

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -1070,9 +1070,7 @@ bool WebPage::renderPdf(const QString &fileName)
 
     // Fix for PDF prints on Mac OSX. Produces selectable text
     #ifdef Q_WS_MACX
-        if(fileName.endsWith(".pdf")) {
-            printer.setOutputFormat(QPrinter::NativeFormat);
-        }
+        printer.setOutputFormat(QPrinter::NativeFormat);
     #endif
 
     printer.setResolution(PHANTOMJS_PDF_DPI);


### PR DESCRIPTION
Produces selectable text when printing/rasterizing to PDF on OSX.

https://github.com/ariya/phantomjs/issues/10373

Please note: this PR is _almost_ the same as the original one by FreshXOpenSource: https://github.com/ariya/phantomjs/pull/11509 - the difference is that I have tried to refactor the PR to meet Contribution Guidelines and removed the filename extension check.
