### PR TITLE
Set proper jobs number and library paths before building in OpenBSD

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,7 +19,7 @@ elif [[ $OSTYPE = darwin* ]]; then
    # We only support modern Mac machines, they are at least using
    # hyperthreaded dual-core CPU.
    COMPILE_JOBS=4
-elif [[ $OSTYPE == freebsd* ]]; then
+elif [[ $OSTYPE == freebsd* ]] || [[ $OSTYPE == openbsd* ]]; then
    COMPILE_JOBS=`sysctl -n hw.ncpu`
 else
    CPU_CORES=`grep -c ^processor /proc/cpuinfo`

--- a/src/phantomjs.pro
+++ b/src/phantomjs.pro
@@ -60,7 +60,7 @@ include(mongoose/mongoose.pri)
 include(linenoise/linenoise.pri)
 include(qcommandline/qcommandline.pri)
 
-linux*|mac {
+linux*|mac|openbsd* {
     INCLUDEPATH += breakpad/src
 
     SOURCES += breakpad/src/client/minidump_file_writer.cc \
@@ -131,3 +131,8 @@ win32-msvc* {
             qico
     }
 }
+
+openbsd* {
+    LIBS += -L/usr/X11R6/lib
+}
+


### PR DESCRIPTION
I've been able to build phantomjs (both latest github code and 1.9.2) in OpenBSD (both the latest snapshot(s) and 5.4) and I'm working on a port to be added to the OpenBSD ports collection.

During this process I've found that a way to set the proper JOBS number was missing when building in OpenBSD, as well as the default directory for some libraries (X11-related stuff)

For the current stable release of phantomjs (1.9.2) I'll patch these files in the port itself, but it would be great if they are added to phantomjs' sources (as it is done with other operating systems).
