### PR TITLE
Add a field for request headers on response

### DIFF
--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -316,6 +316,14 @@ void NetworkAccessManager::handleStarted()
         headers += header;
     }
 
+    QVariantList requestHeaders;
+    foreach (QByteArray headerName, reply->request().rawHeaderList()) {
+        QVariantMap header;
+        header["name"] = QString::fromUtf8(headerName);
+        header["value"] = QString::fromUtf8(reply->request().rawHeader(headerName));
+        requestHeaders += header;
+    }
+
     QVariantMap data;
     data["stage"] = "start";
     data["id"] = m_ids.value(reply);
@@ -326,6 +334,7 @@ void NetworkAccessManager::handleStarted()
     data["bodySize"] = reply->size();
     data["redirectURL"] = reply->header(QNetworkRequest::LocationHeader);
     data["headers"] = headers;
+    data["requestHeaders"] = requestHeaders;
     data["time"] = QDateTime::currentDateTime();
 
     emit resourceReceived(data);


### PR DESCRIPTION
There doesn't appear to be a way to get all of the headers sent with a request. When onResourceRequested is fired the headers aren't complete. This adds the request headers to the data for onResourceReceived in a new field called requestHeaders.

I looked at moving onResourceRequested to after QNetworkAccessManager::createRequest where more headers get set but from the tests it looks like onResourceRequested is used to set headers. 
