### PR TITLE
Font crash bug

### DIFF
--- a/src/qt/qtbase/src/platformsupport/fontdatabases/fontconfig/qfontconfigdatabase.cpp
+++ b/src/qt/qtbase/src/platformsupport/fontdatabases/fontconfig/qfontconfigdatabase.cpp
@@ -659,11 +659,9 @@ QFontEngine *QFontconfigDatabase::fontEngine(const QFontDef &f, void *usrPtr)
 
 QFontEngine *QFontconfigDatabase::fontEngine(const QByteArray &fontData, qreal pixelSize, QFont::HintingPreference hintingPreference)
 {
-    qDebug() << "IN FONTENGINE() FUNCTION";
     QFontEngine *e = QBasicFontDatabase::fontEngine(fontData, pixelSize, hintingPreference); // function may return NULL (0)
     if(e == 0)
     {
-       qDebug() << "IS NULL";
        return 0;
     }
     QFontEngineFT *engine = static_cast<QFontEngineFT*>(e);

--- a/src/qt/qtbase/src/platformsupport/fontdatabases/fontconfig/qfontconfigdatabase.cpp
+++ b/src/qt/qtbase/src/platformsupport/fontdatabases/fontconfig/qfontconfigdatabase.cpp
@@ -659,7 +659,14 @@ QFontEngine *QFontconfigDatabase::fontEngine(const QFontDef &f, void *usrPtr)
 
 QFontEngine *QFontconfigDatabase::fontEngine(const QByteArray &fontData, qreal pixelSize, QFont::HintingPreference hintingPreference)
 {
-    QFontEngineFT *engine = static_cast<QFontEngineFT*>(QBasicFontDatabase::fontEngine(fontData, pixelSize, hintingPreference));
+    qDebug() << "IN FONTENGINE() FUNCTION";
+    QFontEngine *e = QBasicFontDatabase::fontEngine(fontData, pixelSize, hintingPreference); // function may return NULL (0)
+    if(e == 0)
+    {
+       qDebug() << "IS NULL";
+       return 0;
+    }
+    QFontEngineFT *engine = static_cast<QFontEngineFT*>(e);
     QFontDef fontDef = engine->fontDef;
 
     QFontEngineFT::GlyphFormat format;
@@ -705,6 +712,7 @@ QFontEngine *QFontconfigDatabase::fontEngine(const QByteArray &fontData, qreal p
     engine->glyphFormat = format;
 
     return engine;
+  
 }
 
 QStringList QFontconfigDatabase::fallbacksForFamily(const QString &family, QFont::Style style, QFont::StyleHint styleHint, QChar::Script script) const


### PR DESCRIPTION
This fix is a modification in QT. It fixes a lot of SEGFAULT crashes with PhantomJS 2.0
e.g.
#13124
#13003
