### PR TITLE
waitfor.js example - use JSDoc

### DIFF
--- a/examples/waitfor.js
+++ b/examples/waitfor.js
@@ -2,10 +2,10 @@
  * Wait until the test condition is true or a timeout occurs. Useful for waiting
  * on a server response or for a ui change (fadeIn, etc.) to occur.
  *
- * @param testFx javascript condition that evaluates to a boolean,
+ * @param {Function|string} testFx javascript condition that evaluates to a boolean,
  * it can be passed in as a string (e.g.: "1 == 1" or "$('#bar').is(':visible')" or
  * as a callback function.
- * @param onReady what to do when testFx condition is fulfilled,
+ * @param {Function|string} onReady what to do when testFx condition is fulfilled,
  * it can be passed in as a string (e.g.: "1 == 1" or "$('#bar').is(':visible')" or
  * as a callback function.
  * @param timeOutMillis the max amount of time to wait. If not specified, 3 sec is used.


### PR DESCRIPTION
specifying parameter type helps reading code and prevents usage error
