### PR TITLE
Use zlib in WEBKIT_CONFIG to enable WOFF support on Unix-like systems

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -187,8 +187,12 @@ if [[ "$QTWEBKIT" == "bundled" ]]; then
     WEBKIT_DISABLE+=' video'
     WEBKIT_DISABLE+=' gamepad'
 
+    # Use zlib for WOFF support
+    WEBKIT_ENABLE=
+    WEBKIT_ENABLE+=' use_zlib'
+
     ( cd src/qt/qtwebkit &&
-        $QMAKE "WEBKIT_CONFIG -= $WEBKIT_DISABLE" $QMAKE_ARGS &&
+        $QMAKE "WEBKIT_CONFIG -= $WEBKIT_DISABLE" "WEBKIT_CONFIG += $WEBKIT_ENABLE" $QMAKE_ARGS &&
         make -j$COMPILE_JOBS $MAKE_S )
 fi
 


### PR DESCRIPTION
For some reason, the Webkit build isn't satisfied with the detected existence of zlib. It wants to be explicitly told to use it. This minor fix to the PhantomJS build system will do that and thereby enable WOFF support in master.

This has been tested to work on Debian and Ubuntu. I'm afraid I am currently unable to build on my Mac to test there. Also, someone with more knowledge of the Windows build system should check to see if an equivalent change needs to be made on that side.
