### PR TITLE
Fixed write example

### DIFF
--- a/_posts/api/fs/method/2000-01-01-exists.md
+++ b/_posts/api/fs/method/2000-01-01-exists.md
@@ -17,7 +17,7 @@ var fs = require('fs');
 var path = 'output.txt';
 
 if (!fs.exists(path))
-  fs.write('Hello World', path, 'w');
+  fs.write(path, 'Hello World', 'w');
 
 phantom.exit();
 ```


### PR DESCRIPTION
The write() method has the path parameter first, not the content.
