### PR TITLE
Corrected method name in example code

### DIFF
--- a/_posts/api/fs/method/2000-01-01-remove-tree.md
+++ b/_posts/api/fs/method/2000-01-01-remove-tree.md
@@ -21,7 +21,7 @@ fs.makeDirectory(toDelete);
 fs.touch(toDelete + '/test.txt');
 
 // It will delete the 'someFolder' and the 'test.txt' in it
-fs.removeDirectory(toDelete);
+fs.removeTree(toDelete);
 
 phantom.exit();
 ```


### PR DESCRIPTION
`removeDirectory()` was used accidentally, but this document is about `removeTree()`
