### PR TITLE
Fix timing issue in WebPage test.

### DIFF
--- a/test/webpage-spec.js
+++ b/test/webpage-spec.js
@@ -464,13 +464,13 @@ describe("WebPage object", function() {
             page.openUrl(url, openOptions, {});
         });
 
-        waits(50);
+        waitsFor(function() {
+            return handled;
+        }, "can't process POST body in 1s", 1000);
 
         runs(function() {
-            expect(handled).toEqual(true);
             server.close();
         });
-
     });
 
     it("should include post data to request object", function() {


### PR DESCRIPTION
This test doesn't work reliably on my machine. Using `waitsFor` is more reliable and gives better performance than `waits`.

https://github.com/ariya/phantomjs/issues/12771
