### PR TITLE
Removed Homebrew warning from readme

### DIFF
--- a/_posts/documentation/get-started/2000-01-01-download.md
+++ b/_posts/documentation/get-started/2000-01-01-download.md
@@ -30,8 +30,6 @@ The binary `bin/phantomjs` is ready to use.
 
 <pre>brew update &amp;&amp; brew install phantomjs</pre>
 
-**Warning**: MacPorts does not have updated PhantomJS build yet. Installing via MacPorts is not recommended.
-
 ## Linux
 
 For 64-bit system, download [phantomjs-1.9.7-linux-x86_64.tar.bz2](https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.7-linux-x86_64.tar.bz2) (12.6 MB).


### PR DESCRIPTION
Homebrew has the latest version (1.9.7).
