### PR TITLE
Add a way to disable crash dumps (issue #12236).

### DIFF
--- a/src/crashdump.cpp
+++ b/src/crashdump.cpp
@@ -1,0 +1,172 @@
+/*
+  This file is part of the PhantomJS project from Ofi Labs.
+
+  Copyright (C) 2011 Ariya Hidayat <ariya.hidayat@gmail.com>
+  Copyright (C) 2011 Ivan De Marino <ivan.de.marino@gmail.com>
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "crashdump.h"
+
+#include <QtGlobal>
+#include <QString>
+#include <QByteArray>
+
+#ifdef Q_OS_LINUX
+#include "client/linux/handler/exception_handler.h"
+#define HAVE_BREAKPAD
+#define EHC_EXTRA_ARGS true
+#define MDC_PATH_ARG   const char*
+#define MDC_EXTRA_ARGS void*
+#endif
+#ifdef Q_OS_MAC
+#include "client/mac/handler/exception_handler.h"
+#define HAVE_BREAKPAD
+#define EHC_EXTRA_ARGS true, NULL
+#define MDC_PATH_ARG   const char*
+#define MDC_EXTRA_ARGS void*
+#endif
+#ifdef Q_OS_WIN32
+#include "client/windows/handler/exception_handler.h"
+#define HAVE_BREAKPAD
+#define EHC_EXTRA_ARGS ExceptionHandler::HANDLER_ALL
+#define MDC_PATH_ARG   const wchar_t*
+#define MDC_EXTRA_ARGS void*, EXCEPTION_POINTERS*, MDRawAssertionInfo*
+#endif
+
+#ifdef HAVE_BREAKPAD
+
+using google_breakpad::ExceptionHandler;
+
+#ifdef Q_OS_WIN32
+// qgetenv doesn't handle environment variables containing Unicode
+// characters very well.  Breakpad-for-Windows works exclusively with
+// Unicode paths anyway, so we use the native API to retrieve %TEMP%
+// as Unicode.  This code based upon qglobal.cpp::qgetenv.
+static QString
+q_wgetenv(const wchar_t *varName)
+{
+    size_t requiredSize;
+    _wgetenv_s(&requiredSize, 0, 0, varName);
+    if (requiredSize == 0 || requiredSize > size_t(INT_MAX / sizeof(wchar_t)))
+        return QString();
+
+    // Unfortunately it does not appear to be safe to pass QString::data()
+    // to a Windows API that expects wchar_t*.  QChar is too different.
+    // We have to employ a scratch buffer.  Limiting the length to
+    // INT_MAX / sizeof(wchar_t), above, ensures that the multiplication
+    // here cannot overflow.
+    wchar_t *buffer = malloc(requiredSize * sizeof(wchar_t));
+    if (!buffer)
+        return QString();
+
+    // requiredSize includes the terminating null, which we don't want.
+    // The range-check above also ensures that the conversion to int here
+    // does not overflow.
+    _wgetenv_s(&requiredSize, buffer, requiredSize, varName);
+    Q_ASSERT(buffer[requiredSize-1] == L'\0');
+    QString ret = QString::fromWCharArray(buffer, int(requiredSize - 1));
+
+    free(buffer);
+    return ret;
+}
+#endif
+
+//
+// Crash messages.
+//
+
+#ifdef Q_OS_WIN32
+#define CRASH_DUMP_FMT "%ls\\%ls.dmp"
+#define CRASH_DIR_FMT  "%%TEMP%% (%ls)"
+#else
+#define CRASH_DUMP_FMT "%s/%s.dmp"
+#define CRASH_DIR_FMT  "$TMPDIR (%s)"
+#endif
+
+#define CRASH_MESSAGE_BASE \
+    "PhantomJS has crashed. Please read the crash reporting guide at\n" \
+    "<http://phantomjs.org/crash-reporting.html> and file a bug report at\n" \
+    "<https://github.com/ariya/phantomjs/issues/new>.\n"
+
+#define CRASH_MESSAGE_HAVE_DUMP \
+    CRASH_MESSAGE_BASE \
+    "Please attach the crash dump file:\n  " CRASH_DUMP_FMT "\n"
+
+#define CRASH_MESSAGE_NO_DUMP \
+    CRASH_MESSAGE_BASE \
+    "Unfortunately, no crash dump is available.\n" \
+    "(Is " CRASH_DIR_FMT " a directory you cannot write?)\n"
+
+static bool minidumpCallback(MDC_PATH_ARG dump_path,
+                             MDC_PATH_ARG minidump_id,
+                             MDC_EXTRA_ARGS,
+                             bool succeeded)
+{
+    if (succeeded)
+        fprintf(stderr, CRASH_MESSAGE_HAVE_DUMP, dump_path, minidump_id);
+    else
+        fprintf(stderr, CRASH_MESSAGE_NO_DUMP, dump_path);
+    return succeeded;
+}
+
+static ExceptionHandler *initBreakpad()
+{
+    // On all platforms, Breakpad can be disabled by setting the
+    // environment variable PHANTOMJS_DISABLE_CRASH_DUMPS to any
+    // non-empty value.  This is not a command line argument because
+    // we want to initialize Breakpad before parsing the command line.
+    if (!qEnvironmentVariableIsEmpty("PHANTOMJS_DISABLE_CRASH_DUMPS"))
+        return 0;
+
+    // Windows and Unix have different conventions for the environment
+    // variable naming the directory that should hold scratch files.
+#ifdef Q_OS_WIN32
+    std::wstring dumpPath(L".");
+    QString varbuf = q_wgetenv(L"TEMP");
+    if (!varbuf.isEmpty())
+        dumpPath = varbuf.toStdWString();
+#else
+    std::string dumpPath("/tmp");
+    QByteArray varbuf = qgetenv("TMPDIR");
+    if (!varbuf.isEmpty())
+        dumpPath = varbuf.constData();
+#endif
+
+    return new ExceptionHandler(dumpPath, NULL, minidumpCallback, NULL,
+                                EHC_EXTRA_ARGS);
+}
+#else // no HAVE_BREAKPAD
+#define initBreakpad() NULL
+#endif
+
+CrashHandler::CrashHandler()
+  : eh(initBreakpad())
+{}
+
+CrashHandler::~CrashHandler()
+{
+  delete eh;
+}

--- a/src/crashdump.h
+++ b/src/crashdump.h
@@ -28,43 +28,21 @@
   THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#ifndef UTILS_H
-#define UTILS_H
+#ifndef CRASHDUMP_H
+#define CRASHDUMP_H
 
-#include <QtGlobal>
-#include <QtWebKitWidgets/QWebFrame>
-#include <QFile>
+namespace google_breakpad {
+    class ExceptionHandler;
+}
 
-#include "encoding.h"
-
-class QTemporaryFile;
-/**
- * Aggregate common utility functions.
- * Functions are static methods.
- * It's important to notice that, at the moment, this class can't be instantiated by design.
- */
-class Utils
+class CrashHandler
 {
 public:
-    static void messageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg);
-
-    static bool injectJsInFrame(const QString &jsFilePath, const QString &libraryPath, QWebFrame *targetFrame, const bool startingScript = false);
-    static bool injectJsInFrame(const QString &jsFilePath, const QString &jsFileLanguage, const Encoding &jsFileEnc, const QString &libraryPath, QWebFrame *targetFrame, const bool startingScript = false);
-    static QString readResourceFileUtf8(const QString &resourceFilePath);
-
-    static bool loadJSForDebug(const QString &jsFilePath, const QString &jsFileLanguage, const Encoding &jsFileEnc, const QString &libraryPath, QWebFrame *targetFrame, const bool autorun = false);
-    static bool loadJSForDebug(const QString &jsFilePath, const QString &libraryPath, QWebFrame *targetFrame, const bool autorun = false);
-    static void cleanupFromDebug();
-
-    static bool printDebugMessages;
+    CrashHandler();
+    ~CrashHandler();
 
 private:
-    static QString findScript(const QString &jsFilePath, const QString& libraryPath);
-    static QString jsFromScriptFile(const QString& scriptPath, const QString& lang, const Encoding& enc);
-    Utils(); //< This class shouldn't be instantiated
-
-    static QTemporaryFile* m_tempHarness; //< We want to make sure to clean up after ourselves
-    static QTemporaryFile* m_tempWrapper;
+    google_breakpad::ExceptionHandler *eh;
 };
 
