### PR TITLE
allow native modules to be created and require()'d

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -129,6 +129,10 @@ phantom.callback = function(callback) {
 
         '.json': function(module, filename) {
             module.exports = JSON.parse(fs.read(filename));
+        },
+
+        '.phantom': function(module, filename) {
+            module.exports = phantom.loadNativeModule(filename);
         }
     };
 

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -410,7 +410,10 @@ QObject* Phantom::loadNativeModule(const QString &modulePath)
         return 0;
     }
 
-    return (*createExtension)();
+    QObject* extensionObject = (*createExtension)();
+    m_nativeModules.append(extensionObject);
+
+    return extensionObject;
 }
 
 bool Phantom::injectJs(const QString &jsFilePath)
@@ -509,5 +512,7 @@ void Phantom::doExit(int code)
     qDeleteAll(m_pages);
     m_pages.clear();
     m_page = 0;
+    qDeleteAll(m_nativeModules);
+    m_nativeModules.clear();
     QApplication::instance()->exit(code);
 }

--- a/src/phantom.h
+++ b/src/phantom.h
@@ -197,6 +197,7 @@ private:
     QList<QPointer<WebServer> > m_servers;
     Config m_config;
     CookieJar *m_defaultCookieJar;
+    QList<QPointer<QObject> > m_nativeModules;
 
     friend class CustomPage;
 };

--- a/src/phantom.h
+++ b/src/phantom.h
@@ -117,6 +117,7 @@ public slots:
     QObject *createCallback();
     void loadModule(const QString &moduleSource, const QString &filename);
     bool injectJs(const QString &jsFilePath);
+    QObject *loadNativeModule(const QString &modulePath);
 
     /**
      * Allows to set cookies into the CookieJar.

--- a/test/require/require_spec.js
+++ b/test/require/require_spec.js
@@ -216,4 +216,25 @@ describe("require()", function() {
             });
         });
     });
+
+
+    it("can load native modules", function() {
+        require("fs").changeWorkingDirectory(phantom.libraryPath + "/require/test_native_module");
+
+        // first build native module
+        var buildFinished = false;
+        require("child_process").execFile("sh", ["build.sh"], null, function (err, stdout, stderr) {
+            buildFinished = true;
+        });
+
+        waitsFor(function() {
+          return buildFinished;
+        }, "the module to build", 1000);
+
+        runs(function () {
+            var nativeMod = require('./test_native_module/libmodule.phantom');
+            nativeMod.testProperty.should.equal("testPropertyValue");
+            nativeMod.testFunction().should.equal("testFunctionResult");
+        });
+    });
 });

--- a/test/require/test_native_module/.gitignore
+++ b/test/require/test_native_module/.gitignore
@@ -1,0 +1,6 @@
+*
+!module.cpp
+!module.hpp
+!module.pro
+!build.sh
+!.gitignore

--- a/test/require/test_native_module/build.sh
+++ b/test/require/test_native_module/build.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+../../../src/qt/bin/qmake
+make

--- a/test/require/test_native_module/module.cpp
+++ b/test/require/test_native_module/module.cpp
@@ -1,0 +1,25 @@
+#include "module.hpp"
+
+MyExtension::MyExtension()
+    : QObject()
+{
+}
+
+QString MyExtension::testProperty() const
+{
+    return "testPropertyValue";
+}
+
+QString MyExtension::testFunction()
+{
+    return "testFunctionResult";
+}
+
+MyExtension::~MyExtension()
+{
+}
+
+extern "C"
+{
+    Q_DECL_EXPORT QObject * createExtension() { return new MyExtension(); }
+}

--- a/test/require/test_native_module/module.hpp
+++ b/test/require/test_native_module/module.hpp
@@ -1,0 +1,16 @@
+#include <QObject>
+
+class MyExtension : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString testProperty READ testProperty)
+
+public:
+    MyExtension();
+    virtual ~MyExtension();
+
+    QString testProperty() const;
+
+public slots:
+    QString testFunction();
+};

--- a/test/require/test_native_module/module.pro
+++ b/test/require/test_native_module/module.pro
@@ -1,0 +1,4 @@
+TEMPLATE = lib
+HEADERS = module.hpp
+SOURCES = module.cpp
+QMAKE_EXTENSION_SHLIB = phantom


### PR DESCRIPTION
I need to extend phantomjs w/ some C++ code but I don't want to modify phantomjs directly and have to rebuild it constantly (the modifications will be running on travis). So I created this pull request which lets you build and require native modules (ie, shared libraries).

Notes:
- Native modules must end with the .phantom extension and must expose an extern "C" createNativeExtension function that returns a QObject \* to expose to JavaScript.
- I don't think the tests will pass on windows. It doesn't seem to be possible to specify a custom prefix when building a shared library w/ qmake. Or at least I can't find a way.

Let me know what you think.
