### PR TITLE
Added missing CompanyName value for Windows

### DIFF
--- a/src/phantomjs_win.rc
+++ b/src/phantomjs_win.rc
@@ -17,6 +17,7 @@ BEGIN
             VALUE "OriginalFilename",   "phantomjs.exe"
             VALUE "ProductName",        "PhantomJS"
             VALUE "ProductVersion",     PHANTOMJS_VERSION_STRING
+            VALUE "CompanyName",        "PhantomJS.org"
         END
     END
 


### PR DESCRIPTION
Updated the configuration file containing the version information on
Windows.
Add the missing "CompanyName" value with value "PhantomJS.org".
This is in response to my previously opened issue which can be found
here: https://github.com/ariya/phantomjs/issues/13328
