### PR TITLE
Add QtWebkit configuration tests

### DIFF
--- a/src/qt/qtwebkit/Tools/qmake/config.tests/README
+++ b/src/qt/qtwebkit/Tools/qmake/config.tests/README
@@ -1,0 +1,4 @@
+This directory is used for configure-style checks that are run by
+syncqt during processing of configure.pro in the parent directory.
+
+Note: This feature is available in Qt 5 only.

--- a/src/qt/qtwebkit/Tools/qmake/config.tests/fontconfig/fontconfig.cpp
+++ b/src/qt/qtwebkit/Tools/qmake/config.tests/fontconfig/fontconfig.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2011 University of Szeged. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <fontconfig/fontconfig.h>
+
+int main(int, char**)
+{
+    FcInit();
+}

--- a/src/qt/qtwebkit/Tools/qmake/config.tests/fontconfig/fontconfig.pro
+++ b/src/qt/qtwebkit/Tools/qmake/config.tests/fontconfig/fontconfig.pro
@@ -1,0 +1,4 @@
+CONFIG -= qt
+SOURCES = fontconfig.cpp
+CONFIG += link_pkgconfig
+PKGCONFIG += fontconfig

--- a/src/qt/qtwebkit/Tools/qmake/config.tests/gccdepends/gccdepends.pro
+++ b/src/qt/qtwebkit/Tools/qmake/config.tests/gccdepends/gccdepends.pro
@@ -1,0 +1,34 @@
+TEMPLATE = aux
+OBJECTS_DIR = obj
+QMAKE_CXXFLAGS += -MD
+
+base_filename = empty
+object_file = $$OBJECTS_DIR/$${base_filename}.o
+deps_filename = $${base_filename}.d
+
+SOURCES += $${base_filename}.cpp
+
+test.commands = \
+    # Earlier teambuilder and icecream versions would not
+    # respect the -o argument for the .d file, so the file
+    # would end up in the root build dir.
+    test ! -f $${deps_filename} && \
+    \
+    # But it should end up in the OBJECTS_DIR
+    test -f $$OBJECTS_DIR/$${deps_filename} && \
+    \
+    # Icecream 0.9.7 and earlier does not ensure that the
+    # target rule matches the path of the .o file, since
+    # the file is compiled into the current dir and then
+    # moved. Verify that we don't hit that case.
+    grep -q \"$${object_file}:\" $$OBJECTS_DIR/$${deps_filename} && \
+    \
+    # If everything is all right we mark the test as succeeded
+    echo success > $$basename(PWD)
+
+test.depends = $${object_file}
+QMAKE_EXTRA_TARGETS += test
+
+default.target = all
+default.depends += test
+QMAKE_EXTRA_TARGETS += default

--- a/src/qt/qtwebkit/Tools/qmake/config.tests/glx/glx.cpp
+++ b/src/qt/qtwebkit/Tools/qmake/config.tests/glx/glx.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies)
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <GL/glx.h>
+
+int main(int, char**)
+{
+    Display* display = XOpenDisplay(0);
+    int items = 0;
+    (void)glXChooseFBConfig(display, DefaultScreen(display), 0, &items);
+    XCloseDisplay(display);
+
+    return 0;
+}

--- a/src/qt/qtwebkit/Tools/qmake/config.tests/glx/glx.pro
+++ b/src/qt/qtwebkit/Tools/qmake/config.tests/glx/glx.pro
@@ -1,0 +1,4 @@
+SOURCES = glx.cpp
+OBJECTS_DIR = obj
+LIBS += -lX11 -lGL
+

--- a/src/qt/qtwebkit/Tools/qmake/config.tests/gnuld/gnuld.exe.embed.manifest
+++ b/src/qt/qtwebkit/Tools/qmake/config.tests/gnuld/gnuld.exe.embed.manifest
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes'?>
+<assembly xmlns='urn:schemas-microsoft-com:asm.v1' manifestVersion='1.0'>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level='asInvoker' uiAccess='false' />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' publicKeyToken='6595b64144ccf1df' language='*' processorArchitecture='*' />
+    </dependentAssembly>
+  </dependency>
+</assembly>

--- a/src/qt/qtwebkit/Tools/qmake/config.tests/gnuld/gnuld.pro
+++ b/src/qt/qtwebkit/Tools/qmake/config.tests/gnuld/gnuld.pro
@@ -1,0 +1,4 @@
+TEMPLATE = app
+TARGET = gnuld
+SOURCES = main.cpp
+QMAKE_LFLAGS += -Wl,--no-keep-memory

--- a/src/qt/qtwebkit/Tools/qmake/config.tests/gnuld/main.cpp
+++ b/src/qt/qtwebkit/Tools/qmake/config.tests/gnuld/main.cpp
@@ -1,0 +1,5 @@
+
+int main()
+{
+    return 0;
+}

