### PR TITLE
Update 2000-01-01-open.md

### DIFF
--- a/_posts/api/fs/method/2000-01-01-open.md
+++ b/_posts/api/fs/method/2000-01-01-open.md
@@ -19,10 +19,8 @@ var otherFile = fs.open('/path/to/otherFile', {
 });
 
 var yetAnotherFile = fs.open('/path/to/yetAnotherFile', {
-  opts: {
-    mode: 'w', //(see Open Mode above)
-    charset: 'US-ASCII' //An IANA, case insensitive, charset name.
-  }
+  mode: 'w', //(see Open Mode above)
+  charset: 'US-ASCII' //An IANA, case insensitive, charset name.
 });
 ```
 


### PR DESCRIPTION
The wrapping "opts" object in the extended parameters is incorrect and causes the call to fail.
The mode and charset should be passed directly in the base object that's being passed in as extended parameters into to the fs.open function.
