### PR TITLE
[jasmine2] Avoid exception when no test was ran

### DIFF
--- a/examples/run-jasmine2.js
+++ b/examples/run-jasmine2.js
@@ -83,7 +83,7 @@ page.open(system.args[1], function(status){
                   }
                   return 1;
                 } else {
-                  console.log(document.body.querySelector('.alert > .bar.passed').innerText);
+                  console.log(document.body.querySelector('.alert > .bar.passed,.alert > .bar.skipped').innerText);
                   return 0;
                 }
             });


### PR DESCRIPTION
When all tests were skipped, or when no tests were found, run-jasmine2.js would raise an exception because ".alert > .bar.passed" doesn't exist.
As ".alert > .bar.skipped" exists instead, and has similar interesting content, let's use it!
