### PR TITLE
Fix crash on exit if pages have been closed (#12482)

### DIFF
--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -493,8 +493,7 @@ void Phantom::clearCookies()
 // private:
 void Phantom::doExit(int code)
 {
-    if (m_config.debug())
-    {
+    if (m_config.debug()) {
         Utils::cleanupFromDebug();
     }
 
@@ -502,6 +501,9 @@ void Phantom::doExit(int code)
     m_terminated = true;
     m_returnValue = code;
     foreach (QPointer<WebPage> page, m_pages) {
+        if (!page)
+            continue;
+
         // stop processing of JavaScript code by loading a blank page
         page->mainFrame()->setUrl(QUrl(QStringLiteral("about:blank")));
         // delay deletion into the event loop, direct deletion can trigger crashes

--- a/test/regression/issue12482.js
+++ b/test/regression/issue12482.js
@@ -1,0 +1,30 @@
+// https://github.com/ariya/phantomjs/issues/12482
+// regression caused by fix for
+// https://github.com/ariya/phantomjs/issues/12431
+
+var webpage = require('webpage');
+var pages = [
+    webpage.create(),
+    webpage.create(),
+    webpage.create()
+];
+
+var yet_to_load = pages.length;
+function loadHook (status) {
+    if (status !== "success")
+        console.log("FAIL: status = " + status);
+    if (--yet_to_load == 0) {
+        pages[1].close();
+        setTimeout(function(){
+            phantom.exit(0);
+            console.log("FAIL: should not get here");
+        }, 50);
+    }
+}
+
+for (var i = 0; i < pages.length; i++) {
+    pages[i].onConsoleMessage = function(msg) { console.log(msg); };
+    pages[i].open(
+        "data:text/html,<script>setTimeout(function(){console.log("+
+        "'FAIL: page "+i+" survived');},100)</script>", loadHook);
+}


### PR DESCRIPTION
Regression from #12431: the loop to clear all surviving pages
neglects to check for entries in `m_pages` which have already
been closed, fully destructed, and therefore replaced by NULL
pointers.
