### PR TITLE
#11884 - New child windows now inherit the settings of the parent

### DIFF
--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -220,8 +220,8 @@ protected:
             Phantom::instance()->m_pages.append(newPage);
         }
 
-        // Apply default settings
-        newPage->applySettings(Phantom::instance()->defaultPageSettings());
+        // Apply default/existing settings
+        newPage->applySettings(m_webPage->m_settings);
 
         // Signal JS shim to catch, decorate and store this new child page
         emit m_webPage->rawPageCreated(newPage);
@@ -337,6 +337,7 @@ WebPage::WebPage(QObject *parent, const QUrl &baseUrl)
     m_customWebPage = new CustomPage(this);
     m_mainFrame = m_customWebPage->mainFrame();
     m_currentFrame = m_mainFrame;
+    m_settings = Phantom::instance()->defaultPageSettings();
     m_mainFrame->setHtml(BLANK_HTML, baseUrl);
 
     Config *phantomCfg = Phantom::instance()->config();
@@ -583,6 +584,8 @@ void WebPage::showInspector(const int port)
 
 void WebPage::applySettings(const QVariantMap &def)
 {
+    m_settings = def;
+
     QWebSettings *opt = m_customWebPage->settings();
 
     opt->setAttribute(QWebSettings::AutoLoadImages, def[PAGE_SETTINGS_LOAD_IMAGES].toBool());

--- a/src/webpage.h
+++ b/src/webpage.h
@@ -512,6 +512,7 @@ private:
     QRect m_clipRect;
     QPoint m_scrollPosition;
     QVariantMap m_paperSize; // For PDF output via render()
+    QVariantMap m_settings; // For retention of parent page settings
     QString m_libraryPath;
     QWebInspector* m_inspector;
     WebpageCallbacks *m_callbacks;


### PR DESCRIPTION
I hope I did this right. My C++ is rather rusty, and I'm just now familiarizing myself with phantom's code.

This fixes(I hope properly) part of issue #11884, in which child pages created from links, window.opens, etc in an initial page, do not inherit the parent's settings, such as the user agent.

However, it does not provide means of changing a child window's settings separately, before the child page is loaded. I'm guessing a new hook might be needed for that?
