### PR TITLE
Fixes #13432. Allow remote debugging using random port provided by OS. 

### DIFF
--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -220,7 +220,11 @@ bool Phantom::execute()
         qDebug() << "Phantom - execute: Starting normal mode";
 
         if (m_config.debug()) {
+            int originalPort = m_config.remoteDebugPort();
             m_config.setRemoteDebugPort(m_page->showInspector(m_config.remoteDebugPort()));
+            if (m_config.remoteDebugPort() == 0) {
+                qWarning() << "Can't bind remote debugging server to the port" << originalPort;
+            }
             // Debug enabled
             if (!Utils::loadJSForDebug(m_config.scriptFile(), m_config.scriptLanguage(), m_scriptFileEnc, QDir::currentPath(), m_page->mainFrame(), m_config.remoteDebugAutorun())) {
                 m_returnValue = -1;

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -220,12 +220,12 @@ bool Phantom::execute()
         qDebug() << "Phantom - execute: Starting normal mode";
 
         if (m_config.debug()) {
+            m_config.setRemoteDebugPort(m_page->showInspector(m_config.remoteDebugPort()));
             // Debug enabled
             if (!Utils::loadJSForDebug(m_config.scriptFile(), m_config.scriptLanguage(), m_scriptFileEnc, QDir::currentPath(), m_page->mainFrame(), m_config.remoteDebugAutorun())) {
                 m_returnValue = -1;
                 return false;
             }
-            m_page->showInspector(m_config.remoteDebugPort());
         } else {
             if (!Utils::injectJsInFrame(m_config.scriptFile(), m_config.scriptLanguage(), m_scriptFileEnc, QDir::currentPath(), m_page->mainFrame(), true)) {
                 m_returnValue = -1;
@@ -418,6 +418,12 @@ void Phantom::setProxy(const QString& ip, const qint64& port, const QString& pro
             QNetworkProxy::setApplicationProxy(proxy);
         }
     }
+}
+
+int Phantom::remoteDebugPort() const
+{
+    QApplication::processEvents();
+    return m_config.remoteDebugPort();
 }
 
 void Phantom::exit(int code)

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -422,7 +422,6 @@ void Phantom::setProxy(const QString& ip, const qint64& port, const QString& pro
 
 int Phantom::remoteDebugPort() const
 {
-    QApplication::processEvents();
     return m_config.remoteDebugPort();
 }
 

--- a/src/phantom.h
+++ b/src/phantom.h
@@ -55,6 +55,7 @@ class Phantom : public QObject
     Q_PROPERTY(bool cookiesEnabled READ areCookiesEnabled WRITE setCookiesEnabled)
     Q_PROPERTY(QVariantList cookies READ cookies WRITE setCookies)
     Q_PROPERTY(bool webdriverMode READ webdriverMode)
+    Q_PROPERTY(int remoteDebugPort READ remoteDebugPort)
 
 private:
     // Private constructor: the Phantom class is a singleton
@@ -95,6 +96,8 @@ public:
     void setCookiesEnabled(const bool value);
 
     bool webdriverMode() const;
+
+    int remoteDebugPort() const;
 
     /**
      * Create `child_process` module instance

--- a/src/qt/qtwebkit/Source/WebKit/qt/WebCoreSupport/InspectorServerQt.cpp
+++ b/src/qt/qtwebkit/Source/WebKit/qt/WebCoreSupport/InspectorServerQt.cpp
@@ -78,14 +78,15 @@ InspectorServerQt::~InspectorServerQt()
     close();
 }
 
-void InspectorServerQt::listen(quint16 port)
+int InspectorServerQt::listen(quint16 port)
 {
     if (m_tcpServer)
-        return;
+        return m_tcpServer->serverPort();
 
     m_tcpServer = new QTcpServer();
     m_tcpServer->listen(QHostAddress::Any, port);
     connect(m_tcpServer, SIGNAL(newConnection()), SLOT(newConnection()));
+    return m_tcpServer->serverPort();
 }
 
 void InspectorServerQt::close()

--- a/src/qt/qtwebkit/Source/WebKit/qt/WebCoreSupport/InspectorServerQt.h
+++ b/src/qt/qtwebkit/Source/WebKit/qt/WebCoreSupport/InspectorServerQt.h
@@ -43,7 +43,7 @@ public:
 
     static InspectorServerQt* server();
 
-    void listen(quint16 port);
+    int listen(quint16 port);
 
     void registerClient(InspectorClientQt*);
     void unregisterClient(InspectorClientQt*);

--- a/src/qt/qtwebkit/Source/WebKit/qt/WebCoreSupport/QWebPageAdapter.cpp
+++ b/src/qt/qtwebkit/Source/WebKit/qt/WebCoreSupport/QWebPageAdapter.cpp
@@ -845,7 +845,7 @@ void QWebPageAdapter::dynamicPropertyChangeEvent(QObject* obj, QDynamicPropertyC
         QVariant port = obj->property("_q_webInspectorServerPort");
         if (port.isValid()) {
             InspectorServerQt* inspectorServer = InspectorServerQt::server();
-            inspectorServer->listen(port.toInt());
+            obj->setProperty("_q_webInspectorServerPort", inspectorServer->listen(port.toInt()));
         }
 #endif
     } else if (event->propertyName() == "_q_deadDecodedDataDeletionInterval") {

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -592,7 +592,7 @@ int WebPage::offlineStorageQuota() const
     return m_customWebPage->settings()->offlineStorageDefaultQuota();
 }
 
-void WebPage::showInspector(const int port)
+int WebPage::showInspector(const int port)
 {
     m_customWebPage->settings()->setAttribute(QWebSettings::DeveloperExtrasEnabled, true);
     m_inspector = new QWebInspector;
@@ -602,7 +602,9 @@ void WebPage::showInspector(const int port)
         m_inspector->setVisible(true);
     } else {
         m_customWebPage->setProperty("_q_webInspectorServerPort", port);
+        return m_customWebPage->property("_q_webInspectorServerPort").toInt();
     }
+    return port;
 }
 
 void WebPage::applySettings(const QVariantMap& def)

--- a/src/webpage.h
+++ b/src/webpage.h
@@ -129,7 +129,7 @@ public:
     void setCustomHeaders(const QVariantMap& headers);
     QVariantMap customHeaders() const;
 
-    void showInspector(const int remotePort = -1);
+    int showInspector(const int remotePort = -1);
 
     QString footer(int page, int numPages);
     qreal footerHeight() const;


### PR DESCRIPTION
Fixes https://github.com/ariya/phantomjs/issues/13432.

Remote debugging can be started using random port provided by OS like this:
`phantomjs.exe --remote-debugger-port=0 test.js`

This commit will allow script to get the actual port number like this:

``` javascript
console.log(phantom.remoteDebugPort);
```

In the case of dedicated port, `phantom.remoteDebugPort` will return that dedicated port number.
