### PR TITLE
Have QHttpNetworkReply try to interpret the HTTP reason phrase as UTF-8 ...

### DIFF
--- a/test/module/webpage/http-response-encoding.js
+++ b/test/module/webpage/http-response-encoding.js
@@ -1,0 +1,45 @@
+// Basic test for proper encoding of response status lines and header values.
+// See https://github.com/ariya/phantomjs/issues/12758
+
+var assert = require("../../assert");
+var p = require("webpage").create();
+
+var url = "http://localhost:9180/non-ascii-response-headers";
+var rrCalled = false;
+var reCalled = false;
+p.onResourceReceived = function (response) {
+    var i, found = false;
+    for (i = 0; i < response.headers.length; i++) {
+        if (response.headers[i].name === "Set-Cookie") {
+            found = true;
+            assert.strictEqual(response.headers[i].value,
+                               "κουλουράκι"); // Greek: "cookie, pretzel"
+            break;
+        }
+    }
+    assert.isTrue(found);
+
+    if (response.url === url) {
+        rrCalled = true;
+        assert.strictEqual(response.status, 200);
+        assert.strictEqual(response.statusText, "行"); // Chinese: "OK" (srsly)
+    } else {
+        assert.strictEqual(response.url, url + "?1");
+        assert.strictEqual(response.status, 404);
+        assert.strictEqual(response.statusText, "不存在"); // Chinese: "does not exist"
+    }
+};
+
+p.onResourceError = function (err) {
+    reCalled = true;
+    assert.strictEqual(err.url, url + "?1");
+    assert.strictEqual(err.errorCode, 203);
+    assert.strictEqual(err.status, 404);
+    assert.strictEqual(err.statusText, "不存在"); // Chinese: "does not exist"
+};
+
+p.open(url, function () {
+    assert.isTrue(rrCalled);
+    assert.isTrue(reCalled);
+});
+

--- a/test/www/non-ascii-response-headers.py
+++ b/test/www/non-ascii-response-headers.py
@@ -1,0 +1,16 @@
+# -*- encoding: utf-8 -*-
+import cStringIO as StringIO
+import urlparse
+def handle_request(req):
+    url = urlparse.urlparse(req.path)
+    if url.query:
+        req.send_response(404, u"不存在".encode("utf-8"))
+    else:
+        req.send_response(200, u"行".encode("utf-8"))
+    req.send_header("Set-Cookie", u"κουλουράκι".encode("utf-8"))
+    req.end_headers()
+
+    if url.query:
+        return StringIO.StringIO("")
+    else:
+        return StringIO.StringIO("""<!doctype html><img src="?1">""")


### PR DESCRIPTION
...first.

Nowadays, despite what the RFCs say, HTTP reason phrases that aren't ASCII
are far more likely to be UTF-8 than ISO-8859-1.  Qt blindly interprets
them as ISO-8859-1, which causes them to get double-coded in logs and such.
Unfortunately, this can only be fixed deep in the guts of Qt.

https://github.com/ariya/phantomjs/issues/12758
