### PR TITLE
Fix compilation with GCC 5. (Issue #13518)

### DIFF
--- a/src/qt/qtwebkit/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/src/qt/qtwebkit/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -1909,6 +1909,11 @@ void JSObject::putByIndexBeyondVectorLengthWithoutAttributes(ExecState* exec, un
     }
 }
 
+// Explicit instantiations needed by JSArray.cpp.
+template void JSObject::putByIndexBeyondVectorLengthWithoutAttributes<Int32Shape>(ExecState*, unsigned, JSValue);
+template void JSObject::putByIndexBeyondVectorLengthWithoutAttributes<DoubleShape>(ExecState*, unsigned, JSValue);
+template void JSObject::putByIndexBeyondVectorLengthWithoutAttributes<ContiguousShape>(ExecState*, unsigned, JSValue);
+
 void JSObject::putByIndexBeyondVectorLengthWithArrayStorage(ExecState* exec, unsigned i, JSValue value, bool shouldThrow, ArrayStorage* storage)
 {
     VM& vm = exec->vm();


### PR DESCRIPTION
When an out-of-line template is used outside the file it's defined in, the programmer is obliged to explicitly list (in the file with the definition) the set of instantiations required by other files, even if all of those instantiations are also required by the file with the definition.  GCC 5 inlines a template instantiation that 4.x didn't, causing a use from another file to go unsatisfied and the link to fail.

Patch by Khem Raj.
Upstream Qt bug: https://bugreports.qt.io/browse/QTBUG-44829
Upstream Webkit bug: https://bugs.webkit.org/show_bug.cgi?id=147815
