### PR TITLE
implement "page-break-inside: avoid" for non-floating block elements

### DIFF
--- a/src/qt/src/3rdparty/webkit/Source/WebCore/rendering/RenderBlock.cpp
+++ b/src/qt/src/3rdparty/webkit/Source/WebCore/rendering/RenderBlock.cpp
@@ -6054,7 +6054,8 @@ int RenderBlock::applyAfterBreak(RenderBox* child, int logicalOffset, MarginInfo
 
 int RenderBlock::adjustForUnsplittableChild(RenderBox* child, int logicalOffset, bool includeMargins)
 {
-    bool isUnsplittable = child->isReplaced() || child->scrollsOverflow();
+    bool isUnsplittable = child->isReplaced() || child->scrollsOverflow() ||
+                          child->style()->pageBreakInside() == PBAVOID;
     if (!isUnsplittable)
         return logicalOffset;
     int childLogicalHeight = logicalHeightForChild(child) + (includeMargins ? marginBeforeForChild(child) + marginAfterForChild(child) : 0);


### PR DESCRIPTION
This patch is taken from https://bugs.webkit.org/show_bug.cgi?id=5097#c17

It was originally part of PR #211 but was possibly overlooked in PR #344 (when the other two patches got reapplied after the QT source import).
