### PR TITLE
#13638, Incorrect expiration dates

### DIFF
--- a/src/cookiejar.cpp
+++ b/src/cookiejar.cpp
@@ -249,6 +249,8 @@ QVariantList CookieJar::cookiesToMap(const QString &url) const
     QList<QNetworkCookie> cookiesList = cookies(url);
     for (int i = cookiesList.length() -1; i >= 0; --i) {
         c = cookiesList.at(i);
+		
+		cookie.clear();
 
         cookie["domain"] = QVariant(c.domain());
         cookie["name"] = QVariant(QString(c.name()));

--- a/test/module/cookiejar/to-map.js
+++ b/test/module/cookiejar/to-map.js
@@ -1,0 +1,44 @@
+
+var assert = require('../../assert');
+
+var cookies = [{
+                'name':     'beforeExpires',        
+                'value':    'expireValue',              
+                'domain':   '.abc.com',             
+                'path':     '/',
+                'httponly': false,
+                'secure':   false,
+                'expires':  'Tue, 10 Jun 2025 12:28:29 GMT'
+            },
+            {
+                'name':     'noExpiresDate',            
+                'value':    'value',                
+                'domain':   '.abc.com',             
+                'path':     '/',
+                'httponly': false,
+                'secure':   false,
+                'expires':  null
+            },
+            {
+                'name':     'afterExpires',         
+                'value':    'value',                
+                'domain':   '.abc.com',             
+                'path':     '/',
+                'httponly': false,
+                'secure':   false,
+                'expires':  'Mon, 10 Jun 2024 12:28:29 GMT'
+            }];
+
+for(var cookieIdx in cookies)
+    phantom.addCookie(cookies[cookieIdx]);
+
+var phantomCookies = phantom.cookies;
+
+for(var cookieIdx in phantomCookies)
+{
+    if( phantomCookies[cookieIdx].name === "noExpiresDate" )
+    {
+        var expiresDate = phantomCookies[cookieIdx].expires;
+                assert.isTrue(expiresDate === undefined)
+    }
+}


### PR DESCRIPTION
CookieJar.cookiesToMap() propagated expiration dates onto following cookies due to not clearing out the value map between cookies.

Test file: test/module/cookiejar/to-map.js

https://github.com/ariya/phantomjs/issues/13638
