### PR TITLE
structure of cookie objects

### DIFF
--- a/_posts/api/webpage/property/2000-01-01-cookies.md
+++ b/_posts/api/webpage/property/2000-01-01-cookies.md
@@ -7,6 +7,20 @@ permalink: api/webpage/property/cookies.html
 
 Get or set Cookies visible to the current URL (though, for setting, use of `page.addCookie` is preferred). This array will be pre-populated by any existing Cookie data visible to this URL that is stored in the CookieJar, if any.
 
+Cookies is an array of objects: 
+```javascript
+{ 
+  domain: 'example.com',
+  expires: 'Sat Oct 11 2014 21:44:33 GMT+0200 (CEST)',
+  expiry: 1476128618,
+  httponly: false,
+  name: 'cookieName',
+  path: '/',
+  secure: false,
+  value: cookieValue
+}
+```
+
 ## Examples
 
 ```javascript


### PR DESCRIPTION
so devs don't have to run `console.log Object.keys(page.cookies[0])` to investigate how this object looks like
