### PR TITLE
Added devicePixelRatio support (fixes #10964)

### DIFF
--- a/src/qt/qtwebkit/Source/WebKit/qt/WebCoreSupport/QWebPageAdapter.cpp
+++ b/src/qt/qtwebkit/Source/WebKit/qt/WebCoreSupport/QWebPageAdapter.cpp
@@ -1372,6 +1372,11 @@ void QWebPageAdapter::setDevicePixelRatio(float devicePixelRatio)
     page->setDeviceScaleFactor(devicePixelRatio);
 }
 
+float QWebPageAdapter::devicePixelRatio() const
+{
+    return page->deviceScaleFactor();
+}
+
 bool QWebPageAdapter::handleKeyEvent(QKeyEvent *ev)
 {
     Frame* frame = page->focusController()->focusedOrMainFrame();

--- a/src/qt/qtwebkit/Source/WebKit/qt/WebCoreSupport/QWebPageAdapter.h
+++ b/src/qt/qtwebkit/Source/WebKit/qt/WebCoreSupport/QWebPageAdapter.h
@@ -356,6 +356,7 @@ public:
 
     ViewportAttributes viewportAttributesForSize(const QSize& availableSize, const QSize& deviceSize) const;
     void setDevicePixelRatio(float devicePixelRatio);
+    float devicePixelRatio() const;
 
     QWebSettings *settings;
 

--- a/src/qt/qtwebkit/Source/WebKit/qt/WidgetApi/qwebpage.cpp
+++ b/src/qt/qtwebkit/Source/WebKit/qt/WidgetApi/qwebpage.cpp
@@ -1968,6 +1968,7 @@ void QWebPage::setViewportSize(const QSize &size) const
     mainFrame->setViewportSize(size);
 }
 
+
 void QWebPagePrivate::updateWindow()
 {
     QWindow* _window = 0;
@@ -1990,6 +1991,15 @@ void QWebPagePrivate::_q_updateScreen(QScreen* screen)
 {
     if (screen)
         setDevicePixelRatio(screen->devicePixelRatio());
+}
+
+void QWebPage::setDevicePixelRatio(float ratio) {
+    d->setDevicePixelRatio(ratio);
+}
+
+float QWebPage::devicePixelRatio() const
+{
+    return d->devicePixelRatio();
 }
 
 static int getintenv(const char* variable)

--- a/src/qt/qtwebkit/Source/WebKit/qt/WidgetApi/qwebpage.h
+++ b/src/qt/qtwebkit/Source/WebKit/qt/WidgetApi/qwebpage.h
@@ -305,6 +305,8 @@ public:
     virtual void triggerAction(WebAction action, bool checked = false);
 
     QSize viewportSize() const;
+    void setDevicePixelRatio(float ratio);
+    float devicePixelRatio() const;
     void setViewportSize(const QSize &size) const;
     ViewportAttributes viewportAttributesForSize(const QSize& availableSize) const;
 

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -1280,6 +1280,15 @@ void WebPage::_uploadFile(const QString &selector, const QStringList &fileNames)
     el.evaluateJavaScript(JS_ELEMENT_CLICK);
 }
 
+void WebPage::setDevicePixelRatio(float ratio) {
+    m_customWebPage->setDevicePixelRatio(ratio);
+}
+
+float WebPage::devicePixelRatio() const
+{
+    return m_customWebPage->devicePixelRatio();
+}
+
 bool WebPage::injectJs(const QString &jsFilePath) {
     return Utils::injectJsInFrame(jsFilePath, m_libraryPath, m_currentFrame);
 }

--- a/src/webpage.h
+++ b/src/webpage.h
@@ -70,6 +70,7 @@ class WebPage : public QObject, public QWebFrame::PrintCallback
     Q_PROPERTY(bool navigationLocked READ navigationLocked WRITE setNavigationLocked)
     Q_PROPERTY(QVariantMap customHeaders READ customHeaders WRITE setCustomHeaders)
     Q_PROPERTY(qreal zoomFactor READ zoomFactor WRITE setZoomFactor)
+    Q_PROPERTY(float devicePixelRatio READ devicePixelRatio WRITE setDevicePixelRatio)
     Q_PROPERTY(QVariantList cookies READ cookies WRITE setCookies)
     Q_PROPERTY(QString windowName READ windowName)
     Q_PROPERTY(QObjectList pages READ pages)
@@ -139,6 +140,9 @@ public:
 
     void setZoomFactor(qreal zoom);
     qreal zoomFactor() const;
+
+    void setDevicePixelRatio(float ratio);
+    float devicePixelRatio() const;
 
     /**
      * Value of <code>"window.name"</code> within the main page frame.


### PR DESCRIPTION
fixes #10964 

Example:-

``` js
var webPage = require('webpage');
var page = webPage.create();

// An example url that supports @2x background-image with the following css:-
/* body {
     background-image: background-image: url('http://retinajs.s3.amazonaws.com/images/backgrounds/bg.jpg');
  }
  @media all and (-webkit-min-device-pixel-ratio: 1.5) {
     body {
       background-image: background-image: url('http://retinajs.s3.amazonaws.com/images/backgrounds/bg@2x.jpg');
    }
} */
var examplePage = 'http://imulus.github.io/retinajs/';

//Pass a dpr of your choosing
page.devicePixelRatio = 1.5; // in this case, >=1.5 to get the retina-supporting bg-image

page.open(examplePage, function() {
   var backgroundImage = page.evaluate(function() {
     return window.getComputedStyle(document.body).backgroundImage;
   });
   console.log(backgroundImage); // returns http://retinajs.s3.amazonaws.com/images/backgrounds/bg@2x.jpg
   page.render('2x.png');
});
```
