### PR TITLE
preconfig.sh: don't require ICU on OSX

### DIFF
--- a/src/qt/preconfig.sh
+++ b/src/qt/preconfig.sh
@@ -12,6 +12,7 @@ QT_CFG+=' -qpa phantom'         # Default to our custom QPA platform
 
 if [[ $OSTYPE != darwin* ]]; then
     QT_CFG+=' -fontconfig'      # Fontconfig for better font matching
+    QT_CFG+=' -icu'             # ICU for QtWebKit (which provides the OSX headers) but not QtBase
 fi
 
 QT_CFG+=' -release'             # Build only for release (no debugging support)
@@ -39,7 +40,6 @@ QT_CFG+=' -no-sm'
 QT_CFG+=' -no-xinerama'
 QT_CFG+=' -no-xkb'
 QT_CFG+=' -no-xcb'
-QT_CFG+=' -icu'
 QT_CFG+=' -no-pkg-config'
 QT_CFG+=' -no-kms'
 QT_CFG+=' -no-linuxfb'


### PR DESCRIPTION
This isn't needed for the full build, only QtWebKit which has it's own ways of finding the system ICU.
