### PR TITLE
Clean the linux installation part / refactorisation

### DIFF
--- a/_posts/documentation/get-started/2013-08-09-build.md
+++ b/_posts/documentation/get-started/2013-08-09-build.md
@@ -20,9 +20,9 @@ git checkout 1.9
 
 This produces a static build `bin/phantomjs`. This is a self-contained executable, it can be moved to a different directory or another machine.
 
-## Linux
+## GNU/Linux
 
-For Ubuntu Linux (tested on a barebone install of Ubuntu 10.04 Lucid Lynx, Ubuntu 11.04 Natty Narwhal, Ubuntu 12.04 Precise Pangolin):
+### Debian based systems (APT)
 
 ```bash
 sudo apt-get update
@@ -32,8 +32,10 @@ cd phantomjs
 git checkout 1.9
 ./build.sh
 ```
+####Tested on:
++ Ubuntu (10.04, 11.04, 12.04)
 
-For Amazon EC2 AMI (release 2011.09, 2012.03) and CentOS/RHEL 6:
+### RHEL based systems (YUM)
 
 ```bash
 sudo yum install gcc gcc-c++ make git openssl-devel freetype-devel fontconfig-devel
@@ -43,9 +45,7 @@ git checkout 1.9
 ./build.sh
 ```
 
-**Note 1**: `build.sh` by default will launch parallel compile jobs depending on the available CPU cores, e.g. 4 jobs on a modern hyperthreaded dual-core processor. If necessary, e.g. when building on a virtual machine/server or other limited environment, reduce the jobs by passing a number, e.g `./build.sh --jobs 1` to set only one compile job at a time.
-
-**Note 2**: To create an RPM package (EC2 AMI, CentOS, or RHEL), make sure `rpm-build` package is installed and then
+**Note**: To create an RPM package (EC2 AMI, CentOS, or RHEL), make sure `rpm-build` package is installed and then
 run the following _after_ a successful build:
 
 ```bash
@@ -53,7 +53,15 @@ cd rpm
 ./mkrpm.sh phantomjs
 ```
 
-**Note 3**: Compile time for Ubuntu 12.04 running on Amazon EC2 _M1 Extra Large_ (m1.xlarge, 4 cores): 20 minutes, _M1 Large_ (m1.large, 2 cores): 50 minutes, _M1 Medium_ (m1.medium, 1 core): 100 minutes.
+####Tested on:
++ Amazon EC2 AMI (release 2011.09, 2012.03)
++ CentOS/RHEL 6
+
+---
+
+**Note 1**: `build.sh` by default will launch parallel compile jobs depending on the available CPU cores, e.g. 4 jobs on a modern hyperthreaded dual-core processor. If necessary, e.g. when building on a virtual machine/server or other limited environment, reduce the jobs by passing a number, e.g `./build.sh --jobs 1` to set only one compile job at a time.
+
+**Note 2**: Compile time for Ubuntu 12.04 running on Amazon EC2 _M1 Extra Large_ (m1.xlarge, 4 cores): 20 minutes, _M1 Large_ (m1.large, 2 cores): 50 minutes, _M1 Medium_ (m1.medium, 1 core): 100 minutes.
 
 ## Windows
 


### PR DESCRIPTION
IMHO, it is better to distinguish families of linux more than popular elements of those families.

(I'm working on install instructions for Gentoo, for a later pull request)
