### PR TITLE
webPage.addCookie: Correct required properties

### DIFF
--- a/_posts/api/webpage/method/2000-01-01-add-cookie.md
+++ b/_posts/api/webpage/method/2000-01-01-add-cookie.md
@@ -9,7 +9,7 @@ permalink: api/webpage/method/add-cookie.html
 
 **Introduced:** PhantomJS 1.7
 
-Add a Cookie to the page. If the domains do not match, the Cookie will be ignored/rejected. Returns `true` if successfully added, otherwise `false`.
+Add a Cookie to the page. If the `domain` does not match the current page, the Cookie will be ignored/rejected. Returns `true` if successfully added, otherwise `false`.
 
 ## Examples
 
@@ -20,8 +20,8 @@ var page = webPage.create();
 phantom.addCookie({
   'name'     : 'Valid-Cookie-Name',   /* required property */
   'value'    : 'Valid-Cookie-Value',  /* required property */
-  'domain'   : 'localhost',           /* required property */
-  'path'     : '/foo',
+  'domain'   : 'localhost',
+  'path'     : '/foo',                /* required property */
   'httponly' : true,
   'secure'   : false,
   'expires'  : (new Date()).getTime() + (1000 * 60 * 60)   /* <-- expires in 1 hour */


### PR DESCRIPTION
domain is not needed. If omitted, all cookies are permitted. path required.
