### PR TITLE
Deactivate UserGestureIndicator

### DIFF
--- a/src/qt/qtwebkit/Source/WebCore/dom/UserGestureIndicator.cpp
+++ b/src/qt/qtwebkit/Source/WebCore/dom/UserGestureIndicator.cpp
@@ -30,7 +30,7 @@ namespace WebCore {
 
 static bool isDefinite(ProcessingUserGestureState state)
 {
-    return state == DefinitelyProcessingUserGesture || state == DefinitelyNotProcessingUserGesture;
+    return true;//state == DefinitelyProcessingUserGesture || state == DefinitelyNotProcessingUserGesture;
 }
 
 ProcessingUserGestureState UserGestureIndicator::s_state = DefinitelyNotProcessingUserGesture;

--- a/src/qt/qtwebkit/Source/WebCore/dom/UserGestureIndicator.h
+++ b/src/qt/qtwebkit/Source/WebCore/dom/UserGestureIndicator.h
@@ -39,7 +39,7 @@ enum ProcessingUserGestureState {
 class UserGestureIndicator {
     WTF_MAKE_NONCOPYABLE(UserGestureIndicator);
 public:
-    static bool processingUserGesture() { return s_state == DefinitelyProcessingUserGesture; }
+    static bool processingUserGesture() { return true; } //We fake user gesture since we're running in headless mode
 
     explicit UserGestureIndicator(ProcessingUserGestureState);
     ~UserGestureIndicator();

--- a/test/webpage-spec.js
+++ b/test/webpage-spec.js
@@ -1216,7 +1216,7 @@ describe("WebPage closing notification/alerting: closing propagation control", f
 });
 
 describe("WebPage 'onFilePicker'", function() {
-    xit("should be able to set the file to upload when the File Picker is invoked (i.e. clicking on a 'input[type=file]')", function() {
+    it("should be able to set the file to upload when the File Picker is invoked (i.e. clicking on a 'input[type=file]')", function() {
         var system = require('system'),
             fileToUpload = system.os.name === "windows" ? "C:\\Windows\\System32\\drivers\\etc\\hosts" : "/etc/hosts",
             server = require("webserver").create(),


### PR DESCRIPTION
fixes issue #12506 ariya#12506

Since phantomJS is a headless browser, evaluating if the gesture comes
from a user is pointless. The UserGestureIndicator is now a dummy class
that always returns true.
