### PR TITLE
Adds require.resolve() functionality for better combatibility with node modules.

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -266,9 +266,9 @@ phantom.callback = function(callback) {
         require.cache = cache;
         require.extensions = extensions;
         require.paths = paths;
-		require.resolve = function (request) {
-			return self._getFilename(request);
-		};
+        require.resolve = function (request) {
+            return self._getFilename(request);
+        };
         require.stub = function(request, exports) {
             self.stubs[request] = { exports: exports };
         };

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -266,6 +266,9 @@ phantom.callback = function(callback) {
         require.cache = cache;
         require.extensions = extensions;
         require.paths = paths;
+		require.resolve = function (request) {
+			return self._getFilename(request);
+		};
         require.stub = function(request, exports) {
             self.stubs[request] = { exports: exports };
         };


### PR DESCRIPTION
The ability to know the filename that will be resolved by require comes in handy in many cases.

One example would be to use the resolved filename with `page.injectJs()` for injection of modules installed via `npm`.

``` sh
npm install jquery
```

``` js
// In a module:
page.injectJs(require.resolve("jquery"));
```

As things stand now, i use the `module._getFilename()` method to achieve the same.
Adding it to `resolve` would make it easier to have code that runs both on node and phantomjs.

See http://nodejs.org/api/modules.html#modules_all_together for examples in nodejs.
