### PR TITLE
Also send WebPage::customHeaders within our request

### DIFF
--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -557,6 +557,13 @@ void WebPage::openUrl(const QString &address, const QVariant &op, const QVariant
         }
     }
 
+	//Also send the custom headers within our request
+	QMapIterator<QString, QVariant> i(customHeaders());
+    while (i.hasNext()) {
+        i.next();
+        request.setRawHeader(i.key().toUtf8(), i.value().toString().toUtf8());
+    }
+
     if (operation.isEmpty())
         operation = "get";
 


### PR DESCRIPTION
Setting Custom Headers
It works great to the extent that it creates and sends the http request with your custom headers. It fails however to set the document.referrer (as an example) value as accessible by Javascript on the website.
