### PR TITLE
Update 2000-01-02-build.md

### DIFF
--- a/_posts/documentation/get-started/2000-01-02-build.md
+++ b/_posts/documentation/get-started/2000-01-02-build.md
@@ -75,7 +75,11 @@ git checkout 1.9
 
 ## Windows
 
-Install [Microsoft Visual C++](http://www.microsoft.com/visualstudio/), either version 2010 or 2008 (the [Express edition](http://www.microsoft.com/visualstudio/en-us/products/2010-editions/express) should work just fine).
+System Requirements (for building using a Windows 7 virtual machine):
+System Memory: At least 2 GB. The QT link requires at least 1.5 GB.
+Disk Space: At least 2 GB free. The QTWebKit.lib file alone is almost 600 MB.
+
+Install [Microsoft Visual C++](http://www.microsoft.com/visualstudio/), either version 2010 (the [Express edition](http://www.microsoft.com/visualstudio/en-us/products/2010-editions/express) works just fine) or 2008 (the [Express edition](http://www.microsoft.com/visualstudio/en-us/products/2010-editions/express) should work just fine).
 
 Install [ActivePerl 5](http://www.activestate.com/activeperl/) (the free Community Edition should work fine).
 
@@ -107,4 +111,4 @@ src\qt\bin\qmake -r
 nmake
 ```
 
-This produces a static build `bin/phantomjs.exe`. This is a self-contained executable, it can be moved to a different directory or another machine.
+This produces a static build `bin/phantomjs.exe`. This is a self-contained executable, it can be moved to a different directory or another machine. Note: your phantomjs.exe will be significantly larger than the file in the distribution. The distributed file is packed using UPX (as indicated on the Release Preparation page).


### PR DESCRIPTION
Added minimum requirements for Windows 7 build and a note that the generated PhantomJS.exe will be larger than distributed since it is not packed using UPX.
