### PR TITLE
Update download page with working Mac binary

### DIFF
--- a/_posts/documentation/get-started/2000-01-01-download.md
+++ b/_posts/documentation/get-started/2000-01-01-download.md
@@ -22,9 +22,9 @@ The executable `phantomjs.exe` is ready to use.
 
 Download [phantomjs-2.0.0-macosx.zip](https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.0.0-macosx.zip) (13.7 MB) and extract (unzip) the content.
 
-The binary `bin/phantomjs` is ready to use.
+The binary `bin/phantomjs` is ready to use on 10.7 through 10.9.
 
-**Note**: For this static build, the binary is self-contained with no external dependency. It will run on a fresh install of OS X 10.7 (Lion) or later versions. There is no requirement to install Qt or any other libraries.
+**Note**: On 10.0 Yosemite the binary currently fails to launch returning a `Killed: 9` error. Until this is fixed, you may consider use of this working [unofficial build](https://github.com/eugene1g/phantomjs/releases).
 
 ## Linux
 


### PR DESCRIPTION
Ariya, I've tried altering the language of my previously suggested pull request (#13537), to make more clear that a link is being provided to an unofficial build, and that users should only consider its use.

I'd recommend adding this link and accompanying it with whatever language you feel comfortable, to help out the many Mac users who want to use phantomjs but get discouraged by the error upon launch. You might notice, for example, that the top Google autosuggest for phantomjs is "phantomjs killed 9".
