### PR TITLE
Disable the phantom QPA on Windows.

### DIFF
--- a/src/phantomjs.pro
+++ b/src/phantomjs.pro
@@ -13,7 +13,9 @@ DESTDIR = ../bin
 RESOURCES = phantomjs.qrc \
     ghostdriver/ghostdriver.qrc
 
-QTPLUGIN += qphantom
+!winrt:!win32: {
+    QTPLUGIN += qphantom
+}
 
 HEADERS += \
     phantom.h \

--- a/src/qt/qtbase/src/plugins/platforms/phantom/phantom.pro
+++ b/src/qt/qtbase/src/plugins/platforms/phantom/phantom.pro
@@ -8,8 +8,6 @@ load(qt_plugin)
 
 QT += core-private gui-private platformsupport-private
 
-win32: include(../windows/windows.pri)
-
 SOURCES =   main.cpp \
             phantomintegration.cpp \
             phantombackingstore.cpp

--- a/src/qt/qtbase/src/plugins/platforms/phantom/phantomintegration.cpp
+++ b/src/qt/qtbase/src/plugins/platforms/phantom/phantomintegration.cpp
@@ -46,19 +46,11 @@
 
 #if defined(Q_OS_MAC)
 # include <QtPlatformSupport/private/qcoretextfontdatabase_p.h>
-#elif defined(Q_OS_WIN)
-# include "qwindowsfontdatabase.h"
 #else
 # include <QtPlatformSupport/private/qgenericunixfontdatabase_p.h>
 #endif
 
-#if !defined(Q_OS_WIN)
 #include <QtPlatformSupport/private/qgenericunixeventdispatcher_p.h>
-#elif defined(Q_OS_WINRT)
-#include <QtCore/private/qeventdispatcher_winrt_p.h>
-#else
-#include <QtCore/private/qeventdispatcher_win_p.h>
-#endif
 
 PhantomIntegration::PhantomIntegration()
 {
@@ -103,8 +95,6 @@ QPlatformFontDatabase *PhantomIntegration::fontDatabase() const
     if (!db) {
 #if defined(Q_OS_MAC)
         db = new QCoreTextFontDatabase();
-#elif defined(Q_OS_WIN)
-        db = new QWindowsFontDatabase();
 #else
         db = new QGenericUnixFontDatabase();
 #endif
@@ -114,13 +104,5 @@ QPlatformFontDatabase *PhantomIntegration::fontDatabase() const
 
 QAbstractEventDispatcher *PhantomIntegration::createEventDispatcher() const
 {
-#ifdef Q_OS_WIN
-#ifndef Q_OS_WINRT
-    return new QEventDispatcherWin32;
-#else // !Q_OS_WINRT
-    return new QEventDispatcherWinRT;
-#endif // Q_OS_WINRT
-#else
     return createUnixEventDispatcher();
-#endif
 }

--- a/src/qt/qtbase/src/plugins/platforms/platforms.pro
+++ b/src/qt/qtbase/src/plugins/platforms/platforms.pro
@@ -2,7 +2,9 @@ TEMPLATE = subdirs
 
 android:!android-no-sdk: SUBDIRS += android
 
-SUBDIRS += minimal phantom
+SUBDIRS += minimal
+
+!win32:!winrt: SUBDIRS += phantom
 
 !win32|contains(QT_CONFIG, freetype):SUBDIRS += offscreen
 


### PR DESCRIPTION
It cannot, nor should it, be selected on windows machines. There, we
stick to the Windows QPA which is required to get a lot of things up
and running, like an eventloop, socket integration etc. pp.

There was code in the phantom QPA to make it compile, but it never
actually worked since a lot of things where missing (such as
instantiating QWindowsContext among others).

https://github.com/ariya/phantomjs/issues/12494
