### PR TITLE
Add ability to specify the size of the output image file when rendering page

### DIFF
--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -989,6 +989,18 @@ bool WebPage::render(const QString& fileName, const QVariantMap& option)
             f = format.toLocal8Bit().constData();
         }
 
+        if( option.contains("maxWidth") && option.contains("maxHeight") ){
+            int maxWidth = option.value("maxWidth").toInt();
+            int maxHeight = option.value("maxHeight").toInt();
+            rawPageRendering = rawPageRendering.scaled(maxWidth, maxHeight, Qt::KeepAspectRatio);
+        } else if( option.contains("maxWidth") ){
+            int maxWidth = option.value("maxWidth").toInt();
+            rawPageRendering = rawPageRendering.scaledToWidth(maxWidth);
+        } else if( option.contains("maxHeight") ){
+            int maxHeight = option.value("maxHeight").toInt();
+            rawPageRendering = rawPageRendering.scaledToHeight(maxHeight);
+        }
+
         retval = rawPageRendering.save(outFileName, f, quality);
     }
 


### PR DESCRIPTION
Usage: maxHeight and maxWidth values are set in the page.render()
options.  Aspect ratio is preserved.  If only one is specified, the
image is constrained by that dimension.  If both are specified, the
image will fit in the resulting size.

https://github.com/ariya/phantomjs/issues/13771
