### PR TITLE
Disable proxies for QWebInspector instances. Allows remote debugger acce...

### DIFF
--- a/src/qt/src/3rdparty/webkit/Source/WebKit/qt/WebCoreSupport/InspectorServerQt.cpp
+++ b/src/qt/src/3rdparty/webkit/Source/WebKit/qt/WebCoreSupport/InspectorServerQt.cpp
@@ -87,6 +87,7 @@ void InspectorServerQt::listen(quint16 port)
         return;
 
     m_tcpServer = new QTcpServer();
+    m_tcpServer->setProxy(QNetworkProxy::NoProxy);
     m_tcpServer->listen(QHostAddress::Any, port);
     connect(m_tcpServer, SIGNAL(newConnection()), SLOT(newConnection()));
 }


### PR DESCRIPTION
Solves issue #10982

The issue is alleviated if the QTcpServer (which is marked private) is instructed to ignore any proxies (in Phantom's case, the Application level proxy).

This change applies to older releases as well.

Other projects handle this case by using a QNetworkProxyFactory and bypassing the proxy on local subnets.

Since that is much harder and 1.9x series is nearing EOL, this should simply "make it work" for 1.x users.

FWIW, I use PhantomJS at work and we'd like proxy support + remote debugging support if we can help it.
