### PR TITLE
Fix typo in command-line help message

### DIFF
--- a/src/qcommandline/qcommandline.cpp
+++ b/src/qcommandline/qcommandline.cpp
@@ -437,7 +437,7 @@ QCommandLine::help(bool logo)
     h += QFileInfo(d->args[0]).baseName();
   else
     h += QCoreApplication::applicationName();
-  h.append(QLatin1String(" [switchs] [options]"));
+  h.append(QLatin1String(" [switches] [options]"));
   /* Arguments, short */
   foreach (QCommandLineConfigEntry entry, d->config) {
     if (entry.type == QCommandLine::Option) {


### PR DESCRIPTION
I wish I could stop clobbering people with typo-correction patches, but I really can't help myself. :-(

`switches` is misspelt in other parts of the file too, but I've left 'em untouched.

**NOTA BENE:** I'm _assuming_ this builds correctly, haven't tried doing so myself.
