### PR TITLE
Possibility to change proxy runtime

### DIFF
--- a/src/consts.h
+++ b/src/consts.h
@@ -55,6 +55,7 @@
 #define PAGE_SETTINGS_JS_ENABLED            "javascriptEnabled"
 #define PAGE_SETTINGS_XSS_AUDITING          "XSSAuditingEnabled"
 #define PAGE_SETTINGS_USER_AGENT            "userAgent"
+#define PAGE_SETTINGS_PROXY                 "proxy"
 #define PAGE_SETTINGS_LOCAL_ACCESS_REMOTE   "localToRemoteUrlAccessEnabled"
 #define PAGE_SETTINGS_USERNAME              "userName"
 #define PAGE_SETTINGS_PASSWORD              "password"

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -414,6 +414,15 @@ void Phantom::setProxy(const QString &ip, const qint64 &port, const QString &pro
     }
 }
 
+QString Phantom::proxy()
+{
+    QNetworkProxy proxy = QNetworkProxy::applicationProxy();
+    if (proxy.hostName().isEmpty()) {
+        return NULL;
+    }
+    return proxy.hostName() + ":" + QString::number(proxy.port());
+}
+
 void Phantom::exit(int code)
 {
     if (m_config.debug()) {

--- a/src/phantom.h
+++ b/src/phantom.h
@@ -170,6 +170,8 @@ public slots:
      */
     void setProxy(const QString &ip, const qint64 &port = 80, const QString &proxyType = "http", const QString &user = NULL, const QString &password = NULL);
 
+    QString proxy();
+
     // exit() will not exit in debug mode. debugExit() will always exit.
     void exit(int code = 0);
     void debugExit(int code = 0);

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -55,6 +55,8 @@
 #include <QDebug>
 #include <QImageWriter>
 #include <QUuid>
+#include <QUrl>
+#include <QNetworkProxy>
 
 #include "phantom.h"
 #include "networkaccessmanager.h"
@@ -600,7 +602,22 @@ void WebPage::applySettings(const QVariantMap &def)
 
     if (def.contains(PAGE_SETTINGS_RESOURCE_TIMEOUT))
         m_networkAccessManager->setResourceTimeout(def[PAGE_SETTINGS_RESOURCE_TIMEOUT].toInt());
+    if (def.contains(PAGE_SETTINGS_PROXY)) {
+        setProxy(def[PAGE_SETTINGS_PROXY].toString());
+    }
 
+}
+
+void WebPage::setProxy(const QString &proxyUrl)
+{
+    QUrl url(proxyUrl);
+    qDebug() << "Setting proxy to: "<< url.scheme() << url.host() << url.port();
+    QNetworkProxy::ProxyType type = QNetworkProxy::HttpProxy;
+    if (url.scheme() == "socks5") {
+        type = QNetworkProxy::Socks5Proxy;
+    }
+    QNetworkProxy proxy(type, url.host(), url.port(), url.userName(), url.password());
+    m_networkAccessManager->setProxy(proxy);
 }
 
 QString WebPage::userAgent() const

--- a/src/webpage.h
+++ b/src/webpage.h
@@ -483,6 +483,8 @@ public slots:
 
     void clearMemoryCache();
 
+    void setProxy(const QString &proxyUrl);
+
 signals:
     void initialized();
     void loadStarted();


### PR DESCRIPTION
Added setProxy method for to a page:

``` js
page.setProxy('http://my.proxy.com:8080');
 //or
page.setProxy('socks5://someproxy:8080');
```

Theoretically username and password should work also:

```
http://username:password@example.com/
```

There's also a possibility to set proxy using page.openUrl method:

``` js
page.openUrl('http://example.com', 'get', {'proxy': 'http://my.proxy.com:8080'});
```
