### PR TITLE
Add example code to injectJs docs

### DIFF
--- a/_posts/api/webpage/method/2000-01-01-inject-js.md
+++ b/_posts/api/webpage/method/2000-01-01-inject-js.md
@@ -15,16 +15,42 @@ This function returns `true` if injection is successful, otherwise it returns `f
 
 ## Examples
 
+### Inject do.js file into phantomjs.org page
+
 ```javascript
 var webPage = require('webpage');
 var page = webPage.create();
-// @TODO: Finish page.injectJs example.
+
+page.open('http://www.phantomjs.org', function(status) {
+  if (status === 200) {
+    page.includeJs('http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js', function() {
+      if page.injectJs('do.js') {
+        var title = page.evaluate(function() {
+          // returnTitle is a function loaded from our do.js file - see below
+          return returnTitle();
+        });
+        console.log(title);
+        phantom.exit();
+      }
+    });
+  }
+});
+```
+
+Where do.js is simply:
+```javascript
+window.returnTitle = function() {
+  return document.title;
+};
+```
+
+The console log will be:
+```javascript
+"PhantomJS | PhantomJS"
 ```
 
 
+**Note:** The arguments and the return value to the `evaluate` function must be a simple primitive object. The rule of thumb: if it can be serialized via JSON, then it is fine.
 
-
-
-
-
+**Closures, functions, DOM nodes, etc. will _not_ work!**
 


### PR DESCRIPTION
I have added a code example to the docs for injectJs, where previously there was a "// @TODO: Finish page.injectJs example."

I have seen confusion online on how to use injectJs and the differences between injectJs and includeJs. Hopefully adding this example to the docs page will help clear the confusion.
