### PR TITLE
Add a command-line option --local-urls={true,false}

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -56,6 +56,7 @@ static const struct QCommandLineConfigEntry flags[] =
     { QCommandLine::Option, '\0', "load-images", "Loads all inlined images: 'true' (default) or 'false'", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "local-storage-path", "Specifies the location for offline local storage", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "local-storage-quota", "Sets the maximum size of the offline local storage (in KB)", QCommandLine::Optional },
+    { QCommandLine::Option, '\0', "local-url-access", "Allows use of 'file:///' URLs: 'true' (default) or 'false'", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "local-to-remote-url-access", "Allows local content to access remote URL: 'true' or 'false' (default)", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "max-disk-cache-size", "Limits the size of the disk cache (in KB)", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "output-encoding", "Sets the encoding for the terminal output, default is 'utf8'", QCommandLine::Optional },
@@ -247,6 +248,16 @@ bool Config::ignoreSslErrors() const
 void Config::setIgnoreSslErrors(const bool value)
 {
     m_ignoreSslErrors = value;
+}
+
+bool Config::localUrlAccessEnabled() const
+{
+    return m_localUrlAccessEnabled;
+}
+
+void Config::setLocalUrlAccessEnabled(const bool value)
+{
+    m_localUrlAccessEnabled = value;
 }
 
 bool Config::localToRemoteUrlAccessEnabled() const
@@ -535,6 +546,7 @@ void Config::resetToDefaults()
     m_diskCacheEnabled = false;
     m_maxDiskCacheSize = -1;
     m_ignoreSslErrors = false;
+    m_localUrlAccessEnabled = true;
     m_localToRemoteUrlAccessEnabled = false;
     m_outputEncoding = "UTF-8";
     m_proxyType = "http";
@@ -643,6 +655,7 @@ void Config::handleOption(const QString &option, const QVariant &value)
     booleanFlags << "disk-cache";
     booleanFlags << "ignore-ssl-errors";
     booleanFlags << "load-images";
+    booleanFlags << "local-url-access";
     booleanFlags << "local-to-remote-url-access";
     booleanFlags << "remote-debugger-autorun";
     booleanFlags << "web-security";
@@ -684,6 +697,10 @@ void Config::handleOption(const QString &option, const QVariant &value)
 
     if (option == "local-storage-quota") {
         setOfflineStorageDefaultQuota(value.toInt());
+    }
+
+    if (option == "local-url-access") {
+        setLocalUrlAccessEnabled(boolValue);
     }
 
     if (option == "local-to-remote-url-access") {

--- a/src/config.h
+++ b/src/config.h
@@ -45,6 +45,7 @@ class Config: public QObject
     Q_PROPERTY(bool diskCacheEnabled READ diskCacheEnabled WRITE setDiskCacheEnabled)
     Q_PROPERTY(int maxDiskCacheSize READ maxDiskCacheSize WRITE setMaxDiskCacheSize)
     Q_PROPERTY(bool ignoreSslErrors READ ignoreSslErrors WRITE setIgnoreSslErrors)
+    Q_PROPERTY(bool localUrlAccessEnabled READ localUrlAccessEnabled WRITE setLocalUrlAccessEnabled)
     Q_PROPERTY(bool localToRemoteUrlAccessEnabled READ localToRemoteUrlAccessEnabled WRITE setLocalToRemoteUrlAccessEnabled)
     Q_PROPERTY(QString outputEncoding READ outputEncoding WRITE setOutputEncoding)
     Q_PROPERTY(QString proxyType READ proxyType WRITE setProxyType)
@@ -94,6 +95,9 @@ public:
 
     bool ignoreSslErrors() const;
     void setIgnoreSslErrors(const bool value);
+
+    bool localUrlAccessEnabled() const;
+    void setLocalUrlAccessEnabled(const bool value);
 
     bool localToRemoteUrlAccessEnabled() const;
     void setLocalToRemoteUrlAccessEnabled(const bool value);
@@ -201,6 +205,7 @@ private:
     bool m_diskCacheEnabled;
     int m_maxDiskCacheSize;
     bool m_ignoreSslErrors;
+    bool m_localUrlAccessEnabled;
     bool m_localToRemoteUrlAccessEnabled;
     QString m_outputEncoding;
     QString m_proxyType;

--- a/src/networkaccessmanager.h
+++ b/src/networkaccessmanager.h
@@ -67,6 +67,18 @@ private:
     QNetworkRequest* m_networkRequest;
 };
 
+class NoFileAccessReply : public QNetworkReply
+{
+    Q_OBJECT
+
+public:
+    NoFileAccessReply(QObject *parent, const QNetworkRequest &req, const QNetworkAccessManager::Operation op);
+    ~NoFileAccessReply();
+    void abort() {}
+protected:
+    qint64 readData(char *, qint64) { return -1; }
+};
+
 class NetworkAccessManager : public QNetworkAccessManager
 {
     Q_OBJECT
@@ -83,6 +95,7 @@ public:
 
 protected:
     bool m_ignoreSslErrors;
+    bool m_localUrlAccessEnabled;
     int m_authAttempts;
     int m_maxAuthAttempts;
     int m_resourceTimeout;

--- a/test/module/webpage/local-urls-disabled.js
+++ b/test/module/webpage/local-urls-disabled.js
@@ -1,0 +1,18 @@
+// phantomjs: --local-url-access=no
+
+var assert = require("../../assert");
+var p = require("webpage").create();
+
+var url = "file:///nonexistent";
+
+var rsErrorCalled = false;
+p.onResourceError = function (error) {
+    rsErrorCalled = true;
+    assert.strictEqual(error.url, url);
+    assert.strictEqual(error.errorCode, 301);
+    assert.strictEqual(error.errorString, 'Protocol "file" is unknown');
+};
+
+p.open(url, function () {
+    assert(rsErrorCalled);
+});

--- a/test/module/webpage/local-urls-enabled.js
+++ b/test/module/webpage/local-urls-enabled.js
@@ -1,0 +1,19 @@
+// phantomjs: --local-url-access=yes
+
+var assert = require("../../assert");
+var p = require("webpage").create();
+
+var url = "file:///nonexistent";
+
+var rsErrorCalled = false;
+p.onResourceError = function (error) {
+    rsErrorCalled = true;
+    assert.strictEqual(error.url, url);
+    assert.strictEqual(error.errorCode, 203);
+    assert.strictEqual(/^Error opening\b.*?\bnonexistent:/.test(error.errorString),
+                       true);
+};
+
+p.open(url, function () {
+    assert(rsErrorCalled);
+});


### PR DESCRIPTION
The default is 'true'.  When set 'false', file: and qrc: URLs are
treated as invalid (unknown scheme) rather than opening local files,
as requested in issue #12752.

In order to test this, I added a mechanism to test/run-tests.py
allowing individual tests to be annotated with command-line
options to pass to phantomjs or the script.
