### PR TITLE
Create 2000-01-01-on-resource-timeout.md

### DIFF
--- a/_posts/api/webpage/handler/2000-01-01-on-resource-timeout.md
+++ b/_posts/api/webpage/handler/2000-01-01-on-resource-timeout.md
@@ -1,0 +1,31 @@
+---
+layout: post
+title:  onResourceTimeout
+categories: api webpage webpage-handler
+permalink: api/webpage/handler/on-resource-timeout.html
+---
+
+**Introduced:** PhantomJS 1.2
+
+This callback is invoked when a resource requested by the page timeout according to `settings.resourceTimeout`. The only argument to the callback is the `request` metadata object.
+
+The `request` metadata object contains these properties:
+
+ * `id`: the number of the requested resource
+ * `method`: http method
+ * `url`: the URL of the requested resource
+ * `time`: Date object containing the date of the request
+ * `headers`: list of http headers
+ * `errorCode`: the error code of the error
+ * `errorString`: text message of the error
+
+## Examples
+
+```javascript
+var webPage = require('webpage');
+var page = webPage.create();
+
+page.onResourceTimeout = function(request) {
+    console.log('Response (#' + request.id + '): ' + JSON.stringify(request));
+};
+```


### PR DESCRIPTION
The `onResourceTimeout` method which is defined in the [API Reference WebPage](https://github.com/ariya/phantomjs/wiki/API-Reference-WebPage) was missing from the website.
