### PR TITLE
Disable colorized output in tests on Windows.

### DIFF
--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -106,8 +106,8 @@ jasmineEnv.addReporter(new jasmine.ConsoleReporter(
     function (reporter) {
         phantom.exit(reporter.results().failedCount > 0 ? 1 : 0);
     },
-    // Colorized
-    true,
+    // Colorized (but disable colorized output on Windows by default)
+    sys.os.name == 'windows' ? false : true,
     // Verbosity
     verbose
 ));


### PR DESCRIPTION
This fixes #12484.

I don't want to merge this by myself. I want to be sure that everyone's seen this.
Thanks!
