### PR TITLE
Stop claiming version 2.0 will work on XP

### DIFF
--- a/_posts/documentation/get-started/2000-01-01-download.md
+++ b/_posts/documentation/get-started/2000-01-01-download.md
@@ -16,7 +16,7 @@ Download [phantomjs-2.0.0-windows.zip](https://bitbucket.org/ariya/phantomjs/dow
 
 The executable `phantomjs.exe` is ready to use.
 
-**Note**: For this static build, the binary is self-contained with no external dependency. It will run on a fresh install of Windows XP or later versions. There is no requirement to install Qt, WebKit, or any other libraries.
+**Note**: For this static build, the binary is self-contained with no external dependency. It will run on a fresh install of Windows Vista or later versions. There is no requirement to install Qt, WebKit, or any other libraries.
 
 ## Mac OS X
 


### PR DESCRIPTION
The current binaries are built with VS2012, and don't target XP any more. See issue #12992, so this stops claiming that they run on XP.

https://github.com/ariya/phantomjs/issues/12992
