### PR TITLE
implement "page-break-inside: avoid" for non-floating block elements

### DIFF
--- a/src/qt/src/3rdparty/webkit/Source/WebCore/rendering/RenderBlock.cpp
+++ b/src/qt/src/3rdparty/webkit/Source/WebCore/rendering/RenderBlock.cpp
@@ -6054,7 +6054,9 @@ int RenderBlock::applyAfterBreak(RenderBox* child, int logicalOffset, MarginInfo
 
 int RenderBlock::adjustForUnsplittableChild(RenderBox* child, int logicalOffset, bool includeMargins)
 {
-    bool isUnsplittable = child->isReplaced() || child->scrollsOverflow();
+    bool isUnsplittable = child->isReplaced() || child->scrollsOverflow()||
+        child->style()->pageBreakInside() == PBAVOID;
+
     if (!isUnsplittable)
         return logicalOffset;
     int childLogicalHeight = logicalHeightForChild(child) + (includeMargins ? marginBeforeForChild(child) + marginAfterForChild(child) : 0);


### PR DESCRIPTION
This patch is taken from https://bugs.webkit.org/show_bug.cgi?id=5097#c17
The following test page will have green block starting at new page after fix.
 index.Html:
      <pre>
         &lt;html&gt;
           &lt;head&gt;
             &lt;link rel="stylesheet" type="text/css" href="multi.css"&gt;
           &lt;/head&gt;
           &lt;body&gt;
             &lt;div&gt;
               &lt;div id='div1' class='div1'&gt; This is first&lt;/div&gt;
               &lt;div id='div2' class = 'div2'&gt; this is second&lt;/div&gt;
               &lt;div id='div3' class = 'div3'&gt; third&lt;/div&gt;
             &lt;/div&gt;
           &lt;/body&gt;
         &lt;/html&gt;
       </pre>

multi.css:

```
      #div1 {
         width:900px;
         height:600px;
         background-color:red;
         -webkit-print-color-adjust: exact;
        }
      #div2 {
         width:800px;
         height:900px;
         background-color:green;
         page-break-inside: avoid;
         -webkit-print-color-adjust:exact;
       }
       #div3 {
         width:700px;
         height:800px;
         background-color:yellow;
         -webkit-print-color-adjust: exact;
       }
```
