### PR TITLE
Correction to fontconfig usage on Unix-not-OSX.

### DIFF
--- a/src/qt/preconfig.sh
+++ b/src/qt/preconfig.sh
@@ -99,7 +99,8 @@ else
     QT_CFG+=' -system-sqlite -sql-sqlite'
     QT_CFG+=' -system-zlib'
 
-    # Fontconfig is reported to not work correctly on Darwin.
+    # Fontconfig is not required on Darwin (we use Core Text for
+    # font enumeration) and is reported to not work correctly.
     if [[ $OSTYPE != darwin* ]]; then
         QT_CFG+=' -fontconfig'
     fi

--- a/src/qt/qtbase/src/plugins/platforms/phantom/phantomintegration.cpp
+++ b/src/qt/qtbase/src/plugins/platforms/phantom/phantomintegration.cpp
@@ -49,7 +49,7 @@
 #elif defined(Q_OS_WIN)
 # include "qwindowsfontdatabase.h"
 #else
-# include <private/qfontconfigdatabase_p.h>
+# include <QtPlatformSupport/private/qgenericunixfontdatabase_p.h>
 #endif
 
 #if !defined(Q_OS_WIN)
@@ -106,7 +106,7 @@ QPlatformFontDatabase *PhantomIntegration::fontDatabase() const
 #elif defined(Q_OS_WIN)
         db = new QWindowsFontDatabase();
 #else
-        db = new QFontconfigDatabase();
+        db = new QGenericUnixFontDatabase();
 #endif
     }
     return db;


### PR DESCRIPTION
I unfortunately have an emergency followup for the patches you merged this morning.

The PhantomJS QPA hardcoded usage of QFontconfigDatabase on
Unix-not-OSX, causing build failures in "bundle all the libraries" mode.
Use QGenericUnixFontDatabase instead, which is QFontconfigDatabase if
fontconfig is enabled, and QBasicFontDatabase if it isn't.  This means
that the bundled-qtdeps build will use only the fonts bundled with Qt,
and won't be able to find them on a machine that doesn't have the source
tree, which is suboptimal, but at least this makes the bundled-qtdeps
build complete successfully again.

Part of issue #12467.
