### PR TITLE
Fix harfbuzz assertions using patch from Chromium.

### DIFF
--- a/src/qt/src/3rdparty/harfbuzz/src/harfbuzz-hebrew.c
+++ b/src/qt/src/3rdparty/harfbuzz/src/harfbuzz-hebrew.c
@@ -55,6 +55,7 @@ HB_Bool HB_HebrewShape(HB_ShaperItem *shaper_item)
     };
 
     assert(shaper_item->item.script == HB_Script_Hebrew);
+    HB_HeuristicSetGlyphAttributes(shaper_item);
 
 #ifndef NO_OPENTYPE
     if (HB_SelectScript(shaper_item, hebrew_features)) {
@@ -63,7 +64,6 @@ HB_Bool HB_HebrewShape(HB_ShaperItem *shaper_item)
         if (!HB_ConvertStringToGlyphIndices(shaper_item))
             return FALSE;
 
-        HB_HeuristicSetGlyphAttributes(shaper_item);
         HB_OpenTypeShape(shaper_item, /*properties*/0);
         return HB_OpenTypePosition(shaper_item, availableGlyphs, /*doLogClusters*/TRUE);
     }

--- a/src/qt/src/3rdparty/harfbuzz/src/harfbuzz-shaper.cpp
+++ b/src/qt/src/3rdparty/harfbuzz/src/harfbuzz-shaper.cpp
@@ -463,7 +463,7 @@ void HB_HeuristicSetGlyphAttributes(HB_ShaperItem *item)
 
     // ### zeroWidth and justification are missing here!!!!!
 
-    assert(item->num_glyphs <= length);
+    assert(length <= item->num_glyphs);
 
 //     qDebug("QScriptEngine::heuristicSetGlyphAttributes, num_glyphs=%d", item->num_glyphs);
     HB_GlyphAttributes *attributes = item->attributes;
@@ -481,7 +481,6 @@ void HB_HeuristicSetGlyphAttributes(HB_ShaperItem *item)
         }
         ++glyph_pos;
     }
-    assert(glyph_pos == item->num_glyphs);
 
     // first char in a run is never (treated as) a mark
     int cStart = 0;


### PR DESCRIPTION
Exotic text (e.g. attempting to render a binary file such as .zip
or .exe as a webpage) can trigger an assertion failure in the
Harfbuzz code. Chromium developers also noticed this issue and
committed a patch to fix it:

http://lists.freedesktop.org/archives/harfbuzz/2009-August/000354.html

This patch has not been accepted by upstream, but this (old) version
of Harfbuzz has been abandoned and superceded by Harfbuzz-NG.

Issue #11264

_NOTE:_ I've lost this patch during the upgrade to Qt 4.8.5. Reported [here](https://github.com/ariya/phantomjs/issues/12098)
