### PR TITLE
Add doc for additional apt based dependencies

### DIFF
--- a/_posts/documentation/get-started/2000-01-02-build.md
+++ b/_posts/documentation/get-started/2000-01-02-build.md
@@ -26,14 +26,14 @@ This produces a static build `bin/phantomjs`. This is a self-contained executabl
 
 ```bash
 sudo apt-get update
-sudo apt-get install build-essential chrpath git-core libssl-dev libfontconfig1-dev libxft-dev
+sudo apt-get install build-essential chrpath git-core libssl-dev libfontconfig1-dev libxft-dev libicu-dev gperf
 git clone git://github.com/ariya/phantomjs.git
 cd phantomjs
 git checkout 1.9
 ./build.sh
 ```
 ####Tested on:
-+ Ubuntu (10.04, 11.04, 12.04)
++ Ubuntu (10.04, 11.04, 12.04, 13.10)
 + Debian (7.6)
 
 ### yum-based systems


### PR DESCRIPTION
Add additional dependencies on gperf and libicu-dev (for missing unicode/utypes.h during QT build)
