### PR TITLE
Update 2000-01-02-build.md

### DIFF
--- a/_posts/documentation/get-started/2000-01-02-build.md
+++ b/_posts/documentation/get-started/2000-01-02-build.md
@@ -32,7 +32,7 @@ sudo apt-get install g++ flex bison gperf ruby perl \
   libpng-dev libjpeg-dev
 ```
 
-Note: It is recommend also to install `ttf-mscorefonts-installer` package.
+Note: It is recommend also to install `ttf-mscorefonts-installer` package. If build.sh fails due to lack of make or gmake in PATH, then try installing build-essentials.
 
 On Fedora-based distro (tested on CentOS 6), run:
 


### PR DESCRIPTION
installing build-essentials fixed my issue of a missing make or gmake in PATH when trying to run build.sh on a new ubuntu Amazon EC2 instance.
