### PR TITLE
Minor fixes in non-working RPM build script

### DIFF
--- a/rpm/mkrpm.sh
+++ b/rpm/mkrpm.sh
@@ -23,6 +23,5 @@ rpmbuild --define "_topdir ${topdir}" --buildroot ${buildroot} --clean -bb ${nam
 RPMS=(`ls ${topdir}/RPMS/*/*.rpm`)
 cp ${topdir}/RPMS/*/*.rpm ${destdir}/
 rm -fr ${topdir} ${builddir}
-for rpm in "${RPMS[@]}"; do
-    echo ${TMPDIR:-/tmp}/${rpm##*/}
-done
+echo -ne "\n=> RPM build completed\n"
+for rpm in $(ls ${destdir}/*.rpm); do echo ${rpm}; done

--- a/rpm/mkrpm.sh
+++ b/rpm/mkrpm.sh
@@ -3,24 +3,26 @@
 # A silly little helper script to build the RPM.
 set -e
 
-name=${1:?"Usage: build <toolname>"}
+help="Usage: $0 <RPM spec file name> <final RPM destination absolute path>"
+name=${1:?${help}}
 name=${name%.spec}
+destdir=${2:?${help}}
 topdir=$(mktemp -d)
 version=$(awk '/define version/ { print $NF }' ${name}.spec)
 builddir=${TMPDIR:-/tmp}/${name}-${version}
 sourcedir="${topdir}/SOURCES"
 buildroot="${topdir}/BUILDROOT"
 mkdir -p ${topdir}/RPMS ${topdir}/SRPMS ${topdir}/SOURCES ${topdir}/BUILD
-mkdir -p ${buildroot} ${builddir}
+mkdir -p ${buildroot} ${builddir} ${destdir}
 echo "=> Copying sources..."
-( cd .. && tar cf - ./[A-Z]* ./bin ./examples | tar xf - -C ${builddir} )
+( cd .. && tar cf - ./[A-Z]* ./examples | tar xf - -C ${builddir} )
 echo "=> Creating source tarball under ${sourcedir}..."
-( cd ${builddir}/.. && zip -r ${sourcedir}/${name}-${version}-source.zip ${name}-${version}
+( cd ${builddir}/.. && zip -r ${sourcedir}/${name}-${version}-source.zip ${name}-${version} )
 echo "=> Building RPM..."
 rpmbuild --define "_topdir ${topdir}" --buildroot ${buildroot} --clean -bb ${name}.spec
 RPMS=(`ls ${topdir}/RPMS/*/*.rpm`)
-cp ${topdir}/RPMS/*/*.rpm 
-rm -fr ${topdir}
+cp ${topdir}/RPMS/*/*.rpm ${destdir}/
+rm -fr ${topdir} ${builddir}
 for rpm in "${RPMS[@]}"; do
     echo ${TMPDIR:-/tmp}/${rpm##*/}
 done


### PR DESCRIPTION
Syntax error fix
Help message moved to a variable
New parameter - "final RPM destination absolute path"
Fixed copying final RPMs + added ability to specify destination RPM directory
Removed ./bin directory from source since it is not a part of code base and it wasn't possible to build RPMs without running compiling PhantomJS first by running ./build.sh
${builddir} must be also removed after rpmbuild process
