### PR TITLE
remove hardcoded "PhantomJS is launching GhostDriver..." message

### DIFF
--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -196,7 +196,6 @@ bool Phantom::execute()
     if (m_config.isWebdriverMode()) {                                   // Remote WebDriver mode requested
         qDebug() << "Phantom - execute: Starting Remote WebDriver mode";
 
-        Terminal::instance()->cout("PhantomJS is launching GhostDriver...");
         if (!Utils::injectJsInFrame(":/ghostdriver/main.js", QString(), m_scriptFileEnc, QDir::currentPath(), m_page->mainFrame(), true)) {
             m_returnValue = -1;
             return false;


### PR DESCRIPTION
Apart from being undesirable that debugging messages are always
written to stdout, the information is redundant as a similar message
is logged at debug level.
