### PR TITLE
Add GhostJS to list of test frameworks

### DIFF
--- a/_posts/documentation/learn/2000-01-02-headless-testing.md
+++ b/_posts/documentation/learn/2000-01-02-headless-testing.md
@@ -19,6 +19,7 @@ The following table summarizes the list of various test frameworks and the corre
 | [Capybara](http://jnicklas.github.com/capybara) |[Poltergeist](https://github.com/jonleighton/poltergeist), [Terminus](http://terminus.jcoglan.com)
 | [Mocha](http://mochajs.org) | [Chutzpah](http://mmanela.github.io/chutzpah/), [mocha-phantomjs](http://metaskills.net/mocha-phantomjs) |
 | [FuncUnit](http://funcunit.com) | built-in|
+| [GhostJS](https://github.com/KevinGrandon/ghostjs) | built-in|
 | [Hiro](http://hirojs.com) | built-in|
 | [Karma](http://karma-runner.github.com/) (née Testacular) | built-in |
 | [Jasmine](https://github.com/pivotal/jasmine) | [Chutzpah](http://mmanela.github.io/chutzpah/), [grunt-contrib-jasmine](https://github.com/gruntjs/grunt-contrib-jasmine), [guard-jasmine](https://github.com/netzpirat/guard-jasmine), [phantom-jasmine](https://github.com/jcarver989/phantom-jasmine)|


### PR DESCRIPTION
If you wouldn't mind. Thanks! :)

(Just realized this was in the wrong position, I should move it)
