### PR TITLE
Use homebrew to install upx on OSX

### DIFF
--- a/_posts/documentation/get-started/2000-01-01-download.md
+++ b/_posts/documentation/get-started/2000-01-01-download.md
@@ -24,7 +24,10 @@ Download [phantomjs-2.0.0-macosx.zip](https://bitbucket.org/ariya/phantomjs/down
 
 **Note**: For this static build, the binary is self-contained with no external dependency. It will run on a fresh install of OS X 10.7 (Lion) or later versions. There is no requirement to install Qt or any other libraries.
 
-**Known Issue**: If launching the executable fails with the error `Killed: 9`, please decompress the binary first with [upx](http://upx.sourceforge.net/): `upx -d bin/phantomjs`.
+**Known Issue**: If launching the executable fails with the error `Killed: 9`, please install [upx](http://upx.sourceforge.net/): and decompress the binary:
+
+    brew install upx
+    upx -d bin/phantomjs
 
 ## Linux
 


### PR DESCRIPTION
Since upx website doesn't provide binaries
