### PR TITLE
fix markdown code block in _posts/api/webpage/property/2000-01-01-paper-...

### DIFF
--- a/_posts/api/webpage/property/2000-01-01-paper-size.md
+++ b/_posts/api/webpage/property/2000-01-01-paper-size.md
@@ -84,6 +84,7 @@ page.paperSize = {
 ```
 
 A repeating page `header` and `footer` can also be added via this property, as in [this example](https://github.com/ariya/phantomjs/blob/master/examples/printheaderfooter.js):
+
 ```javascript
 var webPage = require('webpage');
 var page = webPage.create();


### PR DESCRIPTION
I know it's a minor change but the web page looks deeply wrong right now. :-P

![5t i 3g6a h dlcroq cflv](https://cloud.githubusercontent.com/assets/1396390/5374068/07afdfd4-8097-11e4-90ce-193acdfc93b2.jpg)
