### PR TITLE
Ensure run-jasmine example script always return exit code

### DIFF
--- a/examples/run-jasmine.js
+++ b/examples/run-jasmine.js
@@ -50,8 +50,8 @@ page.onConsoleMessage = function(msg) {
 
 page.open(system.args[1], function(status){
     if (status !== "success") {
-        console.log("Unable to access network");
-        phantom.exit();
+        console.log("Unable to open " + system.args[1]);
+        phantom.exit(1);
     } else {
         waitFor(function(){
             return page.evaluate(function(){
@@ -59,25 +59,30 @@ page.open(system.args[1], function(status){
             });
         }, function(){
             var exitCode = page.evaluate(function(){
-                console.log('');
-                console.log(document.body.querySelector('.description').innerText);
-                var list = document.body.querySelectorAll('.results > #details > .specDetail.failed');
-                if (list && list.length > 0) {
-                  console.log('');
-                  console.log(list.length + ' test(s) FAILED:');
-                  for (i = 0; i < list.length; ++i) {
-                      var el = list[i],
-                          desc = el.querySelector('.description'),
-                          msg = el.querySelector('.resultMessage.fail');
+                try {
+                    console.log('');
+                    console.log(document.body.querySelector('.description').innerText);
+                    var list = document.body.querySelectorAll('.results > #details > .specDetail.failed');
+                    if (list && list.length > 0) {
                       console.log('');
-                      console.log(desc.innerText);
-                      console.log(msg.innerText);
-                      console.log('');
-                  }
-                  return 1;
-                } else {
-                  console.log(document.body.querySelector('.alert > .passingAlert.bar').innerText);
-                  return 0;
+                      console.log(list.length + ' test(s) FAILED:');
+                      for (i = 0; i < list.length; ++i) {
+                          var el = list[i],
+                              desc = el.querySelector('.description'),
+                              msg = el.querySelector('.resultMessage.fail');
+                          console.log('');
+                          console.log(desc.innerText);
+                          console.log(msg.innerText);
+                          console.log('');
+                      }
+                      return 1;
+                    } else {
+                      console.log(document.body.querySelector('.alert > .passingAlert.bar').innerText);
+                      return 0;
+                    }
+                } catch (ex) {
+                    console.log(ex);
+                    return 1;
                 }
             });
             phantom.exit(exitCode);


### PR DESCRIPTION
`run-jasmine.js` wasn't return an exit code when jasmine runner is not properly loaded or when page can't be opened, therefore exit code was 0, signaling to travis-ci all tests passed.
This PR ensures an exit code is always returned.

Thanks,
