### PR TITLE
Update 2000-01-02-build.md

### DIFF
--- a/_posts/documentation/get-started/2000-01-02-build.md
+++ b/_posts/documentation/get-started/2000-01-02-build.md
@@ -26,7 +26,7 @@ This produces a static build `bin/phantomjs`. This is a self-contained executabl
 
 ```bash
 sudo apt-get update
-sudo apt-get install build-essential chrpath git-core libssl-dev libfontconfig1-dev
+sudo apt-get install build-essential chrpath git-core libssl-dev libfontconfig1-dev qt3-dev-tools
 git clone git://github.com/ariya/phantomjs.git
 cd phantomjs
 git checkout 1.9


### PR DESCRIPTION
I found that I needed to have qt3-dev-tools installed on my Ubuntu 12.04 machine in order to build qmake.