--- a/src/qt/qtwebkit/Tools/qmake/config.tests/icu/icu.cpp
+++ b/src/qt/qtwebkit/Tools/qmake/config.tests/icu/icu.cpp
@@ -1,0 +1,46 @@
+/****************************************************************************
+**
+** Copyright (C) 2014 Digia Plc and/or its subsidiary(-ies).
+** Contact: http://www.qt-project.org/legal
+**
+** This file is part of the config.tests of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL21$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and Digia. For licensing terms and
+** conditions see http://qt.digia.com/licensing. For further information
+** use the contact form at http://qt.digia.com/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 or version 3 as published by the Free
+** Software Foundation and appearing in the file LICENSE.LGPLv21 and
+** LICENSE.LGPLv3 included in the packaging of this file. Please review the
+** following information to ensure the GNU Lesser General Public License
+** requirements will be met: https://www.gnu.org/licenses/lgpl.html and
+** http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** In addition, as a special exception, Digia gives you certain additional
+** rights. These rights are described in the Digia Qt LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include <unicode/utypes.h>
+#include <unicode/ucol.h>
+#include <unicode/ustring.h>
+
+int main(int, char **)
+{
+    UErrorCode status = U_ZERO_ERROR;
+    UCollator *collator = ucol_open("ru_RU", &status);
+    if (U_FAILURE(status))
+        return 0;
+    ucol_close(collator);
+    return 0;
+}

--- a/src/qt/qtwebkit/Tools/qmake/config.tests/icu/icu.pro
+++ b/src/qt/qtwebkit/Tools/qmake/config.tests/icu/icu.pro
@@ -1,0 +1,22 @@
+SOURCES = icu.cpp
+CONFIG += console
+CONFIG -= qt dylib
+
+win32 {
+    CONFIG(static, static|shared) {
+        CONFIG(debug, debug|release) {
+            LIBS += -lsicuind -lsicuucd -lsicudtd
+        } else {
+            LIBS += -lsicuin -lsicuuc -lsicudt
+        }
+    } else {
+        LIBS += -licuin -licuuc -licudt
+    }
+    LIBS += -ladvapi32
+} else:!contains(QT_CONFIG,no-pkg-config):packagesExist("icu-i18n") {
+    PKGCONFIG += icu-i18n
+} else {
+    LIBS += -licui18n -licuuc -licudata
+}
+
+load(qt_build_config)

--- a/src/qt/qtwebkit/Tools/qmake/config.tests/leveldb/leveldb.cpp
+++ b/src/qt/qtwebkit/Tools/qmake/config.tests/leveldb/leveldb.cpp
@@ -1,0 +1,28 @@
+/*
+    Copyright (C) 2014 Digia Plc. and/or its subsidiary(-ies)
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Library General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Library General Public License for more details.
+
+    You should have received a copy of the GNU Library General Public License
+    along with this library; see the file COPYING.LIB.  If not, write to
+    the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+    Boston, MA 02110-1301, USA.
+*/
+
+#include <leveldb/db.h>
+#include <leveldb/env.h>
+#include <helpers/memenv/memenv.h>
+
+int main(int, char**)
+{
+    leveldb::Env* inMemoryEnv = leveldb::NewMemEnv(leveldb::Env::Default());
+    return !inMemoryEnv;
+}

--- a/src/qt/qtwebkit/Tools/qmake/config.tests/leveldb/leveldb.pro
+++ b/src/qt/qtwebkit/Tools/qmake/config.tests/leveldb/leveldb.pro
@@ -1,0 +1,5 @@
+SOURCES = leveldb.cpp
+OBJECTS_DIR = obj
+LIBS += -lleveldb -lmemenv
+
+load(qt_build_config)

--- a/src/qt/qtwebkit/Tools/qmake/config.tests/libXcomposite/libXcomposite.cpp
+++ b/src/qt/qtwebkit/Tools/qmake/config.tests/libXcomposite/libXcomposite.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies)
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <X11/extensions/Xcomposite.h>
+
+int main(int, char**)
+{
+    Display* display = XOpenDisplay(0);
+    int majorVersion;
+    int minorVersion;
+    (void)XCompositeQueryVersion(display, &majorVersion, &minorVersion);
+    XCloseDisplay(display);
+    return 0;
+}

--- a/src/qt/qtwebkit/Tools/qmake/config.tests/libXcomposite/libXcomposite.pro
+++ b/src/qt/qtwebkit/Tools/qmake/config.tests/libXcomposite/libXcomposite.pro
@@ -1,0 +1,3 @@
+SOURCES = libXcomposite.cpp
+OBJECTS_DIR = obj
+LIBS += -lXcomposite -lX11

