### PR TITLE
Config tweaks round 2 (#12518)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -173,8 +173,22 @@ if [[ "$QTWEBKIT" == "bundled" ]]; then
     if grep -qEe '-qt-sql-sqlite\>' src/qt/qtbase/config.status; then
         export SQLITE3SRCDIR=$PWD/src/qt/qtbase/src/3rdparty/sqlite/
     fi
+
+    # By default, suppress video and audio-related features.
+    # They can be reactivated with e.g.
+    # --qmake-args WEBKIT_CONFIG+='use_gstreamer video'
+    WEBKIT_DISABLE=
+    WEBKIT_DISABLE+=' use_glib'
+    WEBKIT_DISABLE+=' use_gstreamer'
+    WEBKIT_DISABLE+=' use_gstreamer010'
+    WEBKIT_DISABLE+=' use_native_fullscreen_video'
+    WEBKIT_DISABLE+=' legacy_web_audio'
+    WEBKIT_DISABLE+=' web_audio'
+    WEBKIT_DISABLE+=' video'
+    WEBKIT_DISABLE+=' gamepad'
+
     ( cd src/qt/qtwebkit &&
-        $QMAKE $QMAKE_ARGS &&
+        $QMAKE "WEBKIT_CONFIG -= $WEBKIT_DISABLE" $QMAKE_ARGS &&
         make -j$COMPILE_JOBS $MAKE_S )
 fi
 

--- a/src/qt/qtbase/configure
+++ b/src/qt/qtbase/configure
@@ -1803,6 +1803,20 @@ while [ "$#" -gt 0 ]; do
             UNKNOWN_OPT=yes
         fi
         ;;
+    pulseaudio)
+        if [ "$VAL" = "yes" ] || [ "$VAL" = "no" ]; then
+            CFG_PULSEAUDIO="$VAL"
+        else
+            UNKNOWN_OPT=yes
+        fi
+        ;;
+    alsa)
+        if [ "$VAL" = "yes" ] || [ "$VAL" = "no" ]; then
+            CFG_ALSA="$VAL"
+        else
+            UNKNOWN_OPT=yes
+        fi
+        ;;
     gtkstyle)
         if [ "$VAL" = "yes" ] || [ "$VAL" = "no" ]; then
             CFG_QGTKSTYLE="$VAL"
@@ -2366,6 +2380,15 @@ Third Party Libraries:
 
     -no-glib ........... Do not compile Glib support.
  +  -glib .............. Compile Glib support.
+
+    -no-pulseaudio ..... Do not compile PulseAudio support.
+ +  -pulseaudio ........ Compile PulseAudio support.
+
+    -no-alsa ........... Do not compile ALSA support.
+ +  -alsa .............. Compile ALSA support.
+
+    -no-gtkstyle ....... Do not compile GTK theme support.
+ +  -gtkstyle .......... Compile GTK theme support.
 
 Additional options:
 


### PR DESCRIPTION
Here's the new dependency graph in `--qtdeps=system` mode. (Gray edges go to parts of the C/C++ runtime; blue edges come directly from the phantomjs binary. libc6 has been suppressed entirely, as literally everything else depends on it, so it doubles the visual clutter.)  No more GStreamer.

![pjs-deps](https://cloud.githubusercontent.com/assets/325899/4083255/7682213c-2ef9-11e4-8e2f-295a4fe79f0d.png)
