### PR TITLE
Improvement suggested on OSX installation doc

### DIFF
--- a/_posts/documentation/get-started/2000-01-01-download.md
+++ b/_posts/documentation/get-started/2000-01-01-download.md
@@ -20,7 +20,7 @@ The executable `phantomjs.exe` is ready to use.
 
 ## Mac OS X
 
-Download [phantomjs-2.0.0-macosx.zip](https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.0.0-macosx.zip) (13.7 MB) and extract (unzip) the content.
+Download [phantomjs-2.0.0-macosx.zip](https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.0.0-macosx.zip) (13.7 MB) and extract (unzip) the content. Then move the phantomjs bin to /usr/bin: `sudo mv bin/phantomjs /usr/bin/`
 
 **Note**: For this static build, the binary is self-contained with no external dependency. It will run on a fresh install of OS X 10.7 (Lion) or later versions. There is no requirement to install Qt or any other libraries.
 


### PR DESCRIPTION
This is a suggestion to include moving the executable bin file to /usr/bin, as 3rd party libraries will try to execute it directly.
