### PR TITLE
Update download docs to include npm option

### DIFF
--- a/_posts/documentation/get-started/2000-01-01-download.md
+++ b/_posts/documentation/get-started/2000-01-01-download.md
@@ -28,9 +28,11 @@ The binary `bin/phantomjs` is ready to use.
 
 ## Linux
 
+Install it locally through npm, `npm install phantomjs` or globally `sudo npm -g install phantomjs`.
+
 Binary packages for Linux are still being prepared. There are still issues to be solved until a static build is available (see [issue 12948](https://github.com/ariya/phantomjs/issues/12948) for more details).
 
-In the mean time, it is recommended that you build the Linux version from source.
+In the mean time, it is recommended that you build the Linux version from source or to install it from npm.
 
 ## Source Code
 


### PR DESCRIPTION
In Linux, it's not mentioned in the docs you can install the executable through npm, which can be very handy if you don't need to build the whole binary yourself. For me that line would've been a big time saver.
