### PR TITLE
fix lack of parse time errors location info

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -50,10 +50,12 @@ phantom.__defineErrorSignalHandler__ = function(obj, page, handlers) {
         delete handlers[handlerName];
 
         if (typeof f === 'function') {
-            var connector = function(message, stack) {
+            var connector = function(message, lineNumber, source, stack) {
                 var revisedStack = JSON.parse(stack).map(function(item) {
                     return { file: item.url, line: item.lineNumber, function: item.functionName }
                 });
+                if (revisedStack.length == 0)
+                    revisedStack = [{ file: source, line: lineNumber }];
 
                 f(message, revisedStack);
             };

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -158,9 +158,7 @@ protected:
     }
 
     void javaScriptError(const QString &message, int lineNumber, const QString &sourceID, const QString &stack) {
-        Q_UNUSED(lineNumber);
-        Q_UNUSED(sourceID);
-        emit m_webPage->javaScriptErrorSent(message, stack);
+        emit m_webPage->javaScriptErrorSent(message, lineNumber, sourceID, stack);
     }
 
     QString userAgentForUrl(const QUrl &url) const {

--- a/src/webpage.h
+++ b/src/webpage.h
@@ -465,7 +465,7 @@ signals:
     void loadFinished(const QString &status);
     void javaScriptAlertSent(const QString &msg);
     void javaScriptConsoleMessageSent(const QString &message);
-    void javaScriptErrorSent(const QString &msg, const QString &stack);
+    void javaScriptErrorSent(const QString &msg, int lineNumber, const QString &sourceID, const QString &stack);
     void resourceRequested(const QVariant &requestData, QObject *request);
     void resourceReceived(const QVariant &resource);
     void resourceError(const QVariant &errorData);

--- a/test/fixtures/parse-error-helper.js
+++ b/test/fixtures/parse-error-helper.js
@@ -1,0 +1,2 @@
+var ok;
+bar("run away"

--- a/test/phantom-spec.js
+++ b/test/phantom-spec.js
@@ -88,4 +88,21 @@ describe("phantom global object", function() {
         phantom.onError = undefined;
         expect(phantom.onError).toBeUndefined();
     });
+
+    it("reports parse time error source and line in stack", function() {
+        var stack;
+        phantom.onError = function(message, s) { stack = s; };
+
+        var helperFile = "./fixtures/parse-error-helper.js";
+        phantom.injectJs(helperFile);
+
+        waits(0);
+
+        runs(function() {
+            console.log(stack);
+            expect(stack[0].file).toEqual(helperFile);
+            expect(stack[0].line).toEqual(2);
+            phantom.onError = phantom.defaultErrorHandler;
+        });
+    });
 });


### PR DESCRIPTION
Location information of parse time error is given to javaScriptError not
with stack by with separate lineNumber and sourceID arguments. Put this info
to stack if it is empty so that it will be visible to user.

https://github.com/ariya/phantomjs/issues/11640
