### PR TITLE
Use git tags in build instructions instead of branches

### DIFF
--- a/_posts/documentation/get-started/2000-01-02-build.md
+++ b/_posts/documentation/get-started/2000-01-02-build.md
@@ -14,7 +14,7 @@ Install [Xcode](https://developer.apple.com/xcode/) and the necessary SDK for de
 ```bash
 git clone git://github.com/ariya/phantomjs.git
 cd phantomjs
-git checkout 2.0
+git checkout 2.0.0
 ./build.sh --qt-config "-I /usr/local/include/ -L /usr/local/lib/"
 ```
 
@@ -47,7 +47,7 @@ Then, launch the build:
 ```bash
 git clone git://github.com/ariya/phantomjs.git
 cd phantomjs
-git checkout 2.0
+git checkout 2.0.0
 ./build.sh
 ```
 
@@ -64,7 +64,7 @@ Use Visual Studio Command Prompt, run in the top directory. The results will go 
 ```bash
 git clone git://github.com/ariya/phantomjs.git
 cd phantomjs
-git checkout 2.0
+git checkout 2.0.0
 build.cmd
 ```
 


### PR DESCRIPTION
Shouldn't people check out a tag instead of a branch for building? Otherwise they might get an inconsistent development snapshot, no?
