### PR TITLE
automatic screenshot size based on document size

### DIFF
--- a/examples/rasterize.js
+++ b/examples/rasterize.js
@@ -12,11 +12,14 @@ if (system.args.length < 3 || system.args.length > 5) {
     address = system.args[1];
     output = system.args[2];
     page.viewportSize = { width: 600, height: 600 };
+    var detectViewportSize = true;
     if (system.args.length > 3 && system.args[2].substr(-4) === ".pdf") {
+        detectViewportSize = false;
         size = system.args[3].split('*');
         page.paperSize = size.length === 2 ? { width: size[0], height: size[1], margin: '0px' }
                                            : { format: system.args[3], orientation: 'portrait', margin: '1cm' };
     } else if (system.args.length > 3 && system.args[3].substr(-2) === "px") {
+        detectViewportSize = false;
         size = system.args[3].split('*');
         if (size.length === 2) {
             pageWidth = parseInt(size[0], 10);
@@ -39,6 +42,19 @@ if (system.args.length < 3 || system.args.length > 5) {
             console.log('Unable to load the address!');
             phantom.exit(1);
         } else {
+            if (detectViewportSize) {
+              var detectedViewportSize = page.evaluate(function() {
+                  var container = document.querySelector('body') || document.documentElement;
+                  if (!container) { return; }
+                  return {
+                      width: container.offsetWidth,
+                      height: container.offsetHeight
+                  };
+              });
+              if (detectedViewportSize) {
+                page.viewportSize = detectedViewportSize;
+              }
+            }
             window.setTimeout(function () {
                 page.render(output);
                 phantom.exit();


### PR DESCRIPTION
this change allows that (when no size was specified) an attempt to detect the size automatically based on the document is done,
first we try to use the `body` size, if no `body` is found, just uses the document root (eg. an `svg`).
If this fails, it fallbacks to current behavior (ie. 600x600).
This allows to take screenshot of html where the size depends on its content.