-#endif // UTILS_H
+#endif // CRASHDUMP_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,51 +34,14 @@
 #include "utils.h"
 #include "env.h"
 #include "phantom.h"
-
-#ifdef Q_OS_LINUX
-#include "client/linux/handler/exception_handler.h"
-#endif
-#ifdef Q_OS_MAC
-#include "client/mac/handler/exception_handler.h"
-#endif
+#include "crashdump.h"
 
 #include <QApplication>
 #include <QSslSocket>
 
-#ifdef Q_OS_WIN32
-using namespace google_breakpad;
-static google_breakpad::ExceptionHandler* eh;
-#endif
-
 int main(int argc, char** argv)
 {
-    // Setup Google Breakpad exception handler
-#ifdef Q_OS_LINUX
-    google_breakpad::ExceptionHandler eh("/tmp", NULL, Utils::exceptionHandler, NULL, true);
-#endif
-#ifdef Q_OS_MAC
-    google_breakpad::ExceptionHandler eh("/tmp", NULL, Utils::exceptionHandler, NULL, true, NULL);
-#endif
-#ifdef Q_OS_WIN32
-    // This is needed for CRT to not show dialog for invalid param
-    // failures and instead let the code handle it.
-    _CrtSetReportMode(_CRT_ASSERT, 0);
-
-    DWORD cbBuffer = ExpandEnvironmentStrings(TEXT("%TEMP%"), NULL, 0);
-
-    if (cbBuffer == 0) {
-        eh = new ExceptionHandler(TEXT("."), NULL, Utils::exceptionHandler, NULL, ExceptionHandler::HANDLER_ALL);
-    } else {
-        LPWSTR szBuffer = reinterpret_cast<LPWSTR>(malloc(sizeof(TCHAR) * (cbBuffer + 1)));
-
-        if (ExpandEnvironmentStrings(TEXT("%TEMP%"), szBuffer, cbBuffer + 1) > 0) {
-            wstring lpDumpPath(szBuffer);
-            eh = new ExceptionHandler(lpDumpPath, NULL, Utils::exceptionHandler, NULL, ExceptionHandler::HANDLER_ALL);
-        }
-        free(szBuffer);
-    }
-#endif
-
+    CrashHandler crash_guard;
     QApplication app(argc, argv);
 
     app.setWindowIcon(QIcon(":/phantomjs-icon.png"));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,6 +38,7 @@
 
 #include <QApplication>
 #include <QSslSocket>
+#include <QIcon>
 
 int main(int argc, char** argv)
 {

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -493,10 +493,6 @@ void Phantom::clearCookies()
 // private:
 void Phantom::doExit(int code)
 {
-    if (m_config.debug()) {
-        Utils::cleanupFromDebug();
-    }
-
     emit aboutToExit(code);
     m_terminated = true;
     m_returnValue = code;

--- a/src/phantomjs.pro
+++ b/src/phantomjs.pro
@@ -33,7 +33,8 @@ HEADERS += \
     encoding.h \
     config.h \
     childprocess.h \
-    repl.h
+    repl.h \
+    crashdump.h
 
 SOURCES += phantom.cpp \
     callback.cpp \
@@ -50,7 +51,8 @@ SOURCES += phantom.cpp \
     encoding.cpp \
     config.cpp \
     childprocess.cpp \
-    repl.cpp
+    repl.cpp \
+    crashdump.cpp
 
 OTHER_FILES += \
     bootstrap.js \

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -66,34 +66,6 @@ void Utils::messageHandler(QtMsgType type, const QMessageLogContext &context, co
         abort();
     }
 }
-#ifdef Q_OS_WIN32
-bool Utils::exceptionHandler(const TCHAR* dump_path, const TCHAR* minidump_id,
-                             void* context, EXCEPTION_POINTERS* exinfo,
-                             MDRawAssertionInfo *assertion, bool succeeded)
-{
-    Q_UNUSED(exinfo);
-    Q_UNUSED(assertion);
-    Q_UNUSED(context);
-  
-    fprintf(stderr, "PhantomJS has crashed. Please read the crash reporting guide at " \
-                    "https://github.com/ariya/phantomjs/wiki/Crash-Reporting and file a " \
-                    "bug report at https://github.com/ariya/phantomjs/issues/new with the " \
-                    "crash dump file attached: %ls\\%ls.dmp\n",
-                    dump_path, minidump_id);
-    return succeeded;
-}
-#else
-bool Utils::exceptionHandler(const char* dump_path, const char* minidump_id, void* context, bool succeeded)
-{
-    Q_UNUSED(context);
-    fprintf(stderr, "PhantomJS has crashed. Please read the crash reporting guide at " \
-                    "https://github.com/ariya/phantomjs/wiki/Crash-Reporting and file a " \
-                    "bug report at https://github.com/ariya/phantomjs/issues/new with the " \
-                    "crash dump file attached: %s/%s.dmp\n",
-                    dump_path, minidump_id);
-    return succeeded;
-}
-#endif
 
 bool Utils::injectJsInFrame(const QString &jsFilePath, const QString &libraryPath, QWebFrame *targetFrame, const bool startingScript)
 {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -28,91 +28,17 @@
   THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#include "utils.h"
+#include "consts.h"
+#include "terminal.h"
+
 #include <QFile>
 #include <QDebug>
 #include <QDateTime>
 #include <QDir>
-#include <QTemporaryFile>
+#include <QtWebKitWidgets/QWebFrame>
 
-#include "consts.h"
-#include "terminal.h"
-#include "utils.h"
-
-QTemporaryFile* Utils::m_tempHarness = 0;
-QTemporaryFile* Utils::m_tempWrapper = 0;
-bool Utils::printDebugMessages = false;
-
-void Utils::messageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg)
-{
-    Q_UNUSED(context);
-    QDateTime now = QDateTime::currentDateTime();
-
-    switch (type) {
-    case QtDebugMsg:
-        if (printDebugMessages) {
-            fprintf(stderr, "%s [DEBUG] %s\n", qPrintable(now.toString(Qt::ISODate)), qPrintable(msg));
-        }
-        break;
-    case QtWarningMsg:
-        if (printDebugMessages) {
-            fprintf(stderr, "%s [WARNING] %s\n", qPrintable(now.toString(Qt::ISODate)), qPrintable(msg));
-        }
-        break;
-    case QtCriticalMsg:
-        fprintf(stderr, "%s [CRITICAL] %s\n", qPrintable(now.toString(Qt::ISODate)), qPrintable(msg));
-        break;
-    case QtFatalMsg:
-        fprintf(stderr, "%s [FATAL] %s\n", qPrintable(now.toString(Qt::ISODate)), qPrintable(msg));
-        abort();
-    }
-}
-
-bool Utils::injectJsInFrame(const QString &jsFilePath, const QString &libraryPath, QWebFrame *targetFrame, const bool startingScript)
-{
-    return injectJsInFrame(jsFilePath, QString(), Encoding::UTF8, libraryPath, targetFrame, startingScript);
-}
-
-bool Utils::injectJsInFrame(const QString &jsFilePath, const QString &jsFileLanguage, const Encoding &jsFileEnc, const QString &libraryPath, QWebFrame *targetFrame, const bool startingScript)
-{
-    // Don't do anything if an empty string is passed
-    QString scriptPath = findScript(jsFilePath, libraryPath);
-    QString scriptBody = jsFromScriptFile(scriptPath, jsFileLanguage, jsFileEnc);
-    if (scriptBody.isEmpty())
-    {
-        if (startingScript) {
-            Terminal::instance()->cerr(QString("Can't open '%1'").arg(jsFilePath));
-        } else {
-            qWarning("Can't open '%s'", qPrintable(jsFilePath));
-        }
-        return false;
-    }
-    // Execute JS code in the context of the document
-    targetFrame->evaluateJavaScript(scriptBody, jsFilePath);
-    return true;
-}
-
-bool Utils::loadJSForDebug(const QString& jsFilePath, const QString& libraryPath, QWebFrame* targetFrame, const bool autorun)
-{
-    return loadJSForDebug(jsFilePath, QString(), Encoding::UTF8, libraryPath, targetFrame, autorun);
-}
-
-bool Utils::loadJSForDebug(const QString& jsFilePath, const QString &jsFileLanguage, const Encoding& jsFileEnc, const QString& libraryPath, QWebFrame* targetFrame, const bool autorun)
-{
-    QString scriptPath = findScript(jsFilePath, libraryPath);
-    QString scriptBody = jsFromScriptFile(scriptPath, jsFileLanguage, jsFileEnc);
-
-    QString remoteDebuggerHarnessSrc =  Utils::readResourceFileUtf8(":/remote_debugger_harness.html");
-    remoteDebuggerHarnessSrc = remoteDebuggerHarnessSrc.arg(scriptBody);
-    targetFrame->setHtml(remoteDebuggerHarnessSrc);
-
-    if (autorun) {
-        targetFrame->evaluateJavaScript("__run()", QString());
-    }
-
-    return true;
-}
-
-QString Utils::findScript(const QString& jsFilePath, const QString &libraryPath)
+static QString findScript(const QString& jsFilePath, const QString &libraryPath)
 {
     QString filePath = jsFilePath;
     if (!jsFilePath.isEmpty()) {
@@ -130,7 +56,7 @@ QString Utils::findScript(const QString& jsFilePath, const QString &libraryPath)
     return QString();
 }
 
-QString Utils::jsFromScriptFile(const QString& scriptPath, const QString& scriptLanguage, const Encoding& enc)
+static QString jsFromScriptFile(const QString& scriptPath, const QString& scriptLanguage, const Encoding& enc)
 {
     QFile jsFile(scriptPath);
     if (jsFile.exists() && jsFile.open(QFile::ReadOnly)) {
@@ -158,31 +84,85 @@ QString Utils::jsFromScriptFile(const QString& scriptPath, const QString& script
     }
 }
 
+namespace Utils {
 
-void
-Utils::cleanupFromDebug()
+bool printDebugMessages = false;
+
+void messageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {
-    if (m_tempHarness) {
-        // Will erase the temp file on disk
-        delete m_tempHarness;
-        m_tempHarness = 0;
-    }
-    if (m_tempWrapper) {
-        delete m_tempWrapper;
-        m_tempWrapper = 0;
+    Q_UNUSED(context);
+    QDateTime now = QDateTime::currentDateTime();
+
+    switch (type) {
+    case QtDebugMsg:
+        if (printDebugMessages) {
+            fprintf(stderr, "%s [DEBUG] %s\n", qPrintable(now.toString(Qt::ISODate)), qPrintable(msg));
+        }
+        break;
+    case QtWarningMsg:
+        if (printDebugMessages) {
+            fprintf(stderr, "%s [WARNING] %s\n", qPrintable(now.toString(Qt::ISODate)), qPrintable(msg));
+        }
+        break;
+    case QtCriticalMsg:
+        fprintf(stderr, "%s [CRITICAL] %s\n", qPrintable(now.toString(Qt::ISODate)), qPrintable(msg));
+        break;
+    case QtFatalMsg:
+        fprintf(stderr, "%s [FATAL] %s\n", qPrintable(now.toString(Qt::ISODate)), qPrintable(msg));
+        abort();
     }
 }
 
+bool injectJsInFrame(const QString &jsFilePath, const QString &libraryPath, QWebFrame *targetFrame, const bool startingScript)
+{
+    return injectJsInFrame(jsFilePath, QString(), Encoding::UTF8, libraryPath, targetFrame, startingScript);
+}
 
-QString Utils::readResourceFileUtf8(const QString &resourceFilePath)
+bool injectJsInFrame(const QString &jsFilePath, const QString &jsFileLanguage, const Encoding &jsFileEnc, const QString &libraryPath, QWebFrame *targetFrame, const bool startingScript)
+{
+    // Don't do anything if an empty string is passed
+    QString scriptPath = findScript(jsFilePath, libraryPath);
+    QString scriptBody = jsFromScriptFile(scriptPath, jsFileLanguage, jsFileEnc);
+    if (scriptBody.isEmpty())
+    {
+        if (startingScript) {
+            Terminal::instance()->cerr(QString("Can't open '%1'").arg(jsFilePath));
+        } else {
+            qWarning("Can't open '%s'", qPrintable(jsFilePath));
+        }
+        return false;
+    }
+    // Execute JS code in the context of the document
+    targetFrame->evaluateJavaScript(scriptBody, jsFilePath);
+    return true;
+}
+
+bool loadJSForDebug(const QString& jsFilePath, const QString& libraryPath, QWebFrame* targetFrame, const bool autorun)
+{
+    return loadJSForDebug(jsFilePath, QString(), Encoding::UTF8, libraryPath, targetFrame, autorun);
+}
+
+bool loadJSForDebug(const QString& jsFilePath, const QString &jsFileLanguage, const Encoding& jsFileEnc, const QString& libraryPath, QWebFrame* targetFrame, const bool autorun)
+{
+    QString scriptPath = findScript(jsFilePath, libraryPath);
+    QString scriptBody = jsFromScriptFile(scriptPath, jsFileLanguage, jsFileEnc);
+
+    QString remoteDebuggerHarnessSrc =  readResourceFileUtf8(":/remote_debugger_harness.html");
+    remoteDebuggerHarnessSrc = remoteDebuggerHarnessSrc.arg(scriptBody);
+    targetFrame->setHtml(remoteDebuggerHarnessSrc);
+
+    if (autorun) {
+        targetFrame->evaluateJavaScript("__run()", QString());
+    }
+
+    return true;
+}
+
+QString readResourceFileUtf8(const QString &resourceFilePath)
 {
     QFile f(resourceFilePath);
     f.open(QFile::ReadOnly); //< It's OK to assume this succeed. If it doesn't, we have a bigger problem.
     return QString::fromUtf8(f.readAll());
 }
 
-// private:
-Utils::Utils()
-{
-    // Nothing to do here
-}
+}; // namespace Utils

--- a/src/utils.h
+++ b/src/utils.h
@@ -32,39 +32,47 @@
 #define UTILS_H
 
 #include <QtGlobal>
-#include <QtWebKitWidgets/QWebFrame>
-#include <QFile>
-
 #include "encoding.h"
 
-class QTemporaryFile;
+class QWebFrame;
+
 /**
  * Aggregate common utility functions.
- * Functions are static methods.
- * It's important to notice that, at the moment, this class can't be instantiated by design.
  */
-class Utils
-{
-public:
-    static void messageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg);
 
-    static bool injectJsInFrame(const QString &jsFilePath, const QString &libraryPath, QWebFrame *targetFrame, const bool startingScript = false);
-    static bool injectJsInFrame(const QString &jsFilePath, const QString &jsFileLanguage, const Encoding &jsFileEnc, const QString &libraryPath, QWebFrame *targetFrame, const bool startingScript = false);
-    static QString readResourceFileUtf8(const QString &resourceFilePath);
+namespace Utils {
 
-    static bool loadJSForDebug(const QString &jsFilePath, const QString &jsFileLanguage, const Encoding &jsFileEnc, const QString &libraryPath, QWebFrame *targetFrame, const bool autorun = false);
-    static bool loadJSForDebug(const QString &jsFilePath, const QString &libraryPath, QWebFrame *targetFrame, const bool autorun = false);
-    static void cleanupFromDebug();
+void messageHandler(QtMsgType type,
+                    const QMessageLogContext &context,
+                    const QString &msg);
+extern bool printDebugMessages;
 
-    static bool printDebugMessages;
+bool injectJsInFrame(const QString &jsFilePath,
+                     const QString &libraryPath,
+                     QWebFrame *targetFrame,
+                     const bool startingScript = false);
 
-private:
-    static QString findScript(const QString &jsFilePath, const QString& libraryPath);
-    static QString jsFromScriptFile(const QString& scriptPath, const QString& lang, const Encoding& enc);
-    Utils(); //< This class shouldn't be instantiated
+bool injectJsInFrame(const QString &jsFilePath,
+                     const QString &jsFileLanguage,
+                     const Encoding &jsFileEnc,
+                     const QString &libraryPath,
+                     QWebFrame *targetFrame,
+                     const bool startingScript = false);
 
-    static QTemporaryFile* m_tempHarness; //< We want to make sure to clean up after ourselves
-    static QTemporaryFile* m_tempWrapper;
+ bool loadJSForDebug(const QString &jsFilePath,
+                     const QString &libraryPath,
+                     QWebFrame *targetFrame,
+                     const bool autorun = false);
+
+bool loadJSForDebug(const QString &jsFilePath,
+                    const QString &jsFileLanguage,
+                    const Encoding &jsFileEnc,
+                    const QString &libraryPath,
+                    QWebFrame *targetFrame,
+                    const bool autorun = false);
+
+QString readResourceFileUtf8(const QString &resourceFilePath);
+
 };
 
 #endif // UTILS_H


### PR DESCRIPTION
- If the environment variable PHANTOMJS_DISABLE_CRASH_DUMPS
  is set to any value, do not initialize Breakpad.  (On Windows,
  we still call _CrtSetReportMode(_CRT_ASSERT, 0).)
- On Mac and Linux, if the environment variable TMPDIR is set,
  put the crash dumps there instead of in /tmp.
- Move the code that initializes Breakpad to utils.cpp, so it is
  next to the code that prints the crash message.

Note: only tested on Linux, not even compiled anywhere else.  This change should be mentioned in the documentation somewhere, but I don't know where to put it.