--- a/src/qt/qtwebkit/Tools/qmake/config.tests/libXrender/libXrender.cpp
+++ b/src/qt/qtwebkit/Tools/qmake/config.tests/libXrender/libXrender.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies)
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <X11/extensions/Xrender.h>
+
+int main(int, char**)
+{
+    Display* display = XOpenDisplay(0);
+    int eventBasep;
+    int errorBasep;
+    if (!XRenderQueryExtension(display, &eventBasep, &errorBasep))
+        return -1;
+    return 0;
+}
+

--- a/src/qt/qtwebkit/Tools/qmake/config.tests/libXrender/libXrender.pro
+++ b/src/qt/qtwebkit/Tools/qmake/config.tests/libXrender/libXrender.pro
@@ -1,0 +1,3 @@
+SOURCES = libXrender.cpp
+OBJECTS_DIR = obj
+LIBS += -lXrender -lX11

--- a/src/qt/qtwebkit/Tools/qmake/config.tests/libwebp/libwebp.cpp
+++ b/src/qt/qtwebkit/Tools/qmake/config.tests/libwebp/libwebp.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) Zoltan Horvath (zoltan@webkit.org) 2012 University of Szeged.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "webp/decode.h"
+
+int main(int, char**)
+{
+    WebPDecoderConfig config;
+    WebPInitDecoderConfig(&config);
+    return 0;
+}

--- a/src/qt/qtwebkit/Tools/qmake/config.tests/libwebp/libwebp.pro
+++ b/src/qt/qtwebkit/Tools/qmake/config.tests/libwebp/libwebp.pro
@@ -1,0 +1,5 @@
+SOURCES = libwebp.cpp
+OBJECTS_DIR = obj
+LIBS += -lwebp
+
+load(qt_build_config)

--- a/src/qt/qtwebkit/Tools/qmake/config.tests/libxml2/libxml2.cpp
+++ b/src/qt/qtwebkit/Tools/qmake/config.tests/libxml2/libxml2.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2011 University of Szeged. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <libxml/xmlreader.h>
+
+int main(int, char**)
+{
+    xmlTextReaderSetup(0, 0, 0, 0, 0);
+    return 0;
+}
+

--- a/src/qt/qtwebkit/Tools/qmake/config.tests/libxml2/libxml2.pro
+++ b/src/qt/qtwebkit/Tools/qmake/config.tests/libxml2/libxml2.pro
@@ -1,0 +1,9 @@
+CONFIG -= qt
+SOURCES = libxml2.cpp
+mac {
+    QMAKE_CXXFLAGS += -iwithsysroot /usr/include/libxml2
+    LIBS += -lxml2
+} else {
+    PKGCONFIG += libxml-2.0
+    CONFIG += link_pkgconfig
+}

--- a/src/qt/qtwebkit/Tools/qmake/config.tests/libxslt/libxslt.cpp
+++ b/src/qt/qtwebkit/Tools/qmake/config.tests/libxslt/libxslt.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2011 University of Szeged. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <libxslt/xsltutils.h>
+
+int main(int, char**)
+{
+    xslAddCall(0, 0);
+    return 0;
+}
+

--- a/src/qt/qtwebkit/Tools/qmake/config.tests/libxslt/libxslt.pro
+++ b/src/qt/qtwebkit/Tools/qmake/config.tests/libxslt/libxslt.pro
@@ -1,0 +1,9 @@
+CONFIG -= qt
+SOURCES = libxslt.cpp
+mac {
+    QMAKE_CXXFLAGS += -iwithsysroot /usr/include/libxslt -iwithsysroot /usr/include/libxml2
+    LIBS += -lxslt
+} else {
+    PKGCONFIG += libxslt
+    CONFIG += link_pkgconfig
+}

--- a/src/qt/qtwebkit/Tools/qmake/config.tests/libzlib/libzlib.cpp
+++ b/src/qt/qtwebkit/Tools/qmake/config.tests/libzlib/libzlib.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies)
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <zlib.h>
+
+int main(int, char**)
+{
+    (void)zlibVersion();
+    return 0;
+}

--- a/src/qt/qtwebkit/Tools/qmake/config.tests/libzlib/libzlib.pro
+++ b/src/qt/qtwebkit/Tools/qmake/config.tests/libzlib/libzlib.pro
@@ -1,0 +1,5 @@
+SOURCES = libzlib.cpp
+OBJECTS_DIR = obj
+CONFIG += console
+win32: LIBS += -lzlib
+else: LIBS += -lz


### PR DESCRIPTION
Add missing QtWebkit configuration tests.
They are needed to configure QtWebkit properly:
- enable ICU support;
- enable zlib support (needed for WOFF)

Fixes #12927 
