### PR TITLE
Add support for capturing viewport when rendering images

### DIFF
--- a/src/webpage.h
+++ b/src/webpage.h
@@ -515,7 +515,8 @@ private slots:
     void handleCurrentFrameDestroyed();
 
 private:
-    QImage renderImage();
+    enum RenderMode { Content, Viewport };
+    QImage renderImage(const RenderMode mode = Content);
     bool renderPdf(QPdfWriter& pdfWriter);
     void applySettings(const QVariantMap& defaultSettings);
     QString userAgent() const;


### PR DESCRIPTION
Adds a new 'mode' option to the render API so that images can be captured
based on the viewport size when set to 'viewport' as opposed to being
captured as a page based on the content size when set to 'page'. The
'mode' option defaults to 'page' for backward compatibility.

Fixes #10619
