### PR TITLE
Update networkaccessmanager.cpp - fix #10156 bodysize inconsistances/bytes transferred

### DIFF
--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -2,7 +2,7 @@
   This file is part of the PhantomJS project from Ofi Labs.
 
   Copyright (C) 2011 Ariya Hidayat <ariya.hidayat@gmail.com>
-  Copyright (C) 2011 Ivan De Marino <ivan.de.marino@gmail.com>
+  Copyright (C) 2011 Ivan De Marino <ivan.de.marino@gmail.com>s
 
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
@@ -371,11 +371,7 @@ void NetworkAccessManager::handleStarted()
     QNetworkReply *reply = qobject_cast<QNetworkReply*>(sender());
     if (!reply)
         return;
-    if (m_started.contains(reply))
-        return;
 
-    m_started += reply;
-    
     QVariantList headers;
     foreach (QByteArray headerName, reply->rawHeaderList()) {
         QVariantMap header;
@@ -385,7 +381,13 @@ void NetworkAccessManager::handleStarted()
     }
 
     QVariantMap data;
-    data["stage"] = "start";
+    if (!m_started.contains(reply)) {
+      m_started += reply;
+      data["stage"] = "start";
+    }
+    else {
+      data["stage"] = "data";
+    }
     data["id"] = m_ids.value(reply);
     data["url"] = reply->url().toEncoded().data();
     data["status"] = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute);


### PR DESCRIPTION
Fix problems with size of resource returned (content-length) specifically when no content-length is returned by QT.

QT emits updates as well as 'start' and 'end' when a recource is received via onResouceReceived. Currently the updates are ignored and the number of bytes returned (bodySize) is incorrect as it is just set to the size of the first read which is returned by 'start'. The fix adds a new option 'data' which returns the bytes (bodySize) returned in subsequent reads. If when OnResourceRecevieved is triggered for a particular resource the bytes (bodySize) from 'start' and subsequent 'read'  are added together the correct size of the resource will be calculated ('end' does not return bodysize). This does not rely on content-length being passed by the server for instance when chunking is being used, or when gzip compression is being used as QT specifically removes the Content-Length header and does not return it to phantomjs in this case.

https://github.com/ariya/phantomjs/issues/10156
