### PR TITLE
currentFrame NULL reference

### DIFF
--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -1543,7 +1543,7 @@ QStringList WebPage::childFramesName() const //< deprecated
 void WebPage::changeCurrentFrame(QWebFrame * const frame)
 {
     if (frame != m_currentFrame) {
-        qDebug() << "WebPage - changeCurrentFrame" << "from" << m_currentFrame->frameName() << "to" << frame->frameName();
+        qDebug() << "WebPage - changeCurrentFrame" << "from" << (m_currentFrame == NULL ? "Undefined" : m_currentFrame->frameName()) << "to" << frame->frameName();
         m_currentFrame = frame;
     }
 }


### PR DESCRIPTION
Phantomjs crashes when I have a popup window with an iframe that closes and I try to switch back to the main frame. The crash occurs because a debug line tries to access the frameName of the now not existing frame.

The Issue (and solution) is described here: "Crashing when switching to main frame" https://github.com/ariya/phantomjs/issues/11103.

Issue https://github.com/ariya/phantomjs/issues/11103 was merged into issue https://github.com/ariya/phantomjs/issues/10947 and closed, but was never solved.
