### PR TITLE
Update 2000-01-01-working-directory.md

### DIFF
--- a/_posts/api/fs/property/2000-01-01-working-directory.md
+++ b/_posts/api/fs/property/2000-01-01-working-directory.md
@@ -4,6 +4,9 @@ title:  workingDirectory
 categories: api fs fs-property
 permalink: api/fs/property/working-directory.html
 ---
+The working directory is the directory of the JavaScript file that PhantomJS is executing.
+
+It can be changed using [changeWorkingDirectory()](http://phantomjs.org/api/fs/method/change-working-directory.html).
 
 ## Examples
 


### PR DESCRIPTION
I use PhantomJS to run Jasmine but at the beginning I struggled to get it works.
In my SpecRunner.html file I reference the scripts by relative paths as SpecRunner.html is also used in the context of an ASP.NET MVC project.
The relative paths must be relative to the PhatomJS working directory - and it is not clear from API documentation what the default working directory is.
