### PR TITLE
All local storage paths in one directory and config argument.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,6 +49,10 @@ Q_IMPORT_PLUGIN(qcncodecs)
 Q_IMPORT_PLUGIN(qjpcodecs)
 Q_IMPORT_PLUGIN(qkrcodecs)
 Q_IMPORT_PLUGIN(qtwcodecs)
+#ifdef Q_OS_MAC
+Q_IMPORT_PLUGIN(qgenericbearer)
+Q_IMPORT_PLUGIN(qcorewlanbearer)
+#endif
 #endif
 
 #ifdef Q_OS_WIN32

--- a/src/phantomjs.pro
+++ b/src/phantomjs.pro
@@ -76,6 +76,12 @@ linux*|mac|openbsd* {
         qtwcodecs
 }
 
+mac {
+    QTPLUGIN += \
+        qgenericbearer \
+        qcorewlanbearer
+}
+
 linux* {
     SOURCES += breakpad/src/client/linux/crash_generation/crash_generation_client.cc \
       breakpad/src/client/linux/handler/exception_handler.cc \

--- a/src/qt/preconfig.sh
+++ b/src/qt/preconfig.sh
@@ -128,3 +128,8 @@ make -j$COMPILE_JOBS $SILENT
 pushd src/plugins/codecs/
 make -j$COMPILE_JOBS $SILENT
 popd
+
+# Build bearer
+pushd src/plugins/bearer/
+make -j$COMPILE_JOBS $SILENT
+popd

--- a/src/qt/src/plugins/bearer/bearer.pro
+++ b/src/qt/src/plugins/bearer/bearer.pro
@@ -1,0 +1,20 @@
+TEMPLATE = subdirs
+
+contains(QT_CONFIG, dbus) {
+    contains(QT_CONFIG, icd) {
+        SUBDIRS += icd
+    } else:linux* {
+        SUBDIRS += generic
+        SUBDIRS += connman networkmanager
+    }
+}
+
+#win32:SUBDIRS += nla
+win32:SUBDIRS += generic
+win32:!wince*:SUBDIRS += nativewifi
+macx:contains(QT_CONFIG, corewlan):SUBDIRS += corewlan
+macx:SUBDIRS += generic
+symbian:SUBDIRS += symbian
+blackberry:SUBDIRS += blackberry
+
+isEmpty(SUBDIRS):SUBDIRS = generic

--- a/src/qt/src/plugins/bearer/corewlan/corewlan.pro
+++ b/src/qt/src/plugins/bearer/corewlan/corewlan.pro
@@ -1,0 +1,24 @@
+TARGET = qcorewlanbearer
+include(../../qpluginbase.pri)
+
+QT = core network
+LIBS += -framework Foundation -framework SystemConfiguration
+
+contains(QT_CONFIG, corewlan) {
+    isEmpty(QMAKE_MAC_SDK)|contains(QMAKE_MAC_SDK, "/Developer/SDKs/MacOSX10\.[67]\.sdk") {
+         LIBS += -framework CoreWLAN -framework Security
+    }
+}
+
+HEADERS += qcorewlanengine.h \
+           ../qnetworksession_impl.h \
+           ../qbearerengine_impl.h
+
+SOURCES += main.cpp \
+           ../qnetworksession_impl.cpp
+
+OBJECTIVE_SOURCES += qcorewlanengine.mm
+
+QTDIR_build:DESTDIR = $$QT_BUILD_TREE/plugins/bearer
+target.path += $$[QT_INSTALL_PLUGINS]/bearer
+INSTALLS += target

--- a/src/qt/src/plugins/bearer/corewlan/main.cpp
+++ b/src/qt/src/plugins/bearer/corewlan/main.cpp
@@ -1,0 +1,88 @@
+/****************************************************************************
+**
+** Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
+** Contact: http://www.qt-project.org/legal
+**
+** This file is part of the plugins of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and Digia.  For licensing terms and
+** conditions see http://qt.digia.com/licensing.  For further information
+** use the contact form at http://qt.digia.com/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** In addition, as a special exception, Digia gives you certain additional
+** rights.  These rights are described in the Digia Qt LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 3.0 as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU General Public License version 3.0 requirements will be
+** met: http://www.gnu.org/copyleft/gpl.html.
+**
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "qcorewlanengine.h"
+
+#include <QtNetwork/private/qbearerplugin_p.h>
+
+#include <QtCore/qdebug.h>
+
+#ifndef QT_NO_BEARERMANAGEMENT
+
+QT_BEGIN_NAMESPACE
+
+class QCoreWlanEnginePlugin : public QBearerEnginePlugin
+{
+public:
+    QCoreWlanEnginePlugin();
+    ~QCoreWlanEnginePlugin();
+
+    QStringList keys() const;
+    QBearerEngine *create(const QString &key) const;
+};
+
+QCoreWlanEnginePlugin::QCoreWlanEnginePlugin()
+{
+}
+
+QCoreWlanEnginePlugin::~QCoreWlanEnginePlugin()
+{
+}
+
+QStringList QCoreWlanEnginePlugin::keys() const
+{
+    return QStringList() << QLatin1String("corewlan");
+}
+
+QBearerEngine *QCoreWlanEnginePlugin::create(const QString &key) const
+{
+    if (key == QLatin1String("corewlan"))
+        return new QCoreWlanEngine;
+    else
+        return 0;
+}
+
+Q_EXPORT_STATIC_PLUGIN(QCoreWlanEnginePlugin)
+Q_EXPORT_PLUGIN2(qcorewlanbearer, QCoreWlanEnginePlugin)
+
+QT_END_NAMESPACE
+
+#endif // QT_NO_BEARERMANAGEMENT

--- a/src/qt/src/plugins/bearer/corewlan/qcorewlanengine.h
+++ b/src/qt/src/plugins/bearer/corewlan/qcorewlanengine.h
@@ -1,0 +1,147 @@
+/****************************************************************************
+**
+** Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
+** Contact: http://www.qt-project.org/legal
+**
+** This file is part of the plugins of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and Digia.  For licensing terms and
+** conditions see http://qt.digia.com/licensing.  For further information
+** use the contact form at http://qt.digia.com/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** In addition, as a special exception, Digia gives you certain additional
+** rights.  These rights are described in the Digia Qt LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 3.0 as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU General Public License version 3.0 requirements will be
+** met: http://www.gnu.org/copyleft/gpl.html.
+**
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef QCOREWLANENGINE_H
+#define QCOREWLANENGINE_H
+
+#include "../qbearerengine_impl.h"
+
+#include <QMap>
+#include <QTimer>
+#include <SystemConfiguration/SystemConfiguration.h>
+#include <QThread>
+
+#ifndef QT_NO_BEARERMANAGEMENT
+
+QT_BEGIN_NAMESPACE
+
+class QNetworkConfigurationPrivate;
+class QScanThread;
+
+class QCoreWlanEngine : public QBearerEngineImpl
+{
+     friend class QScanThread;
+    Q_OBJECT
+
+public:
+    QCoreWlanEngine(QObject *parent = 0);
+    ~QCoreWlanEngine();
+
+    QString getInterfaceFromId(const QString &id);
+    bool hasIdentifier(const QString &id);
+
+    void connectToId(const QString &id);
+    void disconnectFromId(const QString &id);
+
+    Q_INVOKABLE void initialize();
+    Q_INVOKABLE void requestUpdate();
+
+    QNetworkSession::State sessionStateForId(const QString &id);
+
+    quint64 bytesWritten(const QString &id);
+    quint64 bytesReceived(const QString &id);
+    quint64 startTime(const QString &id);
+
+    QNetworkConfigurationManager::Capabilities capabilities() const;
+
+    QNetworkSessionPrivate *createSessionBackend();
+
+    QNetworkConfigurationPrivatePointer defaultConfiguration();
+
+    bool requiresPolling() const;
+
+private Q_SLOTS:
+    void doRequestUpdate();
+    void networksChanged();
+
+private:
+    bool isWifiReady(const QString &dev);
+    QList<QNetworkConfigurationPrivate *> foundConfigurations;
+
+    SCDynamicStoreRef storeSession;
+    CFRunLoopSourceRef runloopSource;
+    bool hasWifi;
+    bool scanning;
+    QScanThread *scanThread;
+
+    quint64 getBytes(const QString &interfaceName,bool b);
+
+protected:
+    void startNetworkChangeLoop();
+
+};
+
+class QScanThread : public QThread
+{
+    Q_OBJECT
+
+public:
+    QScanThread(QObject *parent = 0);
+    ~QScanThread();
+
+    void quit();
+    QList<QNetworkConfigurationPrivate *> getConfigurations();
+    QString interfaceName;
+    QMap<QString, QString> configurationInterface;
+    void getUserConfigurations();
+    QString getNetworkNameFromSsid(const QString &ssid);
+    QString getSsidFromNetworkName(const QString &name);
+    bool isKnownSsid(const QString &ssid);
+    QMap<QString, QMap<QString,QString> > userProfiles;
+
+signals:
+    void networksChanged();
+
+protected:
+    void run();
+
+private:
+    QList<QNetworkConfigurationPrivate *> fetchedConfigurations;
+    QMutex mutex;
+    QStringList foundNetwork(const QString &id, const QString &ssid, const QNetworkConfiguration::StateFlags state, const QString &interfaceName, const QNetworkConfiguration::Purpose purpose);
+
+};
+
+QT_END_NAMESPACE
+
+#endif // QT_NO_BEARERMANAGEMENT
+
+#endif

--- a/src/qt/src/plugins/bearer/corewlan/qcorewlanengine.mm
+++ b/src/qt/src/plugins/bearer/corewlan/qcorewlanengine.mm
@@ -1,0 +1,863 @@
+/****************************************************************************
+**
+** Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
+** Contact: http://www.qt-project.org/legal
+**
+** This file is part of the plugins of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and Digia.  For licensing terms and
+** conditions see http://qt.digia.com/licensing.  For further information
+** use the contact form at http://qt.digia.com/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** In addition, as a special exception, Digia gives you certain additional
+** rights.  These rights are described in the Digia Qt LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 3.0 as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU General Public License version 3.0 requirements will be
+** met: http://www.gnu.org/copyleft/gpl.html.
+**
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "qcorewlanengine.h"
+#include "../qnetworksession_impl.h"
+
+#include <QtNetwork/private/qnetworkconfiguration_p.h>
+
+#include <QtCore/qthread.h>
+#include <QtCore/qmutex.h>
+#include <QtCore/qcoreapplication.h>
+#include <QtCore/qstringlist.h>
+
+#include <QtCore/qdebug.h>
+
+#include <QDir>
+
+extern "C" { // Otherwise it won't find CWKeychain* symbols at link time
+#import <CoreWLAN/CoreWLAN.h>
+}
+
+#include "private/qcore_mac_p.h"
+
+#include <net/if.h>
+#include <ifaddrs.h>
+
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_7
+
+@interface QT_MANGLE_NAMESPACE(QNSListener) : NSObject
+{
+    NSNotificationCenter *notificationCenter;
+    CWInterface *currentInterface;
+    QCoreWlanEngine *engine;
+    NSLock *locker;
+}
+- (void)notificationHandler:(NSNotification *)notification;
+- (void)remove;
+- (void)setEngine:(QCoreWlanEngine *)coreEngine;
+- (QCoreWlanEngine *)engine;
+- (void)dealloc;
+
+@property (assign) QCoreWlanEngine* engine;
+
+@end
+
+@implementation QT_MANGLE_NAMESPACE(QNSListener)
+
+- (id) init
+{
+    [locker lock];
+    NSAutoreleasePool *autoreleasepool = [[NSAutoreleasePool alloc] init];
+    notificationCenter = [NSNotificationCenter defaultCenter];
+    currentInterface = [CWInterface interfaceWithName:nil];
+    [notificationCenter addObserver:self selector:@selector(notificationHandler:) name:CWPowerDidChangeNotification object:nil];
+    [locker unlock];
+    [autoreleasepool release];
+    return self;
+}
+
+-(void)dealloc
+{
+    [super dealloc];
+}
+
+-(void)setEngine:(QCoreWlanEngine *)coreEngine
+{
+    [locker lock];
+    if(!engine)
+        engine = coreEngine;
+    [locker unlock];
+}
+
+-(QCoreWlanEngine *)engine
+{
+    return engine;
+}
+
+-(void)remove
+{
+    [locker lock];
+    [notificationCenter removeObserver:self];
+    [locker unlock];
+}
+
+- (void)notificationHandler:(NSNotification *)notification
+{
+    Q_UNUSED(notification);
+    engine->requestUpdate();
+}
+@end
+
+static QT_MANGLE_NAMESPACE(QNSListener) *listener = 0;
+
+QT_BEGIN_NAMESPACE
+
+void networkChangeCallback(SCDynamicStoreRef/* store*/, CFArrayRef changedKeys, void *info)
+{
+    for ( long i = 0; i < CFArrayGetCount(changedKeys); i++) {
+
+        QString changed =  QCFString::toQString((CFStringRef)CFArrayGetValueAtIndex(changedKeys, i));
+        if( changed.contains("/Network/Global/IPv4")) {
+            QCoreWlanEngine* wlanEngine = static_cast<QCoreWlanEngine*>(info);
+            wlanEngine->requestUpdate();
+        }
+    }
+    return;
+}
+
+
+QScanThread::QScanThread(QObject *parent)
+    :QThread(parent)
+{
+}
+
+QScanThread::~QScanThread()
+{
+}
+
+void QScanThread::quit()
+{
+    wait();
+}
+
+void QScanThread::run()
+{
+    NSAutoreleasePool *autoreleasepool = [[NSAutoreleasePool alloc] init];
+    QStringList found;
+    mutex.lock();
+    CWInterface *currentInterface = [CWInterface interfaceWithName: (NSString *)QCFString::toCFStringRef(interfaceName)];
+    mutex.unlock();
+
+    if (currentInterface.powerOn) {
+        NSError *err = nil;
+
+        NSSet* apSet = [currentInterface scanForNetworksWithName:nil error:&err];
+
+        if (!err) {
+            for (CWNetwork *apNetwork in apSet) {
+                const QString networkSsid = QCFString::toQString(CFStringRef([apNetwork ssid]));
+                const QString id = QString::number(qHash(QLatin1String("corewlan:") + networkSsid));
+                found.append(id);
+
+                QNetworkConfiguration::StateFlags state = QNetworkConfiguration::Undefined;
+                bool known = isKnownSsid(networkSsid);
+                if (currentInterface.serviceActive) {
+                    if( networkSsid == QCFString::toQString(CFStringRef([currentInterface ssid]))) {
+                        state = QNetworkConfiguration::Active;
+                    }
+                }
+                if (state == QNetworkConfiguration::Undefined) {
+                    if(known) {
+                        state = QNetworkConfiguration::Discovered;
+                    } else {
+                        state = QNetworkConfiguration::Undefined;
+                    }
+                }
+                QNetworkConfiguration::Purpose purpose = QNetworkConfiguration::UnknownPurpose;
+                if ([apNetwork supportsSecurity:kCWSecurityNone]) {
+                    purpose = QNetworkConfiguration::PublicPurpose;
+                } else {
+                    purpose = QNetworkConfiguration::PrivatePurpose;
+                }
+
+                found.append(foundNetwork(id, networkSsid, state, interfaceName, purpose));
+
+            }
+        }
+    }
+    // add known configurations that are not around.
+    QMapIterator<QString, QMap<QString,QString> > i(userProfiles);
+    while (i.hasNext()) {
+        i.next();
+
+        QString networkName = i.key();
+        const QString id = QString::number(qHash(QLatin1String("corewlan:") + networkName));
+
+        if(!found.contains(id)) {
+            QString networkSsid = getSsidFromNetworkName(networkName);
+            const QString ssidId = QString::number(qHash(QLatin1String("corewlan:") + networkSsid));
+            QNetworkConfiguration::StateFlags state = QNetworkConfiguration::Undefined;
+            QString interfaceName;
+            QMapIterator<QString, QString> ij(i.value());
+            while (ij.hasNext()) {
+                ij.next();
+                interfaceName = ij.value();
+            }
+
+            if (currentInterface.serviceActive) {
+                if( networkSsid == QCFString::toQString(CFStringRef([currentInterface ssid]))) {
+                    state = QNetworkConfiguration::Active;
+                }
+            }
+            if(state == QNetworkConfiguration::Undefined) {
+                if( userProfiles.contains(networkName)
+                    && found.contains(ssidId)) {
+                    state = QNetworkConfiguration::Discovered;
+                }
+            }
+
+            if(state == QNetworkConfiguration::Undefined) {
+                state = QNetworkConfiguration::Defined;
+            }
+
+            found.append(foundNetwork(id, networkName, state, interfaceName, QNetworkConfiguration::UnknownPurpose));
+        }
+    }
+    emit networksChanged();
+    [autoreleasepool release];
+}
+
+QStringList QScanThread::foundNetwork(const QString &id, const QString &name, const QNetworkConfiguration::StateFlags state, const QString &interfaceName, const QNetworkConfiguration::Purpose purpose)
+{
+    QStringList found;
+    QMutexLocker locker(&mutex);
+        QNetworkConfigurationPrivate *ptr = new QNetworkConfigurationPrivate;
+
+        ptr->name = name;
+        ptr->isValid = true;
+        ptr->id = id;
+        ptr->state = state;
+        ptr->type = QNetworkConfiguration::InternetAccessPoint;
+        ptr->bearerType = QNetworkConfiguration::BearerWLAN;
+        ptr->purpose = purpose;
+
+        fetchedConfigurations.append( ptr);
+        configurationInterface.insert(ptr->id, interfaceName);
+
+        locker.unlock();
+        locker.relock();
+       found.append(id);
+    return found;
+}
+
+QList<QNetworkConfigurationPrivate *> QScanThread::getConfigurations()
+{
+    QMutexLocker locker(&mutex);
+
+    QList<QNetworkConfigurationPrivate *> foundConfigurations = fetchedConfigurations;
+    fetchedConfigurations.clear();
+
+    return foundConfigurations;
+}
+
+void QScanThread::getUserConfigurations()
+{
+    QMutexLocker locker(&mutex);
+
+    NSAutoreleasePool *autoreleasepool = [[NSAutoreleasePool alloc] init];
+    userProfiles.clear();
+
+    NSSet *wifiInterfaces = [CWInterface interfaceNames];
+    for (NSString *ifName in wifiInterfaces) {
+
+        CWInterface *wifiInterface = [CWInterface interfaceWithName: ifName];
+        if (!wifiInterface.powerOn)
+            continue;
+
+        NSString *nsInterfaceName = wifiInterface.ssid;
+// add user configured system networks
+        SCDynamicStoreRef dynRef = SCDynamicStoreCreate(kCFAllocatorSystemDefault, (CFStringRef)@"Qt corewlan", nil, nil);
+        NSDictionary * airportPlist = (NSDictionary *)SCDynamicStoreCopyValue(dynRef, (CFStringRef)[NSString stringWithFormat:@"Setup:/Network/Interface/%@/AirPort", nsInterfaceName]);
+        CFRelease(dynRef);
+        if(airportPlist != nil) {
+            NSDictionary *prefNetDict = [airportPlist objectForKey:@"PreferredNetworks"];
+
+            NSArray *thisSsidarray = [prefNetDict valueForKey:@"SSID_STR"];
+            for (NSString *ssidkey in thisSsidarray) {
+                QString thisSsid = QCFString::toQString(CFStringRef(ssidkey));
+                if(!userProfiles.contains(thisSsid)) {
+                    QMap <QString,QString> map;
+                    map.insert(thisSsid, QCFString::toQString(CFStringRef(nsInterfaceName)));
+                    userProfiles.insert(thisSsid, map);
+                }
+            }
+            CFRelease(airportPlist);
+        }
+
+        // 802.1X user profiles
+        QString userProfilePath = QDir::homePath() + "/Library/Preferences/com.apple.eap.profiles.plist";
+        NSDictionary* eapDict = [[[NSDictionary alloc] initWithContentsOfFile: (NSString *)QCFString::toCFStringRef(userProfilePath)] autorelease];
+        if(eapDict != nil) {
+            NSString *profileStr= @"Profiles";
+            NSString *nameStr = @"UserDefinedName";
+            NSString *networkSsidStr = @"Wireless Network";
+            for (id profileKey in eapDict) {
+                if ([profileStr isEqualToString:profileKey]) {
+                    NSDictionary *itemDict = [eapDict objectForKey:profileKey];
+                    for (id itemKey in itemDict) {
+
+                        NSInteger dictSize = [itemKey count];
+                        id objects[dictSize];
+                        id keys[dictSize];
+
+                        [itemKey getObjects:objects andKeys:keys];
+                        QString networkName;
+                        QString ssid;
+                        for(int i = 0; i < dictSize; i++) {
+                            if([nameStr isEqualToString:keys[i]]) {
+                                networkName = QCFString::toQString(CFStringRef(objects[i]));
+                            }
+                            if([networkSsidStr isEqualToString:keys[i]]) {
+                                ssid = QCFString::toQString(CFStringRef(objects[i]));
+                            }
+                            if(!userProfiles.contains(networkName)
+                                && !ssid.isEmpty()) {
+                                QMap<QString,QString> map;
+                                map.insert(ssid, QCFString::toQString(CFStringRef(nsInterfaceName)));
+                                userProfiles.insert(networkName, map);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    [autoreleasepool release];
+}
+
+QString QScanThread::getSsidFromNetworkName(const QString &name)
+{
+    QMutexLocker locker(&mutex);
+
+    QMapIterator<QString, QMap<QString,QString> > i(userProfiles);
+    while (i.hasNext()) {
+        i.next();
+        QMap<QString,QString> map = i.value();
+        QMapIterator<QString, QString> ij(i.value());
+         while (ij.hasNext()) {
+             ij.next();
+             const QString networkNameHash = QString::number(qHash(QLatin1String("corewlan:") +i.key()));
+             if(name == i.key() || name == networkNameHash) {
+                 return ij.key();
+             }
+        }
+    }
+    return QString();
+}
+
+QString QScanThread::getNetworkNameFromSsid(const QString &ssid)
+{
+    QMutexLocker locker(&mutex);
+
+    QMapIterator<QString, QMap<QString,QString> > i(userProfiles);
+    while (i.hasNext()) {
+        i.next();
+        QMap<QString,QString> map = i.value();
+        QMapIterator<QString, QString> ij(i.value());
+         while (ij.hasNext()) {
+             ij.next();
+             if(ij.key() == ssid) {
+                 return i.key();
+             }
+         }
+    }
+    return QString();
+}
+
+bool QScanThread::isKnownSsid(const QString &ssid)
+{
+    QMutexLocker locker(&mutex);
+
+    QMapIterator<QString, QMap<QString,QString> > i(userProfiles);
+    while (i.hasNext()) {
+        i.next();
+        QMap<QString,QString> map = i.value();
+        if(map.keys().contains(ssid)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+
+QCoreWlanEngine::QCoreWlanEngine(QObject *parent)
+:   QBearerEngineImpl(parent), scanThread(0)
+{
+    scanThread = new QScanThread(this);
+    connect(scanThread, SIGNAL(networksChanged()),
+            this, SLOT(networksChanged()));
+}
+
+QCoreWlanEngine::~QCoreWlanEngine()
+{
+    while (!foundConfigurations.isEmpty())
+        delete foundConfigurations.takeFirst();
+    [listener remove];
+    [listener release];
+}
+
+void QCoreWlanEngine::initialize()
+{
+    QMutexLocker locker(&mutex);
+    NSAutoreleasePool *autoreleasepool = [[NSAutoreleasePool alloc] init];
+
+    if ([[CWInterface interfaceNames] count] > 0 && !listener) {
+        listener = [[QT_MANGLE_NAMESPACE(QNSListener) alloc] init];
+        listener.engine = this;
+        hasWifi = true;
+    } else {
+        hasWifi = false;
+    }
+    storeSession = NULL;
+
+    startNetworkChangeLoop();
+    [autoreleasepool release];
+}
+
+
+QString QCoreWlanEngine::getInterfaceFromId(const QString &id)
+{
+    QMutexLocker locker(&mutex);
+
+    return scanThread->configurationInterface.value(id);
+}
+
+bool QCoreWlanEngine::hasIdentifier(const QString &id)
+{
+    QMutexLocker locker(&mutex);
+
+    return scanThread->configurationInterface.contains(id);
+}
+
+void QCoreWlanEngine::connectToId(const QString &id)
+{
+    QMutexLocker locker(&mutex);
+    NSAutoreleasePool *autoreleasepool = [[NSAutoreleasePool alloc] init];
+    QString interfaceString = getInterfaceFromId(id);
+
+    CWInterface *wifiInterface =
+        [CWInterface interfaceWithName: (NSString *)QCFString::toCFStringRef(interfaceString)];
+
+    if (wifiInterface.powerOn) {
+        NSError *err = nil;
+        QString wantedSsid;
+        QNetworkConfigurationPrivatePointer ptr = accessPointConfigurations.value(id);
+
+        const QString idHash = QString::number(qHash(QLatin1String("corewlan:") + ptr->name));
+        const QString idHash2 = QString::number(qHash(QLatin1String("corewlan:") + scanThread->getNetworkNameFromSsid(ptr->name)));
+
+        QString wantedNetwork;
+        QMapIterator<QString, QMap<QString, QString> > i(scanThread->userProfiles);
+        while (i.hasNext()) {
+            i.next();
+            wantedNetwork = i.key();
+            const QString networkNameHash = QString::number(qHash(QLatin1String("corewlan:") + wantedNetwork));
+            if (id == networkNameHash) {
+                wantedSsid = scanThread->getSsidFromNetworkName(wantedNetwork);
+                break;
+            }
+        }
+
+        NSSet *scanSet = [wifiInterface scanForNetworksWithName:(NSString *)QCFString::toCFStringRef(wantedSsid) error:&err];
+
+        if(!err) {
+            for (CWNetwork *apNetwork in scanSet) {
+                CFDataRef ssidData = (CFDataRef)[apNetwork ssidData];
+                bool result = false;
+
+                SecIdentityRef identity = 0;
+                // Check first whether we require IEEE 802.1X authentication for the wanted SSID
+                if (CWKeychainCopyEAPIdentity(ssidData, &identity) == errSecSuccess) {
+                    CFStringRef username = 0;
+                    CFStringRef password = 0;
+                    if (CWKeychainCopyEAPUsernameAndPassword(ssidData, &username, &password) == errSecSuccess) {
+                        result = [wifiInterface associateToEnterpriseNetwork:apNetwork
+                                    identity:identity username:(NSString *)username password:(NSString *)password
+                                    error:&err];
+                        CFRelease(username);
+                        CFRelease(password);
+                    }
+                    CFRelease(identity);
+                } else {
+                    CFStringRef password = 0;
+                    if (CWKeychainCopyPassword(ssidData, &password) == errSecSuccess) {
+                        result = [wifiInterface associateToNetwork:apNetwork password:(NSString *)password error:&err];
+                        CFRelease(password);
+                    }
+                }
+
+                if (!err) {
+                    if (!result) {
+                        emit connectionError(id, ConnectError);
+                    } else {
+                        return;
+                    }
+                } else {
+                    qDebug() <<"associate ERROR"<<  QCFString::toQString(CFStringRef([err localizedDescription ]));
+                }
+            } //end scan network
+        } else {
+            qDebug() <<"scan ERROR"<<  QCFString::toQString(CFStringRef([err localizedDescription ]));
+        }
+        emit connectionError(id, InterfaceLookupError);
+    }
+
+    locker.unlock();
+    emit connectionError(id, InterfaceLookupError);
+    [autoreleasepool release];
+}
+
+void QCoreWlanEngine::disconnectFromId(const QString &id)
+{
+    QMutexLocker locker(&mutex);
+
+    QString interfaceString = getInterfaceFromId(id);
+    NSAutoreleasePool *autoreleasepool = [[NSAutoreleasePool alloc] init];
+
+    CWInterface *wifiInterface =
+        [CWInterface interfaceWithName: (NSString *)QCFString::toCFStringRef(interfaceString)];
+
+    [wifiInterface disassociate];
+    if (wifiInterface.serviceActive) {
+        locker.unlock();
+        emit connectionError(id, DisconnectionError);
+        locker.relock();
+    }
+    [autoreleasepool release];
+}
+
+void QCoreWlanEngine::requestUpdate()
+{
+    scanThread->getUserConfigurations();
+    doRequestUpdate();
+}
+
+void QCoreWlanEngine::doRequestUpdate()
+{
+    QMutexLocker locker(&mutex);
+
+    NSAutoreleasePool *autoreleasepool = [[NSAutoreleasePool alloc] init];
+
+    NSSet *wifiInterfaces = [CWInterface interfaceNames];
+    for (NSString *ifName in wifiInterfaces) {
+            scanThread->interfaceName = QCFString::toQString(CFStringRef(ifName));
+            scanThread->start();
+    }
+    locker.unlock();
+    [autoreleasepool release];
+}
+
+bool QCoreWlanEngine::isWifiReady(const QString &wifiDeviceName)
+{
+    QMutexLocker locker(&mutex);
+    bool haswifi = false;
+    if(hasWifi) {
+        NSAutoreleasePool *autoreleasepool = [[NSAutoreleasePool alloc] init];
+        CWInterface *defaultInterface = [CWInterface interfaceWithName: (NSString *)QCFString::toCFStringRef(wifiDeviceName)];
+        if (defaultInterface.powerOn) {
+            haswifi = true;
+        }
+        [autoreleasepool release];
+    }
+    return haswifi;
+}
+
+
+QNetworkSession::State QCoreWlanEngine::sessionStateForId(const QString &id)
+{
+    QMutexLocker locker(&mutex);
+    QNetworkConfigurationPrivatePointer ptr = accessPointConfigurations.value(id);
+
+    if (!ptr)
+        return QNetworkSession::Invalid;
+
+    if (!ptr->isValid) {
+        return QNetworkSession::Invalid;
+    } else if ((ptr->state & QNetworkConfiguration::Active) == QNetworkConfiguration::Active) {
+        return QNetworkSession::Connected;
+    } else if ((ptr->state & QNetworkConfiguration::Discovered) ==
+                QNetworkConfiguration::Discovered) {
+        return QNetworkSession::Disconnected;
+    } else if ((ptr->state & QNetworkConfiguration::Defined) == QNetworkConfiguration::Defined) {
+        return QNetworkSession::NotAvailable;
+    } else if ((ptr->state & QNetworkConfiguration::Undefined) ==
+                QNetworkConfiguration::Undefined) {
+        return QNetworkSession::NotAvailable;
+    }
+
+    return QNetworkSession::Invalid;
+}
+
+QNetworkConfigurationManager::Capabilities QCoreWlanEngine::capabilities() const
+{
+    return QNetworkConfigurationManager::ForcedRoaming;
+}
+
+void QCoreWlanEngine::startNetworkChangeLoop()
+{
+
+    SCDynamicStoreContext dynStoreContext = { 0, this/*(void *)storeSession*/, NULL, NULL, NULL };
+    storeSession = SCDynamicStoreCreate(NULL,
+                                 CFSTR("networkChangeCallback"),
+                                 networkChangeCallback,
+                                 &dynStoreContext);
+    if (!storeSession ) {
+        qWarning() << "could not open dynamic store: error:" << SCErrorString(SCError());
+        return;
+    }
+
+    CFMutableArrayRef notificationKeys;
+    notificationKeys = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+    CFMutableArrayRef patternsArray;
+    patternsArray = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+
+    CFStringRef storeKey;
+    storeKey = SCDynamicStoreKeyCreateNetworkGlobalEntity(NULL,
+                                                     kSCDynamicStoreDomainState,
+                                                     kSCEntNetIPv4);
+    CFArrayAppendValue(notificationKeys, storeKey);
+    CFRelease(storeKey);
+
+    storeKey = SCDynamicStoreKeyCreateNetworkServiceEntity(NULL,
+                                                      kSCDynamicStoreDomainState,
+                                                      kSCCompAnyRegex,
+                                                      kSCEntNetIPv4);
+    CFArrayAppendValue(patternsArray, storeKey);
+    CFRelease(storeKey);
+
+    if (!SCDynamicStoreSetNotificationKeys(storeSession , notificationKeys, patternsArray)) {
+        qWarning() << "register notification error:"<< SCErrorString(SCError());
+        CFRelease(storeSession );
+        CFRelease(notificationKeys);
+        CFRelease(patternsArray);
+        return;
+    }
+    CFRelease(notificationKeys);
+    CFRelease(patternsArray);
+
+    runloopSource = SCDynamicStoreCreateRunLoopSource(NULL, storeSession , 0);
+    if (!runloopSource) {
+        qWarning() << "runloop source error:"<< SCErrorString(SCError());
+        CFRelease(storeSession );
+        return;
+    }
+
+    CFRunLoopAddSource(CFRunLoopGetCurrent(), runloopSource, kCFRunLoopDefaultMode);
+    return;
+}
+
+QNetworkSessionPrivate *QCoreWlanEngine::createSessionBackend()
+{
+    return new QNetworkSessionPrivateImpl;
+}
+
+QNetworkConfigurationPrivatePointer QCoreWlanEngine::defaultConfiguration()
+{
+    return QNetworkConfigurationPrivatePointer();
+}
+
+bool QCoreWlanEngine::requiresPolling() const
+{
+    return true;
+}
+
+void QCoreWlanEngine::networksChanged()
+{
+    QMutexLocker locker(&mutex);
+
+    QStringList previous = accessPointConfigurations.keys();
+
+    QList<QNetworkConfigurationPrivate *> foundConfigurations = scanThread->getConfigurations();
+    while (!foundConfigurations.isEmpty()) {
+        QNetworkConfigurationPrivate *cpPriv = foundConfigurations.takeFirst();
+
+        previous.removeAll(cpPriv->id);
+
+        if (accessPointConfigurations.contains(cpPriv->id)) {
+            QNetworkConfigurationPrivatePointer ptr = accessPointConfigurations.value(cpPriv->id);
+
+            bool changed = false;
+
+            ptr->mutex.lock();
+
+            if (ptr->isValid != cpPriv->isValid) {
+                ptr->isValid = cpPriv->isValid;
+                changed = true;
+            }
+
+            if (ptr->name != cpPriv->name) {
+                ptr->name = cpPriv->name;
+                changed = true;
+            }
+
+            if (ptr->bearerType != cpPriv->bearerType) {
+                ptr->bearerType = cpPriv->bearerType;
+                changed = true;
+            }
+
+            if (ptr->state != cpPriv->state) {
+                ptr->state = cpPriv->state;
+                changed = true;
+            }
+
+            ptr->mutex.unlock();
+
+            if (changed) {
+                locker.unlock();
+                emit configurationChanged(ptr);
+                locker.relock();
+            }
+
+            delete cpPriv;
+        } else {
+            QNetworkConfigurationPrivatePointer ptr(cpPriv);
+
+            accessPointConfigurations.insert(ptr->id, ptr);
+
+            locker.unlock();
+            emit configurationAdded(ptr);
+            locker.relock();
+        }
+    }
+
+    while (!previous.isEmpty()) {
+        QNetworkConfigurationPrivatePointer ptr =
+            accessPointConfigurations.take(previous.takeFirst());
+
+        locker.unlock();
+        emit configurationRemoved(ptr);
+        locker.relock();
+    }
+
+    locker.unlock();
+    emit updateCompleted();
+
+}
+
+quint64 QCoreWlanEngine::bytesWritten(const QString &id)
+{
+    QMutexLocker locker(&mutex);
+    const QString interfaceStr = getInterfaceFromId(id);
+    return getBytes(interfaceStr,false);
+}
+
+quint64 QCoreWlanEngine::bytesReceived(const QString &id)
+{
+    QMutexLocker locker(&mutex);
+    const QString interfaceStr = getInterfaceFromId(id);
+    return getBytes(interfaceStr,true);
+}
+
+quint64 QCoreWlanEngine::startTime(const QString &identifier)
+{
+    QMutexLocker locker(&mutex);
+    NSAutoreleasePool *autoreleasepool = [[NSAutoreleasePool alloc] init];
+    quint64 timestamp = 0;
+
+    NSString *filePath = @"/Library/Preferences/SystemConfiguration/com.apple.airport.preferences.plist";
+    NSDictionary* plistDict = [[[NSDictionary alloc] initWithContentsOfFile:filePath] autorelease];
+    if(plistDict == nil)
+        return timestamp;
+    NSString *input = @"KnownNetworks";
+    NSString *timeStampStr = @"_timeStamp";
+
+    NSString *ssidStr = @"SSID_STR";
+
+    for (id key in plistDict) {
+        if ([input isEqualToString:key]) {
+
+            NSDictionary *knownNetworksDict = [plistDict objectForKey:key];
+            if(knownNetworksDict == nil)
+                return timestamp;
+            for (id networkKey in knownNetworksDict) {
+                bool isFound = false;
+                NSDictionary *itemDict = [knownNetworksDict objectForKey:networkKey];
+                if(itemDict == nil)
+                    return timestamp;
+                NSInteger dictSize = [itemDict count];
+                id objects[dictSize];
+                id keys[dictSize];
+
+                [itemDict getObjects:objects andKeys:keys];
+                bool ok = false;
+                for(int i = 0; i < dictSize; i++) {
+                    if([ssidStr isEqualToString:keys[i]]) {
+                        const QString ident = QString::number(qHash(QLatin1String("corewlan:") + QCFString::toQString(CFStringRef(objects[i]))));
+                        if(ident == identifier) {
+                            ok = true;
+                        }
+                    }
+                    if(ok && [timeStampStr isEqualToString:keys[i]]) {
+                        timestamp = (quint64)[objects[i] timeIntervalSince1970];
+                        isFound = true;
+                        break;
+                    }
+                }
+                if(isFound)
+                    break;
+            }
+        }
+    }
+    [autoreleasepool release];
+    return timestamp;
+}
+
+quint64 QCoreWlanEngine::getBytes(const QString &interfaceName, bool b)
+{
+    struct ifaddrs *ifAddressList, *ifAddress;
+    struct if_data *if_data;
+
+    quint64 bytes = 0;
+    ifAddressList = nil;
+    if(getifaddrs(&ifAddressList) == 0) {
+        for(ifAddress = ifAddressList; ifAddress; ifAddress = ifAddress->ifa_next) {
+            if(interfaceName == ifAddress->ifa_name) {
+                if_data = (struct if_data*)ifAddress->ifa_data;
+                if(b) {
+                    bytes = if_data->ifi_ibytes;
+                    break;
+                } else {
+                    bytes = if_data->ifi_obytes;
+                    break;
+                }
+            }
+        }
+        freeifaddrs(ifAddressList);
+    }
+    return bytes;
+}
+
+QT_END_NAMESPACE
+
+#else // QT_MAC_PLATFORM_SDK_EQUAL_OR_ABOVE
+#include "qcorewlanengine_10_6.mm"
+#endif

--- a/src/qt/src/plugins/bearer/corewlan/qcorewlanengine_10_6.mm
+++ b/src/qt/src/plugins/bearer/corewlan/qcorewlanengine_10_6.mm
@@ -1,0 +1,917 @@
+/****************************************************************************
+**
+** Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
+** Contact: http://www.qt-project.org/legal
+**
+** This file is part of the plugins of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and Digia.  For licensing terms and
+** conditions see http://qt.digia.com/licensing.  For further information
+** use the contact form at http://qt.digia.com/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** In addition, as a special exception, Digia gives you certain additional
+** rights.  These rights are described in the Digia Qt LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 3.0 as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU General Public License version 3.0 requirements will be
+** met: http://www.gnu.org/copyleft/gpl.html.
+**
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include <SystemConfiguration/SCNetworkConfiguration.h>
+
+@interface QT_MANGLE_NAMESPACE(QNSListener) : NSObject
+{
+    NSNotificationCenter *notificationCenter;
+    CWInterface *currentInterface;
+    QCoreWlanEngine *engine;
+    NSLock *locker;
+}
+- (void)notificationHandler:(NSNotification *)notification;
+- (void)remove;
+- (void)setEngine:(QCoreWlanEngine *)coreEngine;
+- (QCoreWlanEngine *)engine;
+- (void)dealloc;
+
+@property (assign) QCoreWlanEngine* engine;
+
+@end
+
+@implementation QT_MANGLE_NAMESPACE(QNSListener)
+
+- (id) init
+{
+    [locker lock];
+    NSAutoreleasePool *autoreleasepool = [[NSAutoreleasePool alloc] init];
+    notificationCenter = [NSNotificationCenter defaultCenter];
+    currentInterface = [CWInterface interfaceWithName:nil];
+    [notificationCenter addObserver:self selector:@selector(notificationHandler:) name:kCWPowerDidChangeNotification object:nil];
+    [locker unlock];
+    [autoreleasepool release];
+    return self;
+}
+
+-(void)dealloc
+{
+    [super dealloc];
+}
+
+-(void)setEngine:(QCoreWlanEngine *)coreEngine
+{
+    [locker lock];
+    if(!engine)
+        engine = coreEngine;
+    [locker unlock];
+}
+
+-(QCoreWlanEngine *)engine
+{
+    return engine;
+}
+
+-(void)remove
+{
+    [locker lock];
+    [notificationCenter removeObserver:self];
+    [locker unlock];
+}
+
+- (void)notificationHandler:(NSNotification *)notification
+{
+    Q_UNUSED(notification);
+    engine->requestUpdate();
+}
+@end
+
+static QT_MANGLE_NAMESPACE(QNSListener) *listener = 0;
+
+QT_BEGIN_NAMESPACE
+
+void networkChangeCallback(SCDynamicStoreRef/* store*/, CFArrayRef changedKeys, void *info)
+{
+    for ( long i = 0; i < CFArrayGetCount(changedKeys); i++) {
+
+        QString changed =  QCFString::toQString(CFStringRef((CFStringRef)CFArrayGetValueAtIndex(changedKeys, i)));
+        if( changed.contains("/Network/Global/IPv4")) {
+            QCoreWlanEngine* wlanEngine = static_cast<QCoreWlanEngine*>(info);
+            wlanEngine->requestUpdate();
+        }
+    }
+    return;
+}
+
+
+QScanThread::QScanThread(QObject *parent)
+    :QThread(parent)
+{
+}
+
+QScanThread::~QScanThread()
+{
+}
+
+void QScanThread::quit()
+{
+    wait();
+}
+
+void QScanThread::run()
+{
+    NSAutoreleasePool *autoreleasepool = [[NSAutoreleasePool alloc] init];
+    QStringList found;
+    mutex.lock();
+    CWInterface *currentInterface = [CWInterface interfaceWithName: (NSString *)QCFString::toCFStringRef(interfaceName)];
+    mutex.unlock();
+
+    if([currentInterface power]) {
+        NSError *err = nil;
+        NSDictionary *parametersDict =  [NSDictionary dictionaryWithObjectsAndKeys:
+                                   [NSNumber numberWithBool:YES], kCWScanKeyMerge,
+                                   [NSNumber numberWithInt:kCWScanTypeFast], kCWScanKeyScanType,
+                                   [NSNumber numberWithInteger:100], kCWScanKeyRestTime, nil];
+
+        NSArray* apArray = [currentInterface scanForNetworksWithParameters:parametersDict error:&err];
+        CWNetwork *apNetwork;
+
+        if (!err) {
+
+            for(uint row=0; row < [apArray count]; row++ ) {
+                apNetwork = [apArray objectAtIndex:row];
+
+                const QString networkSsid = QCFString::toQString(CFStringRef([apNetwork ssid]));
+                const QString id = QString::number(qHash(QLatin1String("corewlan:") + networkSsid));
+                found.append(id);
+
+                QNetworkConfiguration::StateFlags state = QNetworkConfiguration::Undefined;
+                bool known = isKnownSsid(networkSsid);
+                if( [currentInterface.interfaceState intValue] == kCWInterfaceStateRunning) {
+                    if( networkSsid == QCFString::toQString(CFStringRef([currentInterface ssid]))) {
+                        state = QNetworkConfiguration::Active;
+                    }
+                }
+                if(state == QNetworkConfiguration::Undefined) {
+                    if(known) {
+                        state = QNetworkConfiguration::Discovered;
+                    } else {
+                        state = QNetworkConfiguration::Undefined;
+                    }
+                }
+                QNetworkConfiguration::Purpose purpose = QNetworkConfiguration::UnknownPurpose;
+                if([[apNetwork securityMode] intValue] == kCWSecurityModeOpen) {
+                    purpose = QNetworkConfiguration::PublicPurpose;
+                } else {
+                    purpose = QNetworkConfiguration::PrivatePurpose;
+                }
+
+                found.append(foundNetwork(id, networkSsid, state, interfaceName, purpose));
+
+            }
+        }
+    }
+    // add known configurations that are not around.
+    QMapIterator<QString, QMap<QString,QString> > i(userProfiles);
+    while (i.hasNext()) {
+        i.next();
+
+        QString networkName = i.key();
+        const QString id = QString::number(qHash(QLatin1String("corewlan:") + networkName));
+
+        if(!found.contains(id)) {
+            QString networkSsid = getSsidFromNetworkName(networkName);
+            const QString ssidId = QString::number(qHash(QLatin1String("corewlan:") + networkSsid));
+            QNetworkConfiguration::StateFlags state = QNetworkConfiguration::Undefined;
+            QString interfaceName;
+            QMapIterator<QString, QString> ij(i.value());
+            while (ij.hasNext()) {
+                ij.next();
+                interfaceName = ij.value();
+            }
+
+            if( [currentInterface.interfaceState intValue] == kCWInterfaceStateRunning) {
+                if( networkSsid == QCFString::toQString(CFStringRef([currentInterface ssid]))) {
+                    state = QNetworkConfiguration::Active;
+                }
+            }
+            if(state == QNetworkConfiguration::Undefined) {
+                if( userProfiles.contains(networkName)
+                    && found.contains(ssidId)) {
+                    state = QNetworkConfiguration::Discovered;
+                }
+            }
+
+            if(state == QNetworkConfiguration::Undefined) {
+                state = QNetworkConfiguration::Defined;
+            }
+
+            found.append(foundNetwork(id, networkName, state, interfaceName, QNetworkConfiguration::UnknownPurpose));
+        }
+    }
+    emit networksChanged();
+    [autoreleasepool release];
+}
+
+QStringList QScanThread::foundNetwork(const QString &id, const QString &name, const QNetworkConfiguration::StateFlags state, const QString &interfaceName, const QNetworkConfiguration::Purpose purpose)
+{
+    QStringList found;
+    QMutexLocker locker(&mutex);
+        QNetworkConfigurationPrivate *ptr = new QNetworkConfigurationPrivate;
+
+        ptr->name = name;
+        ptr->isValid = true;
+        ptr->id = id;
+        ptr->state = state;
+        ptr->type = QNetworkConfiguration::InternetAccessPoint;
+        ptr->bearerType = QNetworkConfiguration::BearerWLAN;
+        ptr->purpose = purpose;
+
+        fetchedConfigurations.append( ptr);
+        configurationInterface.insert(ptr->id, interfaceName);
+
+        locker.unlock();
+        locker.relock();
+       found.append(id);
+    return found;
+}
+
+QList<QNetworkConfigurationPrivate *> QScanThread::getConfigurations()
+{
+    QMutexLocker locker(&mutex);
+
+    QList<QNetworkConfigurationPrivate *> foundConfigurations = fetchedConfigurations;
+    fetchedConfigurations.clear();
+
+    return foundConfigurations;
+}
+
+void QScanThread::getUserConfigurations()
+{
+    QMutexLocker locker(&mutex);
+
+    NSAutoreleasePool *autoreleasepool = [[NSAutoreleasePool alloc] init];
+    userProfiles.clear();
+
+    NSArray *wifiInterfaces = [CWInterface supportedInterfaces];
+    for(uint row=0; row < [wifiInterfaces count]; row++ ) {
+
+        CWInterface *wifiInterface = [CWInterface interfaceWithName: [wifiInterfaces objectAtIndex:row]];
+        if ( ![wifiInterface power] )
+            continue;
+
+        NSString *nsInterfaceName = [wifiInterface name];
+// add user configured system networks
+        SCDynamicStoreRef dynRef = SCDynamicStoreCreate(kCFAllocatorSystemDefault, (CFStringRef)@"Qt corewlan", nil, nil);
+        NSDictionary * airportPlist = (NSDictionary *)SCDynamicStoreCopyValue(dynRef, (CFStringRef)[NSString stringWithFormat:@"Setup:/Network/Interface/%@/AirPort", nsInterfaceName]);
+        CFRelease(dynRef);
+        if(airportPlist != nil) {
+            NSDictionary *prefNetDict = [airportPlist objectForKey:@"PreferredNetworks"];
+
+            NSArray *thisSsidarray = [prefNetDict valueForKey:@"SSID_STR"];
+            for(NSString *ssidkey in thisSsidarray) {
+                QString thisSsid = QCFString::toQString(CFStringRef(ssidkey));
+                if(!userProfiles.contains(thisSsid)) {
+                    QMap <QString,QString> map;
+                    map.insert(thisSsid, QCFString::toQString(CFStringRef(nsInterfaceName)));
+                    userProfiles.insert(thisSsid, map);
+                }
+            }
+            CFRelease(airportPlist);
+        }
+
+        // 802.1X user profiles
+        QString userProfilePath = QDir::homePath() + "/Library/Preferences/com.apple.eap.profiles.plist";
+        NSDictionary* eapDict = [[[NSDictionary alloc] initWithContentsOfFile: (NSString *)QCFString::toCFStringRef(userProfilePath)] autorelease];
+        if(eapDict != nil) {
+            NSString *profileStr= @"Profiles";
+            NSString *nameStr = @"UserDefinedName";
+            NSString *networkSsidStr = @"Wireless Network";
+            for (id profileKey in eapDict) {
+                if ([profileStr isEqualToString:profileKey]) {
+                    NSDictionary *itemDict = [eapDict objectForKey:profileKey];
+                    for (id itemKey in itemDict) {
+
+                        NSInteger dictSize = [itemKey count];
+                        id objects[dictSize];
+                        id keys[dictSize];
+
+                        [itemKey getObjects:objects andKeys:keys];
+                        QString networkName;
+                        QString ssid;
+                        for(int i = 0; i < dictSize; i++) {
+                            if([nameStr isEqualToString:keys[i]]) {
+                                networkName = QCFString::toQString(CFStringRef(objects[i]));
+                            }
+                            if([networkSsidStr isEqualToString:keys[i]]) {
+                                ssid = QCFString::toQString(CFStringRef(objects[i]));
+                            }
+                            if(!userProfiles.contains(networkName)
+                                && !ssid.isEmpty()) {
+                                QMap<QString,QString> map;
+                                map.insert(ssid, QCFString::toQString(CFStringRef(nsInterfaceName)));
+                                userProfiles.insert(networkName, map);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    [autoreleasepool release];
+}
+
+QString QScanThread::getSsidFromNetworkName(const QString &name)
+{
+    QMutexLocker locker(&mutex);
+
+    QMapIterator<QString, QMap<QString,QString> > i(userProfiles);
+    while (i.hasNext()) {
+        i.next();
+        QMap<QString,QString> map = i.value();
+        QMapIterator<QString, QString> ij(i.value());
+         while (ij.hasNext()) {
+             ij.next();
+             const QString networkNameHash = QString::number(qHash(QLatin1String("corewlan:") +i.key()));
+             if(name == i.key() || name == networkNameHash) {
+                 return ij.key();
+             }
+        }
+    }
+    return QString();
+}
+
+QString QScanThread::getNetworkNameFromSsid(const QString &ssid)
+{
+    QMutexLocker locker(&mutex);
+
+    QMapIterator<QString, QMap<QString,QString> > i(userProfiles);
+    while (i.hasNext()) {
+        i.next();
+        QMap<QString,QString> map = i.value();
+        QMapIterator<QString, QString> ij(i.value());
+         while (ij.hasNext()) {
+             ij.next();
+             if(ij.key() == ssid) {
+                 return i.key();
+             }
+         }
+    }
+    return QString();
+}
+
+bool QScanThread::isKnownSsid(const QString &ssid)
+{
+    QMutexLocker locker(&mutex);
+
+    QMapIterator<QString, QMap<QString,QString> > i(userProfiles);
+    while (i.hasNext()) {
+        i.next();
+        QMap<QString,QString> map = i.value();
+        if(map.keys().contains(ssid)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+
+QCoreWlanEngine::QCoreWlanEngine(QObject *parent)
+:   QBearerEngineImpl(parent), scanThread(0)
+{
+    scanThread = new QScanThread(this);
+    connect(scanThread, SIGNAL(networksChanged()),
+            this, SLOT(networksChanged()));
+}
+
+QCoreWlanEngine::~QCoreWlanEngine()
+{
+    while (!foundConfigurations.isEmpty())
+        delete foundConfigurations.takeFirst();
+    [listener remove];
+    [listener release];
+}
+
+void QCoreWlanEngine::initialize()
+{
+    QMutexLocker locker(&mutex);
+    NSAutoreleasePool *autoreleasepool = [[NSAutoreleasePool alloc] init];
+
+    if([[CWInterface supportedInterfaces] count] > 0 && !listener) {
+        listener = [[QT_MANGLE_NAMESPACE(QNSListener) alloc] init];
+        listener.engine = this;
+        hasWifi = true;
+    } else {
+        hasWifi = false;
+    }
+    storeSession = NULL;
+
+    startNetworkChangeLoop();
+    [autoreleasepool release];
+}
+
+
+QString QCoreWlanEngine::getInterfaceFromId(const QString &id)
+{
+    QMutexLocker locker(&mutex);
+
+    return scanThread->configurationInterface.value(id);
+}
+
+bool QCoreWlanEngine::hasIdentifier(const QString &id)
+{
+    QMutexLocker locker(&mutex);
+
+    return scanThread->configurationInterface.contains(id);
+}
+
+void QCoreWlanEngine::connectToId(const QString &id)
+{
+    QMutexLocker locker(&mutex);
+    NSAutoreleasePool *autoreleasepool = [[NSAutoreleasePool alloc] init];
+    QString interfaceString = getInterfaceFromId(id);
+
+    CWInterface *wifiInterface =
+        [CWInterface interfaceWithName: (NSString *)QCFString::toCFStringRef(interfaceString)];
+
+    if ([wifiInterface power]) {
+        NSError *err = nil;
+        NSMutableDictionary *params = [NSMutableDictionary dictionaryWithCapacity:0];
+
+        QString wantedSsid;
+
+        QNetworkConfigurationPrivatePointer ptr = accessPointConfigurations.value(id);
+
+        const QString idHash = QString::number(qHash(QLatin1String("corewlan:") + ptr->name));
+        const QString idHash2 = QString::number(qHash(QLatin1String("corewlan:") + scanThread->getNetworkNameFromSsid(ptr->name)));
+
+        bool using8021X = false;
+        if (idHash2 != id) {
+            NSArray *array = [CW8021XProfile allUser8021XProfiles];
+
+            for (NSUInteger i = 0; i < [array count]; ++i) {
+                const QString networkNameHashCheck = QString::number(qHash(QLatin1String("corewlan:") + QCFString::toQString(CFStringRef([[array objectAtIndex:i] userDefinedName]))));
+
+                const QString ssidHash = QString::number(qHash(QLatin1String("corewlan:") + QCFString::toQString(CFStringRef([[array objectAtIndex:i] ssid]))));
+
+                if (id == networkNameHashCheck || id == ssidHash) {
+                    const QString thisName = scanThread->getSsidFromNetworkName(id);
+                    if (thisName.isEmpty())
+                        wantedSsid = id;
+                    else
+                        wantedSsid = thisName;
+
+                    [params setValue: [array objectAtIndex:i] forKey:kCWAssocKey8021XProfile];
+                    using8021X = true;
+                    break;
+                }
+            }
+        }
+
+        if (!using8021X) {
+            QString wantedNetwork;
+            QMapIterator<QString, QMap<QString,QString> > i(scanThread->userProfiles);
+            while (i.hasNext()) {
+                i.next();
+                wantedNetwork = i.key();
+                const QString networkNameHash = QString::number(qHash(QLatin1String("corewlan:") + wantedNetwork));
+                if (id == networkNameHash) {
+                    wantedSsid =  scanThread->getSsidFromNetworkName(wantedNetwork);
+                    break;
+                }
+            }
+        }
+        NSDictionary *scanParameters = [NSDictionary dictionaryWithObjectsAndKeys:
+                                        [NSNumber numberWithBool:YES], kCWScanKeyMerge,
+                                        [NSNumber numberWithInt:kCWScanTypeFast], kCWScanKeyScanType,
+                                        [NSNumber numberWithInteger:100], kCWScanKeyRestTime,
+                                        (NSString *)QCFString::toCFStringRef(wantedSsid), kCWScanKeySSID,
+                                        nil];
+
+        NSArray *scanArray = [wifiInterface scanForNetworksWithParameters:scanParameters error:&err];
+
+        if(!err) {
+            for(uint row=0; row < [scanArray count]; row++ ) {
+                CWNetwork *apNetwork = [scanArray objectAtIndex:row];
+
+                if(wantedSsid == QCFString::toQString(CFStringRef([apNetwork ssid]))) {
+
+                    if(!using8021X) {
+                        SecKeychainAttribute attributes[3];
+
+                        NSString *account = [apNetwork ssid];
+                        NSString *keyKind = @"AirPort network password";
+                        NSString *keyName = account;
+
+                        attributes[0].tag = kSecAccountItemAttr;
+                        attributes[0].data = (void *)[account UTF8String];
+                        attributes[0].length = [account length];
+
+                        attributes[1].tag = kSecDescriptionItemAttr;
+                        attributes[1].data = (void *)[keyKind UTF8String];
+                        attributes[1].length = [keyKind length];
+
+                        attributes[2].tag = kSecLabelItemAttr;
+                        attributes[2].data = (void *)[keyName UTF8String];
+                        attributes[2].length = [keyName length];
+
+                        SecKeychainAttributeList attributeList = {3,attributes};
+
+                        SecKeychainSearchRef searchRef;
+                        SecKeychainSearchCreateFromAttributes(NULL, kSecGenericPasswordItemClass, &attributeList, &searchRef);
+
+                        NSString *password = @"";
+                        SecKeychainItemRef searchItem;
+
+                        if (SecKeychainSearchCopyNext(searchRef, &searchItem) == noErr) {
+                            UInt32 realPasswordLength;
+                            SecKeychainAttribute attributesW[8];
+                            attributesW[0].tag = kSecAccountItemAttr;
+                            SecKeychainAttributeList listW = {1,attributesW};
+                            char *realPassword;
+                            OSStatus status = SecKeychainItemCopyContent(searchItem, NULL, &listW, &realPasswordLength,(void **)&realPassword);
+
+                            if (status == noErr) {
+                                if (realPassword != NULL) {
+
+                                    QByteArray pBuf;
+                                    pBuf.resize(realPasswordLength);
+                                    pBuf.prepend(realPassword);
+                                    pBuf.insert(realPasswordLength,'\0');
+
+                                    password = [NSString stringWithUTF8String:pBuf];
+                                }
+                                SecKeychainItemFreeContent(&listW, realPassword);
+                            }
+
+                            CFRelease(searchItem);
+                        } else {
+                            qDebug() << "SecKeychainSearchCopyNext error";
+                        }
+                        [params setValue: password forKey: kCWAssocKeyPassphrase];
+                    } // end using8021X
+
+
+                    bool result = [wifiInterface associateToNetwork: apNetwork parameters:[NSDictionary dictionaryWithDictionary:params] error:&err];
+
+                    if(!err) {
+                        if(!result) {
+                            emit connectionError(id, ConnectError);
+                        } else {
+                            return;
+                        }
+                    } else {
+                        qDebug() <<"associate ERROR"<<  QCFString::toQString(CFStringRef([err localizedDescription ]));
+                    }
+                }
+            } //end scan network
+        } else {
+            qDebug() <<"scan ERROR"<<  QCFString::toQString(CFStringRef([err localizedDescription ]));
+        }
+        emit connectionError(id, InterfaceLookupError);
+    }
+
+    locker.unlock();
+    emit connectionError(id, InterfaceLookupError);
+    [autoreleasepool release];
+}
+
+void QCoreWlanEngine::disconnectFromId(const QString &id)
+{
+    QMutexLocker locker(&mutex);
+
+    QString interfaceString = getInterfaceFromId(id);
+    NSAutoreleasePool *autoreleasepool = [[NSAutoreleasePool alloc] init];
+
+    CWInterface *wifiInterface =
+        [CWInterface interfaceWithName: (NSString *)QCFString::toCFStringRef(interfaceString)];
+
+    [wifiInterface disassociate];
+    if ([[wifiInterface interfaceState]intValue] != kCWInterfaceStateInactive) {
+        locker.unlock();
+        emit connectionError(id, DisconnectionError);
+        locker.relock();
+    }
+    [autoreleasepool release];
+}
+
+void QCoreWlanEngine::requestUpdate()
+{
+    scanThread->getUserConfigurations();
+    doRequestUpdate();
+}
+
+void QCoreWlanEngine::doRequestUpdate()
+{
+    QMutexLocker locker(&mutex);
+
+    NSAutoreleasePool *autoreleasepool = [[NSAutoreleasePool alloc] init];
+
+    NSArray *wifiInterfaces = [CWInterface supportedInterfaces];
+    for (uint row = 0; row < [wifiInterfaces count]; ++row) {
+            scanThread->interfaceName = QCFString::toQString(CFStringRef([wifiInterfaces objectAtIndex:row]));
+            scanThread->start();
+    }
+    locker.unlock();
+    [autoreleasepool release];
+}
+
+bool QCoreWlanEngine::isWifiReady(const QString &wifiDeviceName)
+{
+    QMutexLocker locker(&mutex);
+    bool haswifi = false;
+    if(hasWifi) {
+        NSAutoreleasePool *autoreleasepool = [[NSAutoreleasePool alloc] init];
+        CWInterface *defaultInterface = [CWInterface interfaceWithName: (NSString *)QCFString::toCFStringRef(wifiDeviceName)];
+        if([defaultInterface power]) {
+            haswifi = true;
+        }
+        [autoreleasepool release];
+    }
+    return haswifi;
+}
+
+
+QNetworkSession::State QCoreWlanEngine::sessionStateForId(const QString &id)
+{
+    QMutexLocker locker(&mutex);
+    QNetworkConfigurationPrivatePointer ptr = accessPointConfigurations.value(id);
+
+    if (!ptr)
+        return QNetworkSession::Invalid;
+
+    if (!ptr->isValid) {
+        return QNetworkSession::Invalid;
+    } else if ((ptr->state & QNetworkConfiguration::Active) == QNetworkConfiguration::Active) {
+        return QNetworkSession::Connected;
+    } else if ((ptr->state & QNetworkConfiguration::Discovered) ==
+                QNetworkConfiguration::Discovered) {
+        return QNetworkSession::Disconnected;
+    } else if ((ptr->state & QNetworkConfiguration::Defined) == QNetworkConfiguration::Defined) {
+        return QNetworkSession::NotAvailable;
+    } else if ((ptr->state & QNetworkConfiguration::Undefined) ==
+                QNetworkConfiguration::Undefined) {
+        return QNetworkSession::NotAvailable;
+    }
+
+    return QNetworkSession::Invalid;
+}
+
+QNetworkConfigurationManager::Capabilities QCoreWlanEngine::capabilities() const
+{
+    return QNetworkConfigurationManager::ForcedRoaming;
+}
+
+void QCoreWlanEngine::startNetworkChangeLoop()
+{
+
+    SCDynamicStoreContext dynStoreContext = { 0, this/*(void *)storeSession*/, NULL, NULL, NULL };
+    storeSession = SCDynamicStoreCreate(NULL,
+                                 CFSTR("networkChangeCallback"),
+                                 networkChangeCallback,
+                                 &dynStoreContext);
+    if (!storeSession ) {
+        qWarning() << "could not open dynamic store: error:" << SCErrorString(SCError());
+        return;
+    }
+
+    CFMutableArrayRef notificationKeys;
+    notificationKeys = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+    CFMutableArrayRef patternsArray;
+    patternsArray = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+
+    CFStringRef storeKey;
+    storeKey = SCDynamicStoreKeyCreateNetworkGlobalEntity(NULL,
+                                                     kSCDynamicStoreDomainState,
+                                                     kSCEntNetIPv4);
+    CFArrayAppendValue(notificationKeys, storeKey);
+    CFRelease(storeKey);
+
+    storeKey = SCDynamicStoreKeyCreateNetworkServiceEntity(NULL,
+                                                      kSCDynamicStoreDomainState,
+                                                      kSCCompAnyRegex,
+                                                      kSCEntNetIPv4);
+    CFArrayAppendValue(patternsArray, storeKey);
+    CFRelease(storeKey);
+
+    if (!SCDynamicStoreSetNotificationKeys(storeSession , notificationKeys, patternsArray)) {
+        qWarning() << "register notification error:"<< SCErrorString(SCError());
+        CFRelease(storeSession );
+        CFRelease(notificationKeys);
+        CFRelease(patternsArray);
+        return;
+    }
+    CFRelease(notificationKeys);
+    CFRelease(patternsArray);
+
+    runloopSource = SCDynamicStoreCreateRunLoopSource(NULL, storeSession , 0);
+    if (!runloopSource) {
+        qWarning() << "runloop source error:"<< SCErrorString(SCError());
+        CFRelease(storeSession );
+        return;
+    }
+
+    CFRunLoopAddSource(CFRunLoopGetCurrent(), runloopSource, kCFRunLoopDefaultMode);
+    return;
+}
+
+QNetworkSessionPrivate *QCoreWlanEngine::createSessionBackend()
+{
+    return new QNetworkSessionPrivateImpl;
+}
+
+QNetworkConfigurationPrivatePointer QCoreWlanEngine::defaultConfiguration()
+{
+    return QNetworkConfigurationPrivatePointer();
+}
+
+bool QCoreWlanEngine::requiresPolling() const
+{
+    return true;
+}
+
+void QCoreWlanEngine::networksChanged()
+{
+    QMutexLocker locker(&mutex);
+
+    QStringList previous = accessPointConfigurations.keys();
+
+    QList<QNetworkConfigurationPrivate *> foundConfigurations = scanThread->getConfigurations();
+    while (!foundConfigurations.isEmpty()) {
+        QNetworkConfigurationPrivate *cpPriv = foundConfigurations.takeFirst();
+
+        previous.removeAll(cpPriv->id);
+
+        if (accessPointConfigurations.contains(cpPriv->id)) {
+            QNetworkConfigurationPrivatePointer ptr = accessPointConfigurations.value(cpPriv->id);
+
+            bool changed = false;
+
+            ptr->mutex.lock();
+
+            if (ptr->isValid != cpPriv->isValid) {
+                ptr->isValid = cpPriv->isValid;
+                changed = true;
+            }
+
+            if (ptr->name != cpPriv->name) {
+                ptr->name = cpPriv->name;
+                changed = true;
+            }
+
+            if (ptr->bearerType != cpPriv->bearerType) {
+                ptr->bearerType = cpPriv->bearerType;
+                changed = true;
+            }
+
+            if (ptr->state != cpPriv->state) {
+                ptr->state = cpPriv->state;
+                changed = true;
+            }
+
+            ptr->mutex.unlock();
+
+            if (changed) {
+                locker.unlock();
+                emit configurationChanged(ptr);
+                locker.relock();
+            }
+
+            delete cpPriv;
+        } else {
+            QNetworkConfigurationPrivatePointer ptr(cpPriv);
+
+            accessPointConfigurations.insert(ptr->id, ptr);
+
+            locker.unlock();
+            emit configurationAdded(ptr);
+            locker.relock();
+        }
+    }
+
+    while (!previous.isEmpty()) {
+        QNetworkConfigurationPrivatePointer ptr =
+            accessPointConfigurations.take(previous.takeFirst());
+
+        locker.unlock();
+        emit configurationRemoved(ptr);
+        locker.relock();
+    }
+
+    locker.unlock();
+    emit updateCompleted();
+
+}
+
+quint64 QCoreWlanEngine::bytesWritten(const QString &id)
+{
+    QMutexLocker locker(&mutex);
+    const QString interfaceStr = getInterfaceFromId(id);
+    return getBytes(interfaceStr,false);
+}
+
+quint64 QCoreWlanEngine::bytesReceived(const QString &id)
+{
+    QMutexLocker locker(&mutex);
+    const QString interfaceStr = getInterfaceFromId(id);
+    return getBytes(interfaceStr,true);
+}
+
+quint64 QCoreWlanEngine::startTime(const QString &identifier)
+{
+    QMutexLocker locker(&mutex);
+    NSAutoreleasePool *autoreleasepool = [[NSAutoreleasePool alloc] init];
+    quint64 timestamp = 0;
+
+    NSString *filePath = @"/Library/Preferences/SystemConfiguration/com.apple.airport.preferences.plist";
+    NSDictionary* plistDict = [[[NSDictionary alloc] initWithContentsOfFile:filePath] autorelease];
+    if(plistDict == nil)
+        return timestamp;
+    NSString *input = @"KnownNetworks";
+    NSString *timeStampStr = @"_timeStamp";
+
+    NSString *ssidStr = @"SSID_STR";
+
+    for (id key in plistDict) {
+        if ([input isEqualToString:key]) {
+
+            NSDictionary *knownNetworksDict = [plistDict objectForKey:key];
+            if(knownNetworksDict == nil)
+                return timestamp;
+            for (id networkKey in knownNetworksDict) {
+                bool isFound = false;
+                NSDictionary *itemDict = [knownNetworksDict objectForKey:networkKey];
+                if(itemDict == nil)
+                    return timestamp;
+                NSInteger dictSize = [itemDict count];
+                id objects[dictSize];
+                id keys[dictSize];
+
+                [itemDict getObjects:objects andKeys:keys];
+                bool ok = false;
+                for(int i = 0; i < dictSize; i++) {
+                    if([ssidStr isEqualToString:keys[i]]) {
+                        const QString ident = QString::number(qHash(QLatin1String("corewlan:") + QCFString::toQString(CFStringRef(objects[i]))));
+                        if(ident == identifier) {
+                            ok = true;
+                        }
+                    }
+                    if(ok && [timeStampStr isEqualToString:keys[i]]) {
+                        timestamp = (quint64)[objects[i] timeIntervalSince1970];
+                        isFound = true;
+                        break;
+                    }
+                }
+                if(isFound)
+                    break;
+            }
+        }
+    }
+    [autoreleasepool release];
+    return timestamp;
+}
+
+quint64 QCoreWlanEngine::getBytes(const QString &interfaceName, bool b)
+{
+    struct ifaddrs *ifAddressList, *ifAddress;
+    struct if_data *if_data;
+
+    quint64 bytes = 0;
+    ifAddressList = nil;
+    if(getifaddrs(&ifAddressList) == 0) {
+        for(ifAddress = ifAddressList; ifAddress; ifAddress = ifAddress->ifa_next) {
+            if(interfaceName == ifAddress->ifa_name) {
+                if_data = (struct if_data*)ifAddress->ifa_data;
+                if(b) {
+                    bytes = if_data->ifi_ibytes;
+                    break;
+                } else {
+                    bytes = if_data->ifi_obytes;
+                    break;
+                }
+            }
+        }
+        freeifaddrs(ifAddressList);
+    }
+    return bytes;
+}
+
+QT_END_NAMESPACE

--- a/src/qt/src/plugins/bearer/generic/generic.pro
+++ b/src/qt/src/plugins/bearer/generic/generic.pro
@@ -1,0 +1,16 @@
+TARGET = qgenericbearer
+include(../../qpluginbase.pri)
+
+QT = core network
+
+HEADERS += qgenericengine.h \
+           ../qnetworksession_impl.h \
+           ../qbearerengine_impl.h \
+           ../platformdefs_win.h
+SOURCES += qgenericengine.cpp \
+           ../qnetworksession_impl.cpp \
+           main.cpp
+
+QTDIR_build:DESTDIR = $$QT_BUILD_TREE/plugins/bearer
+target.path += $$[QT_INSTALL_PLUGINS]/bearer
+INSTALLS += target

--- a/src/qt/src/plugins/bearer/generic/main.cpp
+++ b/src/qt/src/plugins/bearer/generic/main.cpp
@@ -1,0 +1,88 @@
+/****************************************************************************
+**
+** Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
+** Contact: http://www.qt-project.org/legal
+**
+** This file is part of the plugins of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and Digia.  For licensing terms and
+** conditions see http://qt.digia.com/licensing.  For further information
+** use the contact form at http://qt.digia.com/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** In addition, as a special exception, Digia gives you certain additional
+** rights.  These rights are described in the Digia Qt LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 3.0 as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU General Public License version 3.0 requirements will be
+** met: http://www.gnu.org/copyleft/gpl.html.
+**
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "qgenericengine.h"
+
+#include <QtNetwork/private/qbearerplugin_p.h>
+
+#include <QtCore/qdebug.h>
+
+#ifndef QT_NO_BEARERMANAGEMENT
+
+QT_BEGIN_NAMESPACE
+
+class QGenericEnginePlugin : public QBearerEnginePlugin
+{
+public:
+    QGenericEnginePlugin();
+    ~QGenericEnginePlugin();
+
+    QStringList keys() const;
+    QBearerEngine *create(const QString &key) const;
+};
+
+QGenericEnginePlugin::QGenericEnginePlugin()
+{
+}
+
+QGenericEnginePlugin::~QGenericEnginePlugin()
+{
+}
+
+QStringList QGenericEnginePlugin::keys() const
+{
+    return QStringList() << QLatin1String("generic");
+}
+
+QBearerEngine *QGenericEnginePlugin::create(const QString &key) const
+{
+    if (key == QLatin1String("generic"))
+        return new QGenericEngine;
+    else
+        return 0;
+}
+
+Q_EXPORT_STATIC_PLUGIN(QGenericEnginePlugin)
+Q_EXPORT_PLUGIN2(qgenericbearer, QGenericEnginePlugin)
+
+QT_END_NAMESPACE
+
+#endif // QT_NO_BEARERMANAGEMENT

--- a/src/qt/src/plugins/bearer/generic/qgenericengine.cpp
+++ b/src/qt/src/plugins/bearer/generic/qgenericengine.cpp
@@ -1,0 +1,362 @@
+/****************************************************************************
+**
+** Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
+** Contact: http://www.qt-project.org/legal
+**
+** This file is part of the plugins of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and Digia.  For licensing terms and
+** conditions see http://qt.digia.com/licensing.  For further information
+** use the contact form at http://qt.digia.com/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** In addition, as a special exception, Digia gives you certain additional
+** rights.  These rights are described in the Digia Qt LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 3.0 as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU General Public License version 3.0 requirements will be
+** met: http://www.gnu.org/copyleft/gpl.html.
+**
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "qgenericengine.h"
+#include "../qnetworksession_impl.h"
+
+#include <QtNetwork/private/qnetworkconfiguration_p.h>
+
+#include <QtCore/qthread.h>
+#include <QtCore/qmutex.h>
+#include <QtCore/qcoreapplication.h>
+#include <QtCore/qstringlist.h>
+
+#include <QtCore/qdebug.h>
+#include <QtCore/private/qcoreapplication_p.h>
+
+#ifdef Q_OS_WIN
+#include "../platformdefs_win.h"
+#endif
+
+#ifdef Q_OS_LINUX
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <net/if.h>
+#include <net/if_arp.h>
+#include <unistd.h>
+#endif
+
+#ifndef QT_NO_BEARERMANAGEMENT
+
+QT_BEGIN_NAMESPACE
+
+#ifndef QT_NO_NETWORKINTERFACE
+static QNetworkConfiguration::BearerType qGetInterfaceType(const QString &interface)
+{
+#ifdef Q_OS_WIN32
+    unsigned long oid;
+    DWORD bytesWritten;
+
+    NDIS_MEDIUM medium;
+    NDIS_PHYSICAL_MEDIUM physicalMedium;
+
+    HANDLE handle = CreateFile((TCHAR *)QString::fromLatin1("\\\\.\\%1").arg(interface).utf16(), 0,
+                               FILE_SHARE_READ, 0, OPEN_EXISTING, 0, 0);
+    if (handle == INVALID_HANDLE_VALUE)
+        return QNetworkConfiguration::BearerUnknown;
+
+    oid = OID_GEN_MEDIA_SUPPORTED;
+    bytesWritten = 0;
+    bool result = DeviceIoControl(handle, IOCTL_NDIS_QUERY_GLOBAL_STATS, &oid, sizeof(oid),
+                                  &medium, sizeof(medium), &bytesWritten, 0);
+    if (!result) {
+        CloseHandle(handle);
+        return QNetworkConfiguration::BearerUnknown;
+    }
+
+    oid = OID_GEN_PHYSICAL_MEDIUM;
+    bytesWritten = 0;
+    result = DeviceIoControl(handle, IOCTL_NDIS_QUERY_GLOBAL_STATS, &oid, sizeof(oid),
+                             &physicalMedium, sizeof(physicalMedium), &bytesWritten, 0);
+    if (!result) {
+        CloseHandle(handle);
+
+        if (medium == NdisMedium802_3)
+            return QNetworkConfiguration::BearerEthernet;
+        else
+            return QNetworkConfiguration::BearerUnknown;
+    }
+
+    CloseHandle(handle);
+
+    if (medium == NdisMedium802_3) {
+        switch (physicalMedium) {
+        case NdisPhysicalMediumWirelessLan:
+            return QNetworkConfiguration::BearerWLAN;
+        case NdisPhysicalMediumBluetooth:
+            return QNetworkConfiguration::BearerBluetooth;
+        case NdisPhysicalMediumWiMax:
+            return QNetworkConfiguration::BearerWiMAX;
+        default:
+#ifdef BEARER_MANAGEMENT_DEBUG
+            qDebug() << "Physical Medium" << physicalMedium;
+#endif
+            return QNetworkConfiguration::BearerEthernet;
+        }
+    }
+
+#ifdef BEARER_MANAGEMENT_DEBUG
+    qDebug() << medium << physicalMedium;
+#endif
+#elif defined(Q_OS_LINUX)
+    int sock = socket(AF_INET, SOCK_DGRAM, 0);
+
+    ifreq request;
+    strncpy(request.ifr_name, interface.toLocal8Bit().data(), sizeof(request.ifr_name));
+    int result = ioctl(sock, SIOCGIFHWADDR, &request);
+    close(sock);
+
+    if (result >= 0 && request.ifr_hwaddr.sa_family == ARPHRD_ETHER)
+        return QNetworkConfiguration::BearerEthernet;
+#else
+    Q_UNUSED(interface);
+#endif
+
+    return QNetworkConfiguration::BearerUnknown;
+}
+#endif
+
+QGenericEngine::QGenericEngine(QObject *parent)
+:   QBearerEngineImpl(parent)
+{
+    //workaround for deadlock in __cxa_guard_acquire with webkit on macos x
+    //initialise the Q_GLOBAL_STATIC in same thread as the AtomicallyInitializedStatic
+    (void)QNetworkInterface::interfaceFromIndex(0);
+}
+
+QGenericEngine::~QGenericEngine()
+{
+}
+
+QString QGenericEngine::getInterfaceFromId(const QString &id)
+{
+    QMutexLocker locker(&mutex);
+
+    return configurationInterface.value(id);
+}
+
+bool QGenericEngine::hasIdentifier(const QString &id)
+{
+    QMutexLocker locker(&mutex);
+
+    return configurationInterface.contains(id);
+}
+
+void QGenericEngine::connectToId(const QString &id)
+{
+    emit connectionError(id, OperationNotSupported);
+}
+
+void QGenericEngine::disconnectFromId(const QString &id)
+{
+    emit connectionError(id, OperationNotSupported);
+}
+
+void QGenericEngine::initialize()
+{
+    doRequestUpdate();
+}
+
+void QGenericEngine::requestUpdate()
+{
+    doRequestUpdate();
+}
+
+void QGenericEngine::doRequestUpdate()
+{
+#ifndef QT_NO_NETWORKINTERFACE
+    QMutexLocker locker(&mutex);
+
+    // Immediately after connecting with a wireless access point
+    // QNetworkInterface::allInterfaces() will sometimes return an empty list. Calling it again a
+    // second time results in a non-empty list. If we loose interfaces we will end up removing
+    // network configurations which will break current sessions.
+    QList<QNetworkInterface> interfaces = QNetworkInterface::allInterfaces();
+    if (interfaces.isEmpty())
+        interfaces = QNetworkInterface::allInterfaces();
+
+    QStringList previous = accessPointConfigurations.keys();
+
+    // create configuration for each interface
+    while (!interfaces.isEmpty()) {
+        QNetworkInterface interface = interfaces.takeFirst();
+
+        if (!interface.isValid())
+            continue;
+
+        // ignore loopback interface
+        if (interface.flags() & QNetworkInterface::IsLoopBack)
+            continue;
+
+        // ignore WLAN interface handled in separate engine
+        if (qGetInterfaceType(interface.name()) == QNetworkConfiguration::BearerWLAN)
+            continue;
+
+        uint identifier;
+        if (interface.index())
+            identifier = qHash(QLatin1String("generic:") + QString::number(interface.index()));
+        else
+            identifier = qHash(QLatin1String("generic:") + interface.hardwareAddress());
+
+        const QString id = QString::number(identifier);
+
+        previous.removeAll(id);
+
+        QString name = interface.humanReadableName();
+        if (name.isEmpty())
+            name = interface.name();
+
+        QNetworkConfiguration::StateFlags state = QNetworkConfiguration::Defined;
+        if ((interface.flags() & QNetworkInterface::IsRunning) && !interface.addressEntries().isEmpty())
+            state |= QNetworkConfiguration::Active;
+
+        if (accessPointConfigurations.contains(id)) {
+            QNetworkConfigurationPrivatePointer ptr = accessPointConfigurations.value(id);
+
+            bool changed = false;
+
+            ptr->mutex.lock();
+
+            if (!ptr->isValid) {
+                ptr->isValid = true;
+                changed = true;
+            }
+
+            if (ptr->name != name) {
+                ptr->name = name;
+                changed = true;
+            }
+
+            if (ptr->id != id) {
+                ptr->id = id;
+                changed = true;
+            }
+
+            if (ptr->state != state) {
+                ptr->state = state;
+                changed = true;
+            }
+
+            ptr->mutex.unlock();
+
+            if (changed) {
+                locker.unlock();
+                emit configurationChanged(ptr);
+                locker.relock();
+            }
+        } else {
+            QNetworkConfigurationPrivatePointer ptr(new QNetworkConfigurationPrivate);
+
+            ptr->name = name;
+            ptr->isValid = true;
+            ptr->id = id;
+            ptr->state = state;
+            ptr->type = QNetworkConfiguration::InternetAccessPoint;
+            ptr->bearerType = qGetInterfaceType(interface.name());
+
+            accessPointConfigurations.insert(id, ptr);
+            configurationInterface.insert(id, interface.name());
+
+            locker.unlock();
+            emit configurationAdded(ptr);
+            locker.relock();
+        }
+    }
+
+    while (!previous.isEmpty()) {
+        QNetworkConfigurationPrivatePointer ptr =
+            accessPointConfigurations.take(previous.takeFirst());
+
+        configurationInterface.remove(ptr->id);
+
+        locker.unlock();
+        emit configurationRemoved(ptr);
+        locker.relock();
+    }
+
+    locker.unlock();
+#endif
+
+    emit updateCompleted();
+}
+
+QNetworkSession::State QGenericEngine::sessionStateForId(const QString &id)
+{
+    QMutexLocker locker(&mutex);
+
+    QNetworkConfigurationPrivatePointer ptr = accessPointConfigurations.value(id);
+
+    if (!ptr)
+        return QNetworkSession::Invalid;
+
+    QMutexLocker configLocker(&ptr->mutex);
+
+    if (!ptr->isValid) {
+        return QNetworkSession::Invalid;
+    } else if ((ptr->state & QNetworkConfiguration::Active) == QNetworkConfiguration::Active) {
+        return QNetworkSession::Connected;
+    } else if ((ptr->state & QNetworkConfiguration::Discovered) ==
+                QNetworkConfiguration::Discovered) {
+        return QNetworkSession::Disconnected;
+    } else if ((ptr->state & QNetworkConfiguration::Defined) == QNetworkConfiguration::Defined) {
+        return QNetworkSession::NotAvailable;
+    } else if ((ptr->state & QNetworkConfiguration::Undefined) ==
+                QNetworkConfiguration::Undefined) {
+        return QNetworkSession::NotAvailable;
+    }
+
+    return QNetworkSession::Invalid;
+}
+
+QNetworkConfigurationManager::Capabilities QGenericEngine::capabilities() const
+{
+    return QNetworkConfigurationManager::ForcedRoaming;
+}
+
+QNetworkSessionPrivate *QGenericEngine::createSessionBackend()
+{
+    return new QNetworkSessionPrivateImpl;
+}
+
+QNetworkConfigurationPrivatePointer QGenericEngine::defaultConfiguration()
+{
+    return QNetworkConfigurationPrivatePointer();
+}
+
+
+bool QGenericEngine::requiresPolling() const
+{
+    return true;
+}
+
+QT_END_NAMESPACE
+
+#endif // QT_NO_BEARERMANAGEMENT

--- a/src/qt/src/plugins/bearer/generic/qgenericengine.h
+++ b/src/qt/src/plugins/bearer/generic/qgenericengine.h
@@ -1,0 +1,96 @@
+/****************************************************************************
+**
+** Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
+** Contact: http://www.qt-project.org/legal
+**
+** This file is part of the plugins of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and Digia.  For licensing terms and
+** conditions see http://qt.digia.com/licensing.  For further information
+** use the contact form at http://qt.digia.com/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** In addition, as a special exception, Digia gives you certain additional
+** rights.  These rights are described in the Digia Qt LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 3.0 as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU General Public License version 3.0 requirements will be
+** met: http://www.gnu.org/copyleft/gpl.html.
+**
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef QGENERICENGINE_H
+#define QGENERICENGINE_H
+
+#include "../qbearerengine_impl.h"
+
+#include <QMap>
+#include <QTimer>
+
+#ifndef QT_NO_BEARERMANAGEMENT
+
+QT_BEGIN_NAMESPACE
+
+class QNetworkConfigurationPrivate;
+class QNetworkSessionPrivate;
+
+class QGenericEngine : public QBearerEngineImpl
+{
+    Q_OBJECT
+
+public:
+    QGenericEngine(QObject *parent = 0);
+    ~QGenericEngine();
+
+    QString getInterfaceFromId(const QString &id);
+    bool hasIdentifier(const QString &id);
+
+    void connectToId(const QString &id);
+    void disconnectFromId(const QString &id);
+
+    Q_INVOKABLE void initialize();
+    Q_INVOKABLE void requestUpdate();
+
+    QNetworkSession::State sessionStateForId(const QString &id);
+
+    QNetworkConfigurationManager::Capabilities capabilities() const;
+
+    QNetworkSessionPrivate *createSessionBackend();
+
+    QNetworkConfigurationPrivatePointer defaultConfiguration();
+
+    bool requiresPolling() const;
+
+private Q_SLOTS:
+    void doRequestUpdate();
+
+private:
+    QMap<QString, QString> configurationInterface;
+};
+
+QT_END_NAMESPACE
+
+#endif // QT_NO_BEARERMANAGEMENT
+
+#endif
+

--- a/src/qt/src/plugins/bearer/platformdefs_win.h
+++ b/src/qt/src/plugins/bearer/platformdefs_win.h
@@ -1,0 +1,141 @@
+/****************************************************************************
+**
+** Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
+** Contact: http://www.qt-project.org/legal
+**
+** This file is part of the plugins of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and Digia.  For licensing terms and
+** conditions see http://qt.digia.com/licensing.  For further information
+** use the contact form at http://qt.digia.com/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** In addition, as a special exception, Digia gives you certain additional
+** rights.  These rights are described in the Digia Qt LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 3.0 as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU General Public License version 3.0 requirements will be
+** met: http://www.gnu.org/copyleft/gpl.html.
+**
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef QPLATFORMDEFS_WIN_H
+#define QPLATFORMDEFS_WIN_H
+
+#include <winsock2.h>
+#include <mswsock.h>
+#undef interface
+#include <winioctl.h>
+
+QT_BEGIN_NAMESPACE
+
+#ifndef NS_NLA
+
+#define NS_NLA 15
+
+#ifndef NLA_NAMESPACE_GUID
+enum NLA_BLOB_DATA_TYPE {
+    NLA_RAW_DATA = 0,
+    NLA_INTERFACE = 1,
+    NLA_802_1X_LOCATION = 2,
+    NLA_CONNECTIVITY = 3,
+    NLA_ICS = 4
+};
+
+enum NLA_CONNECTIVITY_TYPE {
+    NLA_NETWORK_AD_HOC = 0,
+    NLA_NETWORK_MANAGED = 1,
+    NLA_NETWORK_UNMANAGED = 2,
+    NLA_NETWORK_UNKNOWN = 3
+};
+
+enum NLA_INTERNET {
+    NLA_INTERNET_UNKNOWN = 0,
+    NLA_INTERNET_NO = 1,
+    NLA_INTERNET_YES = 2
+};
+
+struct NLA_BLOB {
+    struct {
+        NLA_BLOB_DATA_TYPE type;
+        DWORD dwSize;
+        DWORD nextOffset;
+    } header;
+
+    union {
+        // NLA_RAW_DATA
+        CHAR rawData[1];
+
+        // NLA_INTERFACE
+        struct {
+            DWORD dwType;
+            DWORD dwSpeed;
+            CHAR adapterName[1];
+        } interfaceData;
+
+        // NLA_802_1X_LOCATION
+        struct {
+            CHAR information[1];
+        } locationData;
+
+        // NLA_CONNECTIVITY
+        struct {
+            NLA_CONNECTIVITY_TYPE type;
+            NLA_INTERNET internet;
+        } connectivity;
+
+        // NLA_ICS
+        struct {
+            struct {
+                DWORD speed;
+                DWORD type;
+                DWORD state;
+                WCHAR machineName[256];
+                WCHAR sharedAdapterName[256];
+            } remote;
+        } ICS;
+    } data;
+};
+#endif // NLA_NAMESPACE_GUID
+
+#endif
+
+enum NDIS_MEDIUM {
+    NdisMedium802_3 = 0,
+};
+
+enum NDIS_PHYSICAL_MEDIUM {
+    NdisPhysicalMediumWirelessLan = 1,
+    NdisPhysicalMediumBluetooth = 10,
+    NdisPhysicalMediumWiMax = 12,
+};
+
+#define OID_GEN_MEDIA_SUPPORTED 0x00010103
+#define OID_GEN_PHYSICAL_MEDIUM 0x00010202
+
+#define IOCTL_NDIS_QUERY_GLOBAL_STATS \
+    CTL_CODE(FILE_DEVICE_PHYSICAL_NETCARD, 0, METHOD_OUT_DIRECT, FILE_ANY_ACCESS)
+
+QT_END_NAMESPACE
+
+#endif // QPLATFORMDEFS_WIN_H

--- a/src/qt/src/plugins/bearer/qbearerengine_impl.h
+++ b/src/qt/src/plugins/bearer/qbearerengine_impl.h
@@ -1,0 +1,85 @@
+/****************************************************************************
+**
+** Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
+** Contact: http://www.qt-project.org/legal
+**
+** This file is part of the plugins of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and Digia.  For licensing terms and
+** conditions see http://qt.digia.com/licensing.  For further information
+** use the contact form at http://qt.digia.com/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** In addition, as a special exception, Digia gives you certain additional
+** rights.  These rights are described in the Digia Qt LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 3.0 as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU General Public License version 3.0 requirements will be
+** met: http://www.gnu.org/copyleft/gpl.html.
+**
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef QBEARERENGINE_IMPL_H
+#define QBEARERENGINE_IMPL_H
+
+#include <QtNetwork/private/qbearerengine_p.h>
+
+#ifndef QT_NO_BEARERMANAGEMENT
+
+QT_BEGIN_NAMESPACE
+
+class QBearerEngineImpl : public QBearerEngine
+{
+    Q_OBJECT
+
+public:
+    enum ConnectionError {
+        InterfaceLookupError = 0,
+        ConnectError,
+        OperationNotSupported,
+        DisconnectionError,
+    };
+
+    QBearerEngineImpl(QObject *parent = 0) : QBearerEngine(parent) {}
+    ~QBearerEngineImpl() {}
+
+    virtual void connectToId(const QString &id) = 0;
+    virtual void disconnectFromId(const QString &id) = 0;
+
+    virtual QString getInterfaceFromId(const QString &id) = 0;
+
+    virtual QNetworkSession::State sessionStateForId(const QString &id) = 0;
+
+    virtual quint64 bytesWritten(const QString &) { return Q_UINT64_C(0); }
+    virtual quint64 bytesReceived(const QString &) { return Q_UINT64_C(0); }
+    virtual quint64 startTime(const QString &) { return Q_UINT64_C(0); }
+
+Q_SIGNALS:
+    void connectionError(const QString &id, QBearerEngineImpl::ConnectionError error);
+};
+
+QT_END_NAMESPACE
+
+#endif // QT_NO_BEARERMANAGEMENT
+
+#endif // QBEARERENGINE_IMPL_H

--- a/src/qt/src/plugins/bearer/qnetworksession_impl.cpp
+++ b/src/qt/src/plugins/bearer/qnetworksession_impl.cpp
@@ -1,0 +1,421 @@
+/****************************************************************************
+**
+** Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
+** Contact: http://www.qt-project.org/legal
+**
+** This file is part of the plugins of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and Digia.  For licensing terms and
+** conditions see http://qt.digia.com/licensing.  For further information
+** use the contact form at http://qt.digia.com/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** In addition, as a special exception, Digia gives you certain additional
+** rights.  These rights are described in the Digia Qt LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 3.0 as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU General Public License version 3.0 requirements will be
+** met: http://www.gnu.org/copyleft/gpl.html.
+**
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "qnetworksession_impl.h"
+#include "qbearerengine_impl.h"
+
+#include <QtNetwork/qnetworksession.h>
+#include <QtNetwork/private/qnetworkconfigmanager_p.h>
+
+#include <QtCore/qdatetime.h>
+#include <QtCore/qdebug.h>
+#include <QtCore/qmutex.h>
+#include <QtCore/qstringlist.h>
+
+#ifndef QT_NO_BEARERMANAGEMENT
+
+QT_BEGIN_NAMESPACE
+
+static QBearerEngineImpl *getEngineFromId(const QString &id)
+{
+    QNetworkConfigurationManagerPrivate *priv = qNetworkConfigurationManagerPrivate();
+
+    foreach (QBearerEngine *engine, priv->engines()) {
+        QBearerEngineImpl *engineImpl = qobject_cast<QBearerEngineImpl *>(engine);
+        if (engineImpl && engineImpl->hasIdentifier(id))
+            return engineImpl;
+    }
+
+    return 0;
+}
+
+class QNetworkSessionManagerPrivate : public QObject
+{
+    Q_OBJECT
+
+public:
+    QNetworkSessionManagerPrivate(QObject *parent = 0) : QObject(parent) {}
+    ~QNetworkSessionManagerPrivate() {}
+
+    inline void forceSessionClose(const QNetworkConfiguration &config)
+    { emit forcedSessionClose(config); }
+
+Q_SIGNALS:
+    void forcedSessionClose(const QNetworkConfiguration &config);
+};
+
+#include "qnetworksession_impl.moc"
+
+Q_GLOBAL_STATIC(QNetworkSessionManagerPrivate, sessionManager);
+
+void QNetworkSessionPrivateImpl::syncStateWithInterface()
+{
+    connect(sessionManager(), SIGNAL(forcedSessionClose(QNetworkConfiguration)),
+            this, SLOT(forcedSessionClose(QNetworkConfiguration)));
+
+    opened = false;
+    isOpen = false;
+    state = QNetworkSession::Invalid;
+    lastError = QNetworkSession::UnknownSessionError;
+
+    qRegisterMetaType<QBearerEngineImpl::ConnectionError>("QBearerEngineImpl::ConnectionError");
+
+    switch (publicConfig.type()) {
+    case QNetworkConfiguration::InternetAccessPoint:
+        activeConfig = publicConfig;
+        engine = getEngineFromId(activeConfig.identifier());
+        if (engine) {
+            qRegisterMetaType<QNetworkConfigurationPrivatePointer>("QNetworkConfigurationPrivatePointer");
+            connect(engine, SIGNAL(configurationChanged(QNetworkConfigurationPrivatePointer)),
+                    this, SLOT(configurationChanged(QNetworkConfigurationPrivatePointer)),
+                    Qt::QueuedConnection);
+            connect(engine, SIGNAL(connectionError(QString,QBearerEngineImpl::ConnectionError)),
+                    this, SLOT(connectionError(QString,QBearerEngineImpl::ConnectionError)),
+                    Qt::QueuedConnection);
+        }
+        break;
+    case QNetworkConfiguration::ServiceNetwork:
+        serviceConfig = publicConfig;
+        // Defer setting engine and signals until open().
+        // fall through
+    case QNetworkConfiguration::UserChoice:
+        // Defer setting serviceConfig and activeConfig until open().
+        // fall through
+    default:
+        engine = 0;
+    }
+
+    networkConfigurationsChanged();
+}
+
+void QNetworkSessionPrivateImpl::open()
+{
+    if (serviceConfig.isValid()) {
+        lastError = QNetworkSession::OperationNotSupportedError;
+        emit QNetworkSessionPrivate::error(lastError);
+    } else if (!isOpen) {
+        if ((activeConfig.state() & QNetworkConfiguration::Discovered) != QNetworkConfiguration::Discovered) {
+            lastError = QNetworkSession::InvalidConfigurationError;
+            state = QNetworkSession::Invalid;
+            emit stateChanged(state);
+            emit QNetworkSessionPrivate::error(lastError);
+            return;
+        }
+        opened = true;
+
+        if ((activeConfig.state() & QNetworkConfiguration::Active) != QNetworkConfiguration::Active &&
+            (activeConfig.state() & QNetworkConfiguration::Discovered) == QNetworkConfiguration::Discovered) {
+            state = QNetworkSession::Connecting;
+            emit stateChanged(state);
+
+            engine->connectToId(activeConfig.identifier());
+        }
+
+        isOpen = (activeConfig.state() & QNetworkConfiguration::Active) == QNetworkConfiguration::Active;
+        if (isOpen)
+            emit quitPendingWaitsForOpened();
+    }
+}
+
+void QNetworkSessionPrivateImpl::close()
+{
+    if (serviceConfig.isValid()) {
+        lastError = QNetworkSession::OperationNotSupportedError;
+        emit QNetworkSessionPrivate::error(lastError);
+    } else if (isOpen) {
+        opened = false;
+        isOpen = false;
+        emit closed();
+    }
+}
+
+void QNetworkSessionPrivateImpl::stop()
+{
+    if (serviceConfig.isValid()) {
+        lastError = QNetworkSession::OperationNotSupportedError;
+        emit QNetworkSessionPrivate::error(lastError);
+    } else {
+        if ((activeConfig.state() & QNetworkConfiguration::Active) == QNetworkConfiguration::Active) {
+            state = QNetworkSession::Closing;
+            emit stateChanged(state);
+
+            engine->disconnectFromId(activeConfig.identifier());
+
+            sessionManager()->forceSessionClose(activeConfig);
+        }
+
+        opened = false;
+        isOpen = false;
+        emit closed();
+    }
+}
+
+void QNetworkSessionPrivateImpl::migrate()
+{
+}
+
+void QNetworkSessionPrivateImpl::accept()
+{
+}
+
+void QNetworkSessionPrivateImpl::ignore()
+{
+}
+
+void QNetworkSessionPrivateImpl::reject()
+{
+}
+
+#ifndef QT_NO_NETWORKINTERFACE
+QNetworkInterface QNetworkSessionPrivateImpl::currentInterface() const
+{
+    if (!engine || state != QNetworkSession::Connected || !publicConfig.isValid())
+        return QNetworkInterface();
+
+    QString interface = engine->getInterfaceFromId(activeConfig.identifier());
+    if (interface.isEmpty())
+        return QNetworkInterface();
+    return QNetworkInterface::interfaceFromName(interface);
+}
+#endif
+
+QVariant QNetworkSessionPrivateImpl::sessionProperty(const QString &key) const
+{
+    if (key == QLatin1String("AutoCloseSessionTimeout")) {
+        if (engine && engine->requiresPolling() &&
+            !(engine->capabilities() & QNetworkConfigurationManager::CanStartAndStopInterfaces)) {
+            return sessionTimeout >= 0 ? sessionTimeout * 10000 : -1;
+        }
+    }
+
+    return QVariant();
+}
+
+void QNetworkSessionPrivateImpl::setSessionProperty(const QString &key, const QVariant &value)
+{
+    if (key == QLatin1String("AutoCloseSessionTimeout")) {
+        if (engine && engine->requiresPolling() &&
+            !(engine->capabilities() & QNetworkConfigurationManager::CanStartAndStopInterfaces)) {
+            int timeout = value.toInt();
+            if (timeout >= 0) {
+                connect(engine, SIGNAL(updateCompleted()),
+                        this, SLOT(decrementTimeout()), Qt::UniqueConnection);
+                sessionTimeout = timeout / 10000;   // convert to poll intervals
+            } else {
+                disconnect(engine, SIGNAL(updateCompleted()), this, SLOT(decrementTimeout()));
+                sessionTimeout = -1;
+            }
+        }
+    }
+}
+
+QString QNetworkSessionPrivateImpl::errorString() const
+{
+    switch (lastError) {
+    case QNetworkSession::UnknownSessionError:
+        return tr("Unknown session error.");
+    case QNetworkSession::SessionAbortedError:
+        return tr("The session was aborted by the user or system.");
+    case QNetworkSession::OperationNotSupportedError:
+        return tr("The requested operation is not supported by the system.");
+    case QNetworkSession::InvalidConfigurationError:
+        return tr("The specified configuration cannot be used.");
+    case QNetworkSession::RoamingError:
+        return tr("Roaming was aborted or is not possible.");
+    default:
+        break;
+    }
+
+    return QString();
+}
+
+QNetworkSession::SessionError QNetworkSessionPrivateImpl::error() const
+{
+    return lastError;
+}
+
+quint64 QNetworkSessionPrivateImpl::bytesWritten() const
+{
+    if (engine && state == QNetworkSession::Connected)
+        return engine->bytesWritten(activeConfig.identifier());
+    return Q_UINT64_C(0);
+}
+
+quint64 QNetworkSessionPrivateImpl::bytesReceived() const
+{
+    if (engine && state == QNetworkSession::Connected)
+        return engine->bytesReceived(activeConfig.identifier());
+    return Q_UINT64_C(0);
+}
+
+quint64 QNetworkSessionPrivateImpl::activeTime() const
+{
+    if (state == QNetworkSession::Connected && startTime != Q_UINT64_C(0))
+        return QDateTime::currentDateTime().toTime_t() - startTime;
+    return Q_UINT64_C(0);
+}
+
+void QNetworkSessionPrivateImpl::updateStateFromServiceNetwork()
+{
+    QNetworkSession::State oldState = state;
+
+    foreach (const QNetworkConfiguration &config, serviceConfig.children()) {
+        if ((config.state() & QNetworkConfiguration::Active) != QNetworkConfiguration::Active)
+            continue;
+
+        if (activeConfig != config) {
+            if (engine) {
+                disconnect(engine, SIGNAL(connectionError(QString,QBearerEngineImpl::ConnectionError)),
+                           this, SLOT(connectionError(QString,QBearerEngineImpl::ConnectionError)));
+            }
+
+            activeConfig = config;
+            engine = getEngineFromId(activeConfig.identifier());
+
+            if (engine) {
+                connect(engine, SIGNAL(connectionError(QString,QBearerEngineImpl::ConnectionError)),
+                        this, SLOT(connectionError(QString,QBearerEngineImpl::ConnectionError)),
+                        Qt::QueuedConnection);
+            }
+            emit newConfigurationActivated();
+        }
+
+        state = QNetworkSession::Connected;
+        if (state != oldState)
+            emit stateChanged(state);
+
+        return;
+    }
+
+    if (serviceConfig.children().isEmpty())
+        state = QNetworkSession::NotAvailable;
+    else
+        state = QNetworkSession::Disconnected;
+
+    if (state != oldState)
+        emit stateChanged(state);
+}
+
+void QNetworkSessionPrivateImpl::updateStateFromActiveConfig()
+{
+    if (!engine)
+        return;
+
+    QNetworkSession::State oldState = state;
+    state = engine->sessionStateForId(activeConfig.identifier());
+
+    bool oldActive = isOpen;
+    isOpen = (state == QNetworkSession::Connected) ? opened : false;
+
+    if (!oldActive && isOpen)
+        emit quitPendingWaitsForOpened();
+    if (oldActive && !isOpen)
+        emit closed();
+
+    if (oldState != state)
+        emit stateChanged(state);
+}
+
+void QNetworkSessionPrivateImpl::networkConfigurationsChanged()
+{
+    if (serviceConfig.isValid())
+        updateStateFromServiceNetwork();
+    else
+        updateStateFromActiveConfig();
+
+    startTime = engine->startTime(activeConfig.identifier());
+}
+
+void QNetworkSessionPrivateImpl::configurationChanged(QNetworkConfigurationPrivatePointer config)
+{
+    if (serviceConfig.isValid() &&
+        (config->id == serviceConfig.identifier() || config->id == activeConfig.identifier())) {
+        updateStateFromServiceNetwork();
+    } else if (config->id == activeConfig.identifier()) {
+        updateStateFromActiveConfig();
+    }
+}
+
+void QNetworkSessionPrivateImpl::forcedSessionClose(const QNetworkConfiguration &config)
+{
+    if (activeConfig == config) {
+        opened = false;
+        isOpen = false;
+
+        emit closed();
+
+        lastError = QNetworkSession::SessionAbortedError;
+        emit QNetworkSessionPrivate::error(lastError);
+    }
+}
+
+void QNetworkSessionPrivateImpl::connectionError(const QString &id, QBearerEngineImpl::ConnectionError error)
+{
+    if (activeConfig.identifier() == id) {
+        networkConfigurationsChanged();
+        switch (error) {
+        case QBearerEngineImpl::OperationNotSupported:
+            lastError = QNetworkSession::OperationNotSupportedError;
+            opened = false;
+            break;
+        case QBearerEngineImpl::InterfaceLookupError:
+        case QBearerEngineImpl::ConnectError:
+        case QBearerEngineImpl::DisconnectionError:
+        default:
+            lastError = QNetworkSession::UnknownSessionError;
+        }
+
+        emit QNetworkSessionPrivate::error(lastError);
+    }
+}
+
+void QNetworkSessionPrivateImpl::decrementTimeout()
+{
+    if (--sessionTimeout <= 0) {
+        disconnect(engine, SIGNAL(updateCompleted()), this, SLOT(decrementTimeout()));
+        sessionTimeout = -1;
+        close();
+    }
+}
+
+QT_END_NAMESPACE
+
+#endif // QT_NO_BEARERMANAGEMENT

--- a/src/qt/src/plugins/bearer/qnetworksession_impl.h
+++ b/src/qt/src/plugins/bearer/qnetworksession_impl.h
@@ -1,0 +1,132 @@
+/****************************************************************************
+**
+** Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
+** Contact: http://www.qt-project.org/legal
+**
+** This file is part of the plugins of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and Digia.  For licensing terms and
+** conditions see http://qt.digia.com/licensing.  For further information
+** use the contact form at http://qt.digia.com/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** In addition, as a special exception, Digia gives you certain additional
+** rights.  These rights are described in the Digia Qt LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 3.0 as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU General Public License version 3.0 requirements will be
+** met: http://www.gnu.org/copyleft/gpl.html.
+**
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef QNETWORKSESSION_IMPL_H
+#define QNETWORKSESSION_IMPL_H
+
+//
+//  W A R N I N G
+//  -------------
+//
+// This file is not part of the Qt API.  It exists purely as an
+// implementation detail.  This header file may change from version to
+// version without notice, or even be removed.
+//
+// We mean it.
+//
+
+#include "qbearerengine_impl.h"
+
+#include <QtNetwork/private/qnetworkconfigmanager_p.h>
+#include <QtNetwork/private/qnetworksession_p.h>
+
+#ifndef QT_NO_BEARERMANAGEMENT
+
+QT_BEGIN_NAMESPACE
+
+class QBearerEngineImpl;
+
+class QNetworkSessionPrivateImpl : public QNetworkSessionPrivate
+{
+    Q_OBJECT
+
+public:
+    QNetworkSessionPrivateImpl()
+        : startTime(0), sessionTimeout(-1)
+    {}
+    ~QNetworkSessionPrivateImpl()
+    {}
+
+    //called by QNetworkSession constructor and ensures
+    //that the state is immediately updated (w/o actually opening
+    //a session). Also this function should take care of 
+    //notification hooks to discover future state changes.
+    void syncStateWithInterface();
+
+#ifndef QT_NO_NETWORKINTERFACE
+    QNetworkInterface currentInterface() const;
+#endif
+    QVariant sessionProperty(const QString& key) const;
+    void setSessionProperty(const QString& key, const QVariant& value);
+
+    void open();
+    void close();
+    void stop();
+    void migrate();
+    void accept();
+    void ignore();
+    void reject();
+
+    QString errorString() const; //must return translated string
+    QNetworkSession::SessionError error() const;
+
+    quint64 bytesWritten() const;
+    quint64 bytesReceived() const;
+    quint64 activeTime() const;
+
+private Q_SLOTS:
+    void networkConfigurationsChanged();
+    void configurationChanged(QNetworkConfigurationPrivatePointer config);
+    void forcedSessionClose(const QNetworkConfiguration &config);
+    void connectionError(const QString &id, QBearerEngineImpl::ConnectionError error);
+    void decrementTimeout();
+
+private:
+    void updateStateFromServiceNetwork();
+    void updateStateFromActiveConfig();
+
+private:
+    QBearerEngineImpl *engine;
+
+    quint64 startTime;
+
+    QNetworkSession::SessionError lastError;
+
+    int sessionTimeout;
+
+    bool opened;
+};
+
+QT_END_NAMESPACE
+
+#endif // QT_NO_BEARERMANAGEMENT
+
+#endif // QNETWORKSESSION_IMPL_H

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -385,22 +385,22 @@ WebPage::WebPage(QObject *parent, const QUrl &baseUrl)
     m_mainFrame->setScrollBarPolicy(Qt::Vertical, Qt::ScrollBarAlwaysOff);
 
     m_customWebPage->settings()->setAttribute(QWebSettings::OfflineStorageDatabaseEnabled, true);
+    m_customWebPage->settings()->setAttribute(QWebSettings::OfflineWebApplicationCacheEnabled, true);
+    m_customWebPage->settings()->setAttribute(QWebSettings::LocalStorageEnabled, true);
     if (phantomCfg->offlineStoragePath().isEmpty()) {
         m_customWebPage->settings()->setOfflineStoragePath(QDesktopServices::storageLocation(QDesktopServices::DataLocation));
+        m_customWebPage->settings()->setOfflineWebApplicationCachePath(QDesktopServices::storageLocation(QDesktopServices::DataLocation));
+        m_customWebPage->settings()->setLocalStoragePath(QDesktopServices::storageLocation(QDesktopServices::DataLocation));
     } else {
         m_customWebPage->settings()->setOfflineStoragePath(phantomCfg->offlineStoragePath());
+        m_customWebPage->settings()->setOfflineWebApplicationCachePath(phantomCfg->offlineStoragePath());
+        m_customWebPage->settings()->setLocalStoragePath(phantomCfg->offlineStoragePath());
     }
     if (phantomCfg->offlineStorageDefaultQuota() > 0) {
         m_customWebPage->settings()->setOfflineStorageDefaultQuota(phantomCfg->offlineStorageDefaultQuota());
     }
 
-    m_customWebPage->settings()->setAttribute(QWebSettings::OfflineWebApplicationCacheEnabled, true);
-    m_customWebPage->settings()->setOfflineWebApplicationCachePath(QDesktopServices::storageLocation(QDesktopServices::DataLocation));
-
     m_customWebPage->settings()->setAttribute(QWebSettings::FrameFlatteningEnabled, true);
-
-    m_customWebPage->settings()->setAttribute(QWebSettings::LocalStorageEnabled, true);
-    m_customWebPage->settings()->setLocalStoragePath(QDesktopServices::storageLocation(QDesktopServices::DataLocation));
 
     // Custom network access manager to allow traffic monitoring.
     m_networkAccessManager = new NetworkAccessManager(this, phantomCfg);


### PR DESCRIPTION
Currently phantomjs stores offline application cache data and what it calls local storage data in a shared directory, while phantomjs has a command-line parameter for such data.  This patch places all of this data into the user-specified directory (--local-storage-path) so that it is possible to run multiple independent phantomjs sessions in separate processes in a single user session on a system.

This will affect any existing user of --local-storage-path who also uses offline application storage in their site.

Please note, the navigator.onLine osx change might cause build problems on non-osx.  Probably need some modifications to the bearer.pro file that comments out building for anything other than osx.  But I'm not familiar with .pro files enough to blindly make those changes without testing.  So please consider immediately testing a build and modify that file to handle building bearer for mac but not for other systems.
