### PR TITLE
Backport crash fixes to Phantom::doExit from master

### DIFF
--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -468,7 +468,15 @@ void Phantom::doExit(int code)
     emit aboutToExit(code);
     m_terminated = true;
     m_returnValue = code;
-    qDeleteAll(m_pages);
+    foreach (QPointer<WebPage> page, m_pages) {
+        if (!page)
+            continue;
+
+        // stop processing of JavaScript code by loading a blank page
+        page->mainFrame()->setUrl(QUrl(QString("about:blank")));
+        // delay deletion into the event loop, direct deletion can trigger crashes
+        page->deleteLater();
+    }
     m_pages.clear();
     m_page = 0;
     QApplication::instance()->exit(code);


### PR DESCRIPTION
The relevant bits from these commits were applied:
cf12fc4a236e071382e9e6b9c391b606eac17ea1
a9809996b168a5696b917702ccc3696c70e71233
1e7829db97d5134336d6f9e4961c1cfd1d1bf9d5

https://github.com/ariya/phantomjs/issues/11642
