### PR TITLE
Prevent to break cookie domain

### DIFF
--- a/src/cookiejar.cpp
+++ b/src/cookiejar.cpp
@@ -488,7 +488,7 @@ bool CookieJar::contains(const QNetworkCookie &cookie) const
     for (int i = cookiesList.length() -1; i >= 0; --i) {
         if (cookie.name() == cookiesList.at(i).name() &&
             cookie.value() == cookiesList.at(i).value() &&
-            (cookie.domain().isEmpty() || cookiesList.at(i).domain().prepend('.').endsWith(cookie.domain())) &&
+            (cookie.domain().isEmpty() || ('.' + cookiesList.at(i).domain()).endsWith(cookie.domain())) &&
             (cookie.path().isEmpty() || cookiesList.at(i).path() == cookie.path()) &&
             cookie.isSecure() == cookiesList.at(i).isSecure() &&
             cookie.isHttpOnly() == cookiesList.at(i).isHttpOnly() &&


### PR DESCRIPTION
CookieJar breaks the domain of a cookie when the cookie is added.
It inserts `.` at the beginning of it by calling `domain().prepend('.')` in `CookieJar::contains()`.

`CookieJar::contains()` shouldn't break any object states, so this pull-request fixes this problem by using `'.' + domain()` instead of `QString::prepend()`.
