### PR TITLE
Support for Japanese coding Windows-31J and x-euc-jp

### DIFF
--- a/src/qt/src/3rdparty/webkit/Source/WebCore/platform/text/TextCodecICU.cpp
+++ b/src/qt/src/3rdparty/webkit/Source/WebCore/platform/text/TextCodecICU.cpp
@@ -146,6 +146,7 @@ void TextCodecICU::registerEncodingNames(EncodingNameRegistrar registrar)
     registrar("x-cp1250", "windows-1250");
     registrar("x-cp1251", "windows-1251");
     registrar("x-euc", "EUC-JP");
+    registrar("Windows-31J", "Shift_JIS");
     registrar("x-windows-949", "windows-949");
     registrar("KSC5601", "KSC_5601");
     registrar("x-uhc", "windows-949");

--- a/src/qt/src/gui/text/qfont_x11.cpp
+++ b/src/qt/src/gui/text/qfont_x11.cpp
@@ -169,6 +169,7 @@ void QFont::initialize()
 
     case 17: // SJIS
     case 18: // eucJP
+    case 2024: // Windows-31J
         mib = 63;
         break;
     }

--- a/src/qt/src/plugins/codecs/jp/main.cpp
+++ b/src/qt/src/plugins/codecs/jp/main.cpp
@@ -99,6 +99,7 @@ QList<int> JPTextCodecs::mibEnums() const
     list += QEucJpCodec::_mibEnum();
     list += QJisCodec::_mibEnum();
     list += QSjisCodec::_mibEnum();
+    list += 2024; // Windows-31J
 #ifdef Q_WS_X11
     list += QFontJis0201Codec::_mibEnum();
     list += QFontJis0208Codec::_mibEnum();
@@ -112,7 +113,7 @@ QTextCodec *JPTextCodecs::createForMib(int mib)
         return new QEucJpCodec;
     if (mib == QJisCodec::_mibEnum())
         return new QJisCodec;
-    if (mib == QSjisCodec::_mibEnum())
+    if (mib == QSjisCodec::_mibEnum() || mib == 2024)
         return new QSjisCodec;
 #ifdef Q_WS_X11
     if (mib == QFontJis0208Codec::_mibEnum())

--- a/src/qt/src/plugins/codecs/jp/qeucjpcodec.cpp
+++ b/src/qt/src/plugins/codecs/jp/qeucjpcodec.cpp
@@ -256,6 +256,18 @@ QByteArray QEucJpCodec::_name()
 {
     return "EUC-JP";
 }
+
+/*!
+    Returns the codec's mime name.
+*/
+QList<QByteArray> QEucJpCodec::_aliases()
+{
+    QList<QByteArray> list;
+    list << "euc-jp"
+         << "x-euc-jp";
+    return list;
+}
+
 #endif // QT_NO_TEXTCODEC
 
 QT_END_NAMESPACE

--- a/src/qt/src/plugins/codecs/jp/qeucjpcodec.h
+++ b/src/qt/src/plugins/codecs/jp/qeucjpcodec.h
@@ -82,7 +82,7 @@ QT_BEGIN_NAMESPACE
 class QEucJpCodec : public QTextCodec {
 public:
     static QByteArray _name();
-    static QList<QByteArray> _aliases() { return QList<QByteArray>(); }
+    static QList<QByteArray> _aliases();
     static int _mibEnum();
 
     QByteArray name() const { return _name(); }

--- a/src/qt/src/plugins/codecs/jp/qsjiscodec.cpp
+++ b/src/qt/src/plugins/codecs/jp/qsjiscodec.cpp
@@ -221,6 +221,10 @@ QList<QByteArray> QSjisCodec::_aliases()
 {
     QList<QByteArray> list;
     list << "SJIS" // Qt 3 compat
+         << "Shift-JIS"
+         << "windows-31j"
+         << "Windows-31J"
+         << "MS932"
          << "MS_Kanji";
     return list;
 }


### PR DESCRIPTION
Japanese coding sites of Windows-31J and x-euc-jp are garbled now.
I was support for that codings.
