### PR TITLE
Fix documentation for POST method for webpage open() method

### DIFF
--- a/_posts/api/webpage/method/2000-01-01-open.md
+++ b/_posts/api/webpage/method/2000-01-01-open.md
@@ -32,10 +32,7 @@ As of PhantomJS 1.2, the open function can be used to request a URL with methods
 ```javascript
 var webPage = require('webpage');
 var page = webPage.create();
-var postBody = {
-  user: 'username',
-  password: 'password'
-};
+var postBody = 'user=username&password=password';
 
 page.open('http://www.google.com/', 'POST', postBody, function(status) {
   console.log('Status: ' + status);


### PR DESCRIPTION
Change the example for POST data to use directly POST request body instead of javascript object.
