### PR TITLE
Cast maxDiskCacheSize to qint64 to allow disk cache be more than 2Gb.

### DIFF
--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -124,7 +124,7 @@ NetworkAccessManager::NetworkAccessManager(QObject *parent, const Config *config
         m_networkDiskCache = new QNetworkDiskCache(this);
         m_networkDiskCache->setCacheDirectory(QDesktopServices::storageLocation(QDesktopServices::CacheLocation));
         if (config->maxDiskCacheSize() >= 0)
-            m_networkDiskCache->setMaximumCacheSize(config->maxDiskCacheSize() * 1024);
+            m_networkDiskCache->setMaximumCacheSize(qint64(config->maxDiskCacheSize()) * 1024);
         setCache(m_networkDiskCache);
     }
 


### PR DESCRIPTION
https://github.com/ariya/phantomjs/issues/12303
