### PR TITLE
Explain that OSX binary needs decompressing with upx

### DIFF
--- a/_posts/documentation/get-started/2000-01-01-download.md
+++ b/_posts/documentation/get-started/2000-01-01-download.md
@@ -22,7 +22,7 @@ The executable `phantomjs.exe` is ready to use.
 
 Download [phantomjs-2.0.0-macosx.zip](https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.0.0-macosx.zip) (13.7 MB) and extract (unzip) the content.
 
-The binary `bin/phantomjs` is ready to use.
+The binary `bin/phantomjs` is compressed with [upx](http://upx.sourceforge.net/) (available in homebrew). Decompress the binary with `upx -d bin/phantomjs`. The binary `bin/phantomjs` is now ready to use.
 
 **Note**: For this static build, the binary is self-contained with no external dependency. It will run on a fresh install of OS X 10.7 (Lion) or later versions. There is no requirement to install Qt or any other libraries.
 


### PR DESCRIPTION
As per https://github.com/ariya/phantomjs/issues/12900, the OSX binary of phantomjs must be decompressed with `upx` before it can be used. This is a difficult issue to diagnose as without decompression the following error is displayed:

```
$ phantomjs
[1]    19787 killed     phantomjs phantom.js
```

The original instructions indicating the binary is immediately available to be used is misleading.
