### PR TITLE
Add option --script-language to explicitly set javascript or coffeescript

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -65,6 +65,7 @@ static const struct QCommandLineConfigEntry flags[] =
     { QCommandLine::Option, '\0', "proxy-auth", "Provides authentication information for the proxy, e.g. ''-proxy-auth=username:password'", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "proxy-type", "Specifies the proxy type, 'http' (default), 'none' (disable completely), or 'socks5'", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "script-encoding", "Sets the encoding used for the starting script, default is 'utf8'", QCommandLine::Optional },
+    { QCommandLine::Option, '\0', "script-language", "Sets the script language instead of detecting it: 'javascript', 'coffeescript'", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "web-security", "Enables web security, 'true' (default) or 'false'", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "ssl-protocol", "Sets the SSL protocol (supported protocols: 'SSLv3' (default), 'SSLv2', 'TLSv1', 'any')", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "ssl-certificates-path", "Sets the location for custom CA certificates (if none set, uses system default)", QCommandLine::Optional },
@@ -364,6 +365,20 @@ void Config::setScriptEncoding(const QString &value)
     m_scriptEncoding = value;
 }
 
+QString Config::scriptLanguage() const
+{
+    return m_scriptLanguage;
+}
+
+void Config::setScriptLanguage(const QString &value)
+{
+    if (value.isEmpty()) {
+        return;
+    }
+
+    m_scriptLanguage = value;
+}
+
 QString Config::scriptFile() const
 {
     return m_scriptFile;
@@ -528,6 +543,7 @@ void Config::resetToDefaults()
     m_proxyAuthPass.clear();
     m_scriptArgs.clear();
     m_scriptEncoding = "UTF-8";
+    m_scriptLanguage.clear();
     m_scriptFile.clear();
     m_unknownOption.clear();
     m_versionFlag = false;
@@ -685,6 +701,10 @@ void Config::handleOption(const QString &option, const QVariant &value)
 
     if (option == "script-encoding") {
         setScriptEncoding(value.toString());
+    }
+
+    if (option == "script-language") {
+        setScriptLanguage(value.toString());
     }
 
     if (option == "web-security") {

--- a/src/config.h
+++ b/src/config.h
@@ -121,6 +121,9 @@ public:
     QString scriptEncoding() const;
     void setScriptEncoding(const QString &value);
 
+    QString scriptLanguage() const;
+    void setScriptLanguage(const QString &value);
+
     QString scriptFile() const;
     void setScriptFile(const QString &value);
 
@@ -203,6 +206,7 @@ private:
     QString m_proxyAuthPass;
     QStringList m_scriptArgs;
     QString m_scriptEncoding;
+    QString m_scriptLanguage;
     QString m_scriptFile;
     QString m_unknownOption;
     bool m_versionFlag;

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -205,7 +205,7 @@ bool Phantom::execute()
         qDebug() << "Phantom - execute: Starting Remote WebDriver mode";
 
         Terminal::instance()->cout("PhantomJS is launching GhostDriver...");
-        if (!Utils::injectJsInFrame(":/ghostdriver/main.js", m_scriptFileEnc, QDir::currentPath(), m_page->mainFrame(), true)) {
+        if (!Utils::injectJsInFrame(":/ghostdriver/main.js", QString(), m_scriptFileEnc, QDir::currentPath(), m_page->mainFrame(), true)) {
             m_returnValue = -1;
             return false;
         }
@@ -225,7 +225,7 @@ bool Phantom::execute()
             }
             m_page->showInspector(m_config.remoteDebugPort());
         } else {
-            if (!Utils::injectJsInFrame(m_config.scriptFile(), m_scriptFileEnc, QDir::currentPath(), m_page->mainFrame(), true)) {
+            if (!Utils::injectJsInFrame(m_config.scriptFile(), m_config.scriptLanguage(), m_scriptFileEnc, QDir::currentPath(), m_page->mainFrame(), true)) {
                 m_returnValue = -1;
                 return false;
             }

--- a/src/utils.h
+++ b/src/utils.h
@@ -59,7 +59,7 @@ public:
 #endif    
     static QVariant coffee2js(const QString &script);
     static bool injectJsInFrame(const QString &jsFilePath, const QString &libraryPath, QWebFrame *targetFrame, const bool startingScript = false);
-    static bool injectJsInFrame(const QString &jsFilePath, const Encoding &jsFileEnc, const QString &libraryPath, QWebFrame *targetFrame, const bool startingScript = false);
+    static bool injectJsInFrame(const QString &jsFilePath, const QString &jsFileLanguage, const Encoding &jsFileEnc, const QString &libraryPath, QWebFrame *targetFrame, const bool startingScript = false);
     static QString readResourceFileUtf8(const QString &resourceFilePath);
 
     static bool loadJSForDebug(const QString &jsFilePath, const Encoding &jsFileEnc, const QString &libraryPath, QWebFrame *targetFrame, const bool autorun = false);
@@ -70,7 +70,7 @@ public:
 
 private:
     static QString findScript(const QString &jsFilePath, const QString& libraryPath);
-    static QString jsFromScriptFile(const QString& scriptPath, const Encoding& enc);
+    static QString jsFromScriptFile(const QString& scriptPath, const QString& lang, const Encoding& enc);
     Utils(); //< This class shouldn't be instantiated
 
     static QTemporaryFile* m_tempHarness; //< We want to make sure to clean up after ourselves


### PR DESCRIPTION
For #11744 I want to write a script in coffeescript and give it a shebang line of `#!/usr/bin/env phantomjs`. Unfortunately there's no way to specify the language of the script, so it would have to end in `.coffee` to be interpreted as coffeescript.

This PR add `--script-language` to override `.coffee` file extension matching.

On some platforms it will be possible to use the shebang `#!/usr/bin/env phantomjs --script-language=coffeescript`.
