### PR TITLE
Select monospace font family properly

### DIFF
--- a/src/qt/src/gui/kernel/qfontconfigdatabase.cpp
+++ b/src/qt/src/gui/kernel/qfontconfigdatabase.cpp
@@ -286,6 +286,7 @@ static const char *getFcFamilyForStyleHint(const QFont::StyleHint style)
         stylehint = "serif";
         break;
     case QFont::TypeWriter:
+    case QFont::Monospace:
         stylehint = "monospace";
         break;
     default:


### PR DESCRIPTION
CSS style "font-family: monospace" should select monospace font.

https://github.com/ariya/phantomjs/issues/11764
