### PR TITLE
Change 'hundreds' to 'thousands' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [PhantomJS](http://phantomjs.org) - Scriptable Headless WebKit
 
-PhantomJS ([www.phantomjs.org](http://phantomjs.org)) is a headless WebKit scriptable with JavaScript. It is used by hundreds of [developers](http://phantomjs.org/buzz.html) and dozens of [organizations](http://phantomjs.org/users.html) for web-related development workflow.
+PhantomJS ([www.phantomjs.org](http://phantomjs.org)) is a headless WebKit scriptable with JavaScript. It is used by thousands of [developers](http://phantomjs.org/buzz.html) and dozens of [organizations](http://phantomjs.org/users.html) for web-related development workflow.
 
 The latest [stable release](http://phantomjs.org/release-2.0.html) is version 2.0.
 


### PR DESCRIPTION
I've been using PhantomJS for a long time now at multiple companies. Every rather experienced JavaScript developer I know uses or has used PhantomJS. Hence I think it should at least be 'thousands of developers'
