### PR TITLE
PhantomJS default configuration file support

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -626,6 +626,18 @@ void Config::resetToDefaults()
     m_webdriverLogFile = QString();
     m_webdriverLogLevel = "INFO";
     m_webdriverSeleniumGridHub = QString();
+
+    loadDefaultJsonFile();
+}
+
+void Config::loadDefaultJsonFile()
+{
+    const QString filePath = "phantomjs.json";
+    QFile f(filePath);
+
+    if (f.exists()) {
+        loadJsonFile(filePath);
+    }
 }
 
 void Config::setProxyAuthPass(const QString& value)

--- a/src/config.h
+++ b/src/config.h
@@ -212,6 +212,7 @@ public slots:
 
 private:
     void resetToDefaults();
+    void loadDefaultJsonFile();
     void setProxyHost(const QString& value);
     void setProxyPort(const int value);
     void setAuthUser(const QString& value);


### PR DESCRIPTION
Load the file `phantomjs.json` if it exists at the root of the working directory to initialise default configuration

https://github.com/ariya/phantomjs/issues/13300
