### PR TITLE
Replace proxy initialization with existing method

### DIFF
--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -103,25 +103,10 @@ void Phantom::init()
     m_page->setCookieJar(m_defaultCookieJar);
     m_pages.append(m_page);
 
+    // Set up proxy if required
     QString proxyType = m_config.proxyType();
     if (proxyType != "none") {
-        if (m_config.proxyHost().isEmpty()) {
-            QNetworkProxyFactory::setUseSystemConfiguration(true);
-        } else {
-            QNetworkProxy::ProxyType networkProxyType = QNetworkProxy::HttpProxy;
-
-            if (proxyType == "socks5") {
-                networkProxyType = QNetworkProxy::Socks5Proxy;
-            }
-
-            if(!m_config.proxyAuthUser().isEmpty() && !m_config.proxyAuthPass().isEmpty()) {
-                QNetworkProxy proxy(networkProxyType, m_config.proxyHost(), m_config.proxyPort(), m_config.proxyAuthUser(), m_config.proxyAuthPass());
-                QNetworkProxy::setApplicationProxy(proxy);
-            } else {
-                QNetworkProxy proxy(networkProxyType, m_config.proxyHost(), m_config.proxyPort());
-                QNetworkProxy::setApplicationProxy(proxy);
-            }
-        }
+        setProxy(m_config.proxyHost(), m_config.proxyPort(), proxyType, m_config.proxyAuthUser(), m_config.proxyAuthPass());
     }
 
     // Set output encoding
@@ -412,8 +397,7 @@ void Phantom::setProxy(const QString &ip, const qint64 &port, const QString &pro
     qDebug() << "Set " << proxyType << " proxy to: " << ip << ":" << port;
     if (ip.isEmpty()) {
         QNetworkProxyFactory::setUseSystemConfiguration(true);
-    }
-    else {
+    } else {
         QNetworkProxy::ProxyType networkProxyType = QNetworkProxy::HttpProxy;
 
         if (proxyType == "socks5") {


### PR DESCRIPTION
Since we have setProxy() method, we can replace the existing code
block in Phantom::init() with simple method call getting rid of
duplicated code.
