### PR TITLE
Fix typo in dependencies of Debian-based distro

### DIFF
--- a/_posts/documentation/get-started/2000-01-02-build.md
+++ b/_posts/documentation/get-started/2000-01-02-build.md
@@ -29,7 +29,7 @@ On Debian-based distro (tested on Ubuntu 14.04), run:
 ```bash
 sudo apt-get install build-essential g++ flex bison gperf ruby perl \
   libsqlite3-dev libfontconfig1-dev libicu-dev libfreetype6 libssl-dev \
-  libpng-dev libjpeg-dev python libX11-dev libxext-dev
+  libpng-dev libjpeg-dev python libx11-dev libxext-dev
 ```
 
 Note: It is recommend also to install `ttf-mscorefonts-installer` package.


### PR DESCRIPTION
Fix capitalization of "libx11-dev"
