### PR TITLE
Add linux build automation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:14.04
+MAINTAINER Matthieu Paret <matthieu@ifeelgoods.com>
+# sudo docker run -v /home/matt/dev/phantomjs:/home/app 8c8a6dc2fd33 ./build.sh --confirm 
+
+RUN apt-get update
+RUN apt-get install -y build-essential g++ flex bison gperf ruby perl libsqlite3-dev libfontconfig1-dev libicu-dev libfreetype6 libssl-dev libc-dev libpng-dev libjpeg-dev python libx11-dev libxext-dev
+
+RUN mkdir -p /home/app
+ENV HOME /home/app
+WORKDIR /home/app
+
+CMD ["./build.sh"]

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,18 @@
+machine:
+  pre:
+    - |
+      sudo curl -L -o /usr/bin/docker 'http://s3-external-1.amazonaws.com/circle-downloads/docker-1.8.2-circleci'
+      sudo chmod 0755 /usr/bin/docker
+      sudo service docker start
+checkout:
+  post:
+    - git submodule sync
+    - git submodule update --init
+dependencies:
+  post:
+   - sudo pip install docker-compose
+test:
+   pre:
+     - sudo docker build -t 'ubuntu-build-env' . 
+   override:
+     - sudo docker run -v `pwd`:/home/app ubuntu-build-env ./build.sh --confirm 

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,6 @@
+general:
+  artifacts:
+    - "bin/phantomjs" # a single file, relative to the build directory
 machine:
   pre:
     - |


### PR DESCRIPTION
### Description
- Add Dockerfile / circleci to build phantomjs
  This will permit to get a linux binary and verify the compilation is working.

We can download the binary for each build https://circleci.com/gh/ifeelgoods/phantomjs/3#artifacts.
