### PR TITLE
Fix example runner for Jasmine 2.3

### DIFF
--- a/examples/run-jasmine2.js
+++ b/examples/run-jasmine2.js
@@ -37,7 +37,7 @@ function waitFor(testFx, onReady, timeOutMillis) {
 
 
 if (system.args.length !== 2) {
-    console.log('Usage: run-jasmine.js URL');
+    console.log('Usage: run-jasmine2.js URL');
     phantom.exit(1);
 }
 
@@ -55,16 +55,17 @@ page.open(system.args[1], function(status){
     } else {
         waitFor(function(){
             return page.evaluate(function(){
-                return document.body.querySelector('.symbolSummary .pending') === null
+                return (document.body.querySelector('.symbolSummary .pending') === null &&
+                        document.body.querySelector('.duration') !== null);
             });
         }, function(){
             var exitCode = page.evaluate(function(){
                 console.log('');
 
-                var el = document.body.querySelector('.banner');
-                var banner = el.querySelector('.title').innerText + " " +
-                             el.querySelector('.version').innerText + " " +
-                             el.querySelector('.duration').innerText;
+                var title = 'Jasmine';
+                var version = document.body.querySelector('.version').innerText;
+                var duration = document.body.querySelector('.duration').innerText;
+                var banner = title + ' ' + version + ' ' + duration;
                 console.log(banner);
 
                 var list = document.body.querySelectorAll('.results > .failures > .spec-detail.failed');


### PR DESCRIPTION
Some banner elements (particularly the test run duration) have moved; this
change extracts the text values from the new locations.  Also, the test run
duration is now populated after all tests are run, so include it as a "complete"
condition in the `waitsFor` function.

Closes #13459
