### PR TITLE
[Travis CI] Migrate to new container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
 language: cpp
+sudo: false
 compiler:
   - gcc
 cache: apt
 
-before_install:
-  - sudo apt-get -yqq update    #< Suggested by the Travis CI doc
-  - sudo apt-get -fyq install   #< Fixes inconsistency of packages installed previously
-
-install:
-  - sudo apt-get -yq install build-essential chrpath libssl-dev libfontconfig1-dev sqlite3 libsqlite3-dev ruby gperf bison flex libicu48 libicu-dev #< Build Dependencies
+addons:
+  apt:
+    packages:
+    - gperf
+    - libicu-dev
+    - libssl-dev
 
 before_script:
   - chmod +x ./build.sh
@@ -16,9 +17,9 @@ before_script:
   - chmod +x ./test/run-tests-ghostdriver.sh
   
 script:
-  - ./build.sh --confirm --silent   #< Build
-  - ./test/run-tests.sh             #< Test (PhantomJS)
-  - ./test/run-tests-ghostdriver.sh #< Test (GhostDriver / PhantomJSDriver)
+  - ./build.sh --qtdeps=bundled --confirm --silent   #< Build
+  - ./test/run-tests.sh                              #< Test (PhantomJS)
+  - ./test/run-tests-ghostdriver.sh                  #< Test (GhostDriver / PhantomJSDriver)
 
 notifications:
   irc:


### PR DESCRIPTION
Bring Travis CI back again.

I removed already installed packages (like bison, libfontconfig1-dev).
I also added argument `qtdeps=bundled` to build PhantomJS with libraries included with Qt.

You can view current output here: https://travis-ci.org/Vitallium/phantomjs
Only Ghostdriver's tests are failing now.

Issue: #13554
