### PR TITLE
Use Array.prototype.slice in window.callPhantom

### DIFF
--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -76,7 +76,7 @@
 #define BLANK_HTML                      "<html><head></head><body></body></html>"
 #define CALLBACKS_OBJECT_NAME           "_phantom"
 #define INPAGE_CALL_NAME                "window.callPhantom"
-#define CALLBACKS_OBJECT_INJECTION      INPAGE_CALL_NAME" = function() { return window."CALLBACKS_OBJECT_NAME".call.call(_phantom, Array.prototype.splice.call(arguments, 0)); };"
+#define CALLBACKS_OBJECT_INJECTION      INPAGE_CALL_NAME" = function() { return window."CALLBACKS_OBJECT_NAME".call.call(_phantom, Array.prototype.slice.call(arguments, 0)); };"
 #define CALLBACKS_OBJECT_PRESENT        "typeof(window."CALLBACKS_OBJECT_NAME") !== \"undefined\";"
 
 #define STDOUT_FILENAME "/dev/stdout"


### PR DESCRIPTION
Fixes #12306.

`window.callPhantom` formerly used `Array.prototype.splice` for cloning its arguments to the internal `_phantom.call`. This relied on non-standard behaviour of the `splice` method when only a single argument was passed to it (it requires 2 arguments, as per the [spec](http://es5.github.io/#x15.4.4.12)).

The correct method for cloning the arguments array is to use `Array.prototype.slice`, which accepts a single argument (index) and returns a new array from the specified index.
