### PR TITLE
Fixed build file name from build.sh to build.py

### DIFF
--- a/_posts/documentation/get-started/2000-01-02-build.md
+++ b/_posts/documentation/get-started/2000-01-02-build.md
@@ -15,7 +15,7 @@ Install [Xcode](https://developer.apple.com/xcode/) and the necessary SDK for de
 git clone --recurse-submodules git://github.com/ariya/phantomjs.git
 cd phantomjs
 git checkout 2.0.0
-./build.sh --qt-config "-I /usr/local/include/ -L /usr/local/lib/"
+./build.py --qt-config "-I /usr/local/include/ -L /usr/local/lib/"
 ```
 
 This produces a statically built `bin/phantomjs`. This is a self-contained executable, it can be moved to a different directory or another machine.
@@ -48,10 +48,10 @@ Then, launch the build:
 git clone --recurse-submodules git://github.com/ariya/phantomjs.git
 cd phantomjs
 git checkout 2.0.0
-./build.sh
+./build.py
 ```
 
-**Note**: `build.sh` by default will launch parallel compile jobs depending on the available CPU cores, e.g. 4 jobs on a modern hyperthreaded dual-core processor. If necessary, e.g. when building on a virtual machine/server or other limited environment, reduce the jobs by passing a number, e.g `./build.sh --jobs 1` to set only one compile job at a time.
+**Note**: `build.py` by default will launch parallel compile jobs depending on the available CPU cores, e.g. 4 jobs on a modern hyperthreaded dual-core processor. If necessary, e.g. when building on a virtual machine/server or other limited environment, reduce the jobs by passing a number, e.g `./build.py --jobs 1` to set only one compile job at a time.
 
 This produces a build `bin/phantomjs`. This is an executable; it can be moved to a different directory (e.g. /usr/local/bin) or another machine.
 
@@ -67,10 +67,10 @@ Use Visual Studio Command Prompt, run in the top directory. The results will go 
 git clone --recurse-submodules git://github.com/ariya/phantomjs.git
 cd phantomjs
 git checkout 2.0.0
-build.cmd
+build.py
 ```
 
-**Note**: `git.exe` has to be on PATH. If you are using a wrapper (`git.cmd`, `git.bat`, etc.) modify `build.cmd` and replace `git.exe` with whatever you have on the PATH.
+**Note**: `git.exe` has to be on PATH. If you are using a wrapper (`git.cmd`, `git.bat`, etc.) modify `build.py` and replace `git.exe` with whatever you have on the PATH.
 
 **Note**: Enabling incremental linking will make the linkage process faster.
 

--- a/_posts/documentation/get-started/2000-01-02-build.md
+++ b/_posts/documentation/get-started/2000-01-02-build.md
@@ -70,8 +70,6 @@ git checkout 2.0.0
 build.py
 ```
 
-**Note**: `git.exe` has to be on PATH. If you are using a wrapper (`git.cmd`, `git.bat`, etc.) modify `build.py` and replace `git.exe` with whatever you have on the PATH.
-
 **Note**: Enabling incremental linking will make the linkage process faster.
 
 This produces a static build `bin/phantomjs.exe`. This is a self-contained executable, it can be moved to a different directory or another machine.


### PR DESCRIPTION
# What is this PR?

This PR solves the error that the build file is not build.sh as it is stated in the build document but build.py by fixing the build document.
# Risks

The build document is essential to build from source. If this PR introduces wrong information unexperienced users might not be able to build phantomjs. 
Also, not tested on Windows, can't determine the whether the document is correct for Windows.
