### PR TITLE
Add a note about symlinking

### DIFF
--- a/_posts/documentation/get-started/2000-01-02-build.md
+++ b/_posts/documentation/get-started/2000-01-02-build.md
@@ -53,6 +53,12 @@ git checkout 2.0
 
 **Note**: `build.sh` by default will launch parallel compile jobs depending on the available CPU cores, e.g. 4 jobs on a modern hyperthreaded dual-core processor. If necessary, e.g. when building on a virtual machine/server or other limited environment, reduce the jobs by passing a number, e.g `./build.sh --jobs 1` to set only one compile job at a time.
 
+If you get a `command not found` type of error, make sure to symlink the executable in the `phantomjs` directory to your path.
+```
+// example, if phantomjs is in your home directory
+sudo ln -s ~/phantomjs /usr/bin/phantomjs
+```
+
 ## Windows
 
 **Note**: Supported toolchains: `MSVC2012` and `MSVC2013`.


### PR DESCRIPTION
Current: There is a step missing in the Linux installation instructions that enables you to run phantomjs without explicitly calling it from `phantomjs/bin`
Proposed: Add a note to symlink the right executable to the right place
https://github.com/ariya/phantomjs/issues/13357
