### PR TITLE
Give appropriate URL to evaluated JS files.

### DIFF
--- a/src/consts.h
+++ b/src/consts.h
@@ -40,6 +40,9 @@
 #define HTTP_HEADER_CONTENT_LENGTH      "content-length"
 #define HTTP_HEADER_CONTENT_TYPE        "content-type"
 
+#define JAVASCRIPT_SOURCE_PLATFORM_URL  "phantomjs://platform/%1"
+#define JAVASCRIPT_SOURCE_CODE_URL      "phantomjs://code/%1"
+
 #define JS_ELEMENT_CLICK "(function (el) { " \
     "var ev = document.createEvent('MouseEvents');" \
     "ev.initEvent(\"click\", true, true);" \

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -110,7 +110,7 @@ void Phantom::init()
         QWebSettings::setOfflineStorageDefaultQuota(m_config.offlineStorageDefaultQuota());
     }
 
-    m_page = new WebPage(this, QUrl(QString(JAVASCRIPT_SOURCE_CODE_URL).arg("html")));
+    m_page = new WebPage(this, QUrl::fromLocalFile(m_config.scriptFile()));
     m_page->setCookieJar(m_defaultCookieJar);
     m_pages.append(m_page);
 

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -110,7 +110,7 @@ void Phantom::init()
         QWebSettings::setOfflineStorageDefaultQuota(m_config.offlineStorageDefaultQuota());
     }
 
-    m_page = new WebPage(this, QUrl::fromLocalFile(m_config.scriptFile()));
+    m_page = new WebPage(this, QUrl(QString(JAVASCRIPT_SOURCE_CODE_URL).arg("html")));
     m_page->setCookieJar(m_defaultCookieJar);
     m_pages.append(m_page);
 
@@ -381,7 +381,7 @@ void Phantom::loadModule(const QString& moduleSource, const QString& filename)
         "require.cache['" + filename + "'].exports," +
         "require.cache['" + filename + "']" +
         "));";
-    m_page->mainFrame()->evaluateJavaScript(scriptSource);
+    m_page->mainFrame()->evaluateJavaScript(scriptSource, QString(JAVASCRIPT_SOURCE_PLATFORM_URL).arg(QFileInfo(filename).fileName()));
 }
 
 bool Phantom::injectJs(const QString& jsFilePath)
@@ -479,7 +479,7 @@ void Phantom::onInitialized()
     // Bootstrap the PhantomJS scope
     m_page->mainFrame()->evaluateJavaScript(
         Utils::readResourceFileUtf8(":/bootstrap.js"),
-        QString("phantomjs://bootstrap.js")
+        QString(JAVASCRIPT_SOURCE_PLATFORM_URL).arg("bootstrap.js")
     );
 }
 

--- a/src/repl.cpp
+++ b/src/repl.cpp
@@ -147,7 +147,7 @@ REPL::REPL(QWebFrame* webframe, Phantom* parent)
     linenoiseSetCompletionCallback(REPL::offerCompletion);
 
     // Inject REPL utility functions
-    m_webframe->evaluateJavaScript(Utils::readResourceFileUtf8(":/repl.js"), QString("phantomjs://repl.js"));
+    m_webframe->evaluateJavaScript(Utils::readResourceFileUtf8(":/repl.js"), QString(JAVASCRIPT_SOURCE_PLATFORM_URL).arg("repl.js"));
 
     // Add self to JavaScript world
     m_webframe->addToJavaScriptWindowObject("_repl", this);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -133,8 +133,7 @@ bool injectJsInFrame(const QString& jsFilePath, const QString& jsFileLanguage, c
         return false;
     }
     // Execute JS code in the context of the document
-    const QUrl jsFileUrl = QUrl::fromLocalFile(QDir::currentPath()).resolved(jsFilePath);
-    targetFrame->evaluateJavaScript(scriptBody, jsFileUrl);
+    targetFrame->evaluateJavaScript(scriptBody, QString(JAVASCRIPT_SOURCE_CODE_URL).arg(QFileInfo(scriptPath).fileName()));
     return true;
 }
 
@@ -149,7 +148,7 @@ bool loadJSForDebug(const QString& jsFilePath, const QString& jsFileLanguage, co
     QString scriptBody = jsFromScriptFile(scriptPath, jsFileLanguage, jsFileEnc);
 
     scriptBody = QString("function __run() {\n%1\n}").arg(scriptBody);
-    targetFrame->evaluateJavaScript(scriptBody);
+    targetFrame->evaluateJavaScript(scriptBody, QString(JAVASCRIPT_SOURCE_CODE_URL).arg(QFileInfo(scriptPath).fileName()));
 
     if (autorun) {
         targetFrame->evaluateJavaScript("__run()", QString());


### PR DESCRIPTION
This will enable remote debugger to correctly load and display available runtime scripts.
Modules will be sourced from `JAVASCRIPT_SOURCE_PLATFORM_URL` template.
Program scripts which includes main script and any script loaded using `phantom.injectJs()` will be sourced from `JAVASCRIPT_SOURCE_CODE_URL` template.

Issue #12864
