### PR TITLE
Don't rely on JSON.parse() in page.evaluate().

### DIFF
--- a/src/modules/webpage.js
+++ b/src/modules/webpage.js
@@ -371,7 +371,7 @@ function decorateNewPage(opts, page) {
             case "object":      //< for type "object"
             case "array":       //< for type "array"
             case "date":        //< for type "date"
-                str += "JSON.parse(" + JSON.stringify(JSON.stringify(arg)) + "),"
+                str += JSON.stringify(arg) + ","
                 break;
             case "string":      //< for type "string"
                 str += quoteString(arg) + ',';

--- a/test/module/webpage/evaluate-broken-json.js
+++ b/test/module/webpage/evaluate-broken-json.js
@@ -10,5 +10,4 @@ var result = page.evaluate(function(obj) {
     return obj.value * obj.value;
 }, { value: 4 });
 
-// FAIL
-// assert.equal(result, 16);
+assert.equal(result, 16);


### PR DESCRIPTION
PhantomJS can break if there is custom implementation of JSON.parse().

However, we don't need to use it. JSON is also a valid JavaScript. Let's solve our problem by avoiding it.

https://github.com/ariya/phantomjs/issues/12615
