### PR TITLE
Cast response body to string in binary mode.

### DIFF
--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -409,7 +409,7 @@ void WebServerResponse::write(const QVariant& body)
     if (m_encoding.isEmpty()) {
         data = body.toString().toUtf8();
     } else if (m_encoding.toLower() == "binary") {
-        data = body.toByteArray();
+        data = body.toString().toLatin1();
     } else {
         Encoding encoding;
         encoding.setEncoding(m_encoding);


### PR DESCRIPTION
QVariantHelper expects body to be the same type as before conversion.
If target type doesn't match the source type, QVariantHelper will return 0.
We can't convert in this way: `QString -> QVariant -> QByteArray`
Instead we must use the following way: `QString -> QVariant -> QString`

Fixes: #13026
