### PR TITLE
Set the terminate handler to std::abort.

### DIFF
--- a/src/crashdump.h
+++ b/src/crashdump.h
@@ -42,6 +42,7 @@ public:
     ~CrashHandler();
 
 private:
+    void (*old_terminate_handler)();
     google_breakpad::ExceptionHandler *eh;
 };
 


### PR DESCRIPTION
Per issue #12541.
