### PR TITLE
PDF font embedding fails on Mac 64-bit due to unimplemented methods in QCoreTextFontEngine

### DIFF
--- a/src/qt/qtbase/src/platformsupport/fontdatabases/mac/qfontengine_coretext_p.h
+++ b/src/qt/qtbase/src/platformsupport/fontdatabases/mac/qfontengine_coretext_p.h
@@ -104,6 +104,7 @@ public:
     bool supportsTransformation(const QTransform &transform) const;
 
     virtual QFontEngine *cloneWithSize(qreal pixelSize) const;
+    virtual QFontEngine::Properties properties() const;
     virtual int glyphMargin(QFontEngine::GlyphFormat format) { Q_UNUSED(format); return 0; }
 
     static bool supportsColorGlyphs()


### PR DESCRIPTION
…n QCoreTextFontEngine (QTBUG-10094)
