### PR TITLE
Fix wrong call example

### DIFF
--- a/_posts/api/fs/method/2000-01-01-remove.md
+++ b/_posts/api/fs/method/2000-01-01-remove.md
@@ -17,7 +17,7 @@ When errors occur during a call, it will throw a 'Unable to remove file PATH' an
 var fs = require('fs');
 var toDelete = 'someFile.txt';
 
-fs.removeDirectory(toDelete);
+fs.remove(toDelete);
 
 phantom.exit();
 ```


### PR DESCRIPTION
The documentation is for remove function but the example shows removeDirectory.
