### PR TITLE
Update 2000-01-01-render.md

### DIFF
--- a/_posts/api/webpage/method/2000-01-01-render.md
+++ b/_posts/api/webpage/method/2000-01-01-render.md
@@ -13,15 +13,18 @@ Currently, the output format is automatically set based on the file extension.
 
 ## Supported formats
 
-* PNG
-* GIF
-* JPEG
 * PDF
+* PNG
+* JPEG
+* BMP
+* PPM
+* GIF support depends on the build of Qt used
 
 ## Quality
 
-An integer between 0 and 100.
+An integer between 0 and 100. 
 
+The quality setting only has an effect on jpeg and png formats. With jpeg, it sets the quality level as a percentage, in the same way as most image editors. (The output file always has 2x2 subsampling.) A level of 0 produces a very small, very low quality file, and 100 produces a much larger, high-quality file. The default level is 75. With png, it sets the lossless (Deflate) compression level, with 0 producing the smallest files, and 100 producing the largest. However, the files look identical, and are always true-colour.
 
 ## Examples
 
@@ -36,7 +39,9 @@ page.open("http://www.google.com", function start(status) {
 });
 ```
 
+## More information
 
+The image generation code (except for PDF output) uses QImage from the Qt framework, documented at http://doc.qt.io/qt-5/qimage.html#save.
 
 
 


### PR DESCRIPTION
Updated with extra information based on the source code and my testing.
GIF export does not work (using PhantomJS 2.0 on Windows 7) - Qt documentation lists the GIF format as read-only, requiring a plugin to be able to write it. BMP and PPM export work without problems. XBM works, but looks terrible. XPM appears to work, but the files will not load.
