### PR TITLE
Linux instructions missing python dependancy

### DIFF
--- a/_posts/documentation/get-started/2000-01-02-build.md
+++ b/_posts/documentation/get-started/2000-01-02-build.md
@@ -29,7 +29,7 @@ On Debian-based distro (tested on Ubuntu 14.04), run:
 ```bash
 sudo apt-get install build-essential g++ flex bison gperf ruby perl \
   libsqlite3-dev libfontconfig1-dev libicu-dev libfreetype6 libssl-dev \
-  libpng-dev libjpeg-dev
+  libpng-dev libjpeg-dev python
 ```
 
 Note: It is recommend also to install `ttf-mscorefonts-installer` package.


### PR DESCRIPTION
On ubuntu:12.04 the current instructions fail with during build with a `No module named xml.dom` error.
Adding `python` to the `apt-get install` instructions seems to fix this.
