### PR TITLE
Update of reference for mongoose license

### DIFF
--- a/third-party.txt
+++ b/third-party.txt
@@ -17,7 +17,7 @@ http://www.webkit.org/coding/bsd-license.html.
 
 Mongoose - https://github.com/valenok/mongoose
 License: MIT
-Reference: https://github.com/valenok/mongoose/blob/master/LICENSE
+Reference: https://github.com/cesanta/mongoose/commit/abbf27338ef554cce0281ac157aa71a9c1b82a55
 
 Breakpad - http://code.google.com/p/google-breakpad/
 License: BSD.


### PR DESCRIPTION
As it seems that project Mongoose has been relicensed from MIT to GPL2. The link provided is leading to the new licensing agreement but as today version 3.1 of Mongoose is used which is licensed under MIT therefore correct reference to a license should be provided.

Maybe even the reference to the project should be changed as the version 3.1 which is used is no longer downloadable from the link.
