### PR TITLE
Build on phantomjs.org: Add system requirements and a note

### DIFF
--- a/_posts/documentation/get-started/2000-01-02-build.md
+++ b/_posts/documentation/get-started/2000-01-02-build.md
@@ -7,6 +7,10 @@ permalink: build.html
 
 **Warning**: Compiling PhantomJS from source takes a long time, mainly due to thousands of files in the WebKit module. With 4 parallel compile jobs on a modern machine, the entire process takes roughly 30 minutes. It is highly recommended to download and install the ready-made [binary package]({{ site.url }}/download.html) if it is available.
 
+**System Requirements**: Approximately 4 GB of RAM and 3 GB of disk is required for the compilation process.
+
+**Note**: If the compilation process is interrupted, once started again the `build.py` script will continue where left off.
+
 ## Mac OS X
 
 Install [Xcode](https://developer.apple.com/xcode/) and the necessary SDK for development (gcc, various tools, libraries, etc).
@@ -32,7 +36,7 @@ sudo apt-get install build-essential g++ flex bison gperf ruby perl \
   libpng-dev libjpeg-dev python libx11-dev libxext-dev
 ```
 
-Note: It is recommend also to install `ttf-mscorefonts-installer` package.
+**Note**: It is recommend also to install `ttf-mscorefonts-installer` package.
 
 On Fedora-based distro (tested on CentOS 6), run:
 


### PR DESCRIPTION
Add system requirements

Add a note on what happens if build.py is interrupted and started again
