### PR TITLE
Remove MacPorts warning and replace with instructions

### DIFF
--- a/_posts/documentation/get-started/2000-01-01-download.md
+++ b/_posts/documentation/get-started/2000-01-01-download.md
@@ -30,7 +30,9 @@ The binary `bin/phantomjs` is ready to use.
 
 <pre>brew update &amp;&amp; brew install phantomjs</pre>
 
-**Warning**: MacPorts does not have updated PhantomJS build yet. Installing via MacPorts is not recommended.
+**Alternative** installation using MacPorts:
+
+<pre>sudo port selfupdate &amp;&amp; sudo port install phantomjs</pre>
 
 ## Linux
 


### PR DESCRIPTION
MacPorts now has phantomjs 1.9.7.
