### PR TITLE
add note to Mac install instructions

### DIFF
--- a/_posts/documentation/get-started/2000-01-01-download.md
+++ b/_posts/documentation/get-started/2000-01-01-download.md
@@ -26,6 +26,8 @@ The binary `bin/phantomjs` is ready to use.
 
 **Note**: For this static build, the binary is self-contained with no external dependency. It will run on a fresh install of OS X 10.7 (Lion) or later versions. There is no requirement to install Qt or any other libraries.
 
+**Note**: There are some [known](https://github.com/ariya/phantomjs/issues/12928) [issues](https://github.com/ariya/phantomjs/issues/12974) with Yosemite. After unzip, if you find you are getting a `Killed: 9` error, [this discussion](http://stackoverflow.com/questions/28267809/phantomjs-getting-killed-9-for-anything-im-trying) may be helpful. Basically, you may need to install and used `upx` to unpack the binary `bin/phantomjs`.
+
 ## Linux
 
 Binary packages for Linux are still being prepared. There are still issues to be solved until a static build is available (see [issue 12948](https://github.com/ariya/phantomjs/issues/12948) for more details).


### PR DESCRIPTION
Inform users that the zip binary may not work on Yosemite due to a `Killed: 9` error.
Workaround exists: download and install `upx`, use it to unpack the phantomjs binary.
