### PR TITLE
Don't change the URL of the main execution context on `phantom::exit`

### DIFF
--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -100,7 +100,6 @@ void Phantom::init()
     CookieJar::instance(m_config.cookiesFile());
 
     m_page = new WebPage(this, QUrl::fromLocalFile(m_config.scriptFile()));
-    m_pages.append(m_page);
 
     QString proxyType = m_config.proxyType();
     if (proxyType != "none") {
@@ -478,6 +477,7 @@ void Phantom::doExit(int code)
         page->deleteLater();
     }
     m_pages.clear();
+    delete m_page;
     m_page = 0;
     QApplication::instance()->exit(code);
 }


### PR DESCRIPTION
We shouldn't change the URL of the main execution context. Because this will change security policy of our main frame which leads to the following message: `Unsafe JavaScript attempt to access frame with URL about:blank from frame with URL file://bla.js. Domains, protocols and ports must match.`

We can fix it by isolating main frame of PhantomJS execution context. We can destroy it separately.

This fixes: #12697 #12660
