### PR TITLE
JSON arguments that do not translate from cmd line

### DIFF
--- a/_posts/documentation/learn/2000-01-07-command-line.md
+++ b/_posts/documentation/learn/2000-01-07-command-line.md
@@ -65,4 +65,14 @@ The contents of `config.json` should be a standalone JavaScript object. Keys are
 
   /* etc. */
 }
+
+There are some keys that do not translate directly:
+
+* --disk-cache => diskCacheEnabled
+* --load-images => autoLoadImages
+* --local-storage-path => offlineStoragePath
+* --local-storage-quota => offlineStorageDefaultQuota
+* --local-to-remote-url-access => localToRemoteUrlAccessEnabled
+* --web-security => webSecurityEnabled
+
 ```

--- a/_posts/documentation/learn/2000-01-07-command-line.md
+++ b/_posts/documentation/learn/2000-01-07-command-line.md
@@ -68,11 +68,11 @@ The contents of `config.json` should be a standalone JavaScript object. Keys are
 
 There are some keys that do not translate directly:
 
-* --disk-cache => diskCacheEnabled
-* --load-images => autoLoadImages
-* --local-storage-path => offlineStoragePath
-* --local-storage-quota => offlineStorageDefaultQuota
-* --local-to-remote-url-access => localToRemoteUrlAccessEnabled
-* --web-security => webSecurityEnabled
+ * --disk-cache => diskCacheEnabled
+ * --load-images => autoLoadImages
+ * --local-storage-path => offlineStoragePath
+ * --local-storage-quota => offlineStorageDefaultQuota
+ * --local-to-remote-url-access => localToRemoteUrlAccessEnabled
+ * --web-security => webSecurityEnabled
 
 ```


### PR DESCRIPTION
A note about keys that do not translate from --space-dash to CamelCase
