### PR TITLE
Stop processing of JavaScript after phantom.exit().

### DIFF
--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -501,8 +501,12 @@ void Phantom::doExit(int code)
     emit aboutToExit(code);
     m_terminated = true;
     m_returnValue = code;
-    foreach (QPointer<WebPage> page, m_pages)
-      page->deleteLater();
+    foreach (QPointer<WebPage> page, m_pages) {
+        // stop processing of JavaScript code by loading a blank page
+        page->mainFrame()->setUrl(QUrl(QStringLiteral("about://blank")));
+        // delay deletion into the event loop, direct deletion can trigger crashes
+        page->deleteLater();
+    }
     m_pages.clear();
     m_page = 0;
     QApplication::instance()->exit(code);


### PR DESCRIPTION
This code:

```
console.log("Hello World!");
phantom.exit();
console.log("Meh, noone should see me!");
```

currently produces this unexpected output:

```
Hello World!
Meh, noone should see me!
```

This patch fixes it to only output the first line, by loading a blank
page on phantom.exit(). Direct deletion of the web page can trigger
crashes, so this is a safe workaround.

https://github.com/ariya/phantomjs/issues/12431
