### PR TITLE
Update 2000-01-01-download.md

### DIFF
--- a/_posts/documentation/get-started/2000-01-01-download.md
+++ b/_posts/documentation/get-started/2000-01-01-download.md
@@ -26,6 +26,12 @@ The binary `bin/phantomjs` is ready to use.
 
 **Note**: For this static build, the binary is self-contained with no external dependency. It will run on a fresh install of OS X 10.7 (Lion) or later versions. There is no requirement to install Qt or any other libraries.
 
+**Note**: OS X 10.10 (Yosemite) users will need to unpack this binary using UPX (Otherwise the app exists with error message "Killed 9"). 
+```shell
+brew install upx
+upx -d phantomjs
+```
+
 ## Linux
 
 Binary packages for Linux are still being prepared. There are still issues to be solved until a static build is available (see [issue 12948](https://github.com/ariya/phantomjs/issues/12948) for more details).


### PR DESCRIPTION
The app seems to be packed in a format that Yosemite doesn't support. A simple two step process solved the problem. It will be useful to have this documented.

More details here: https://github.com/ariya/phantomjs/issues/12974
