### PR TITLE
Test for leaks when --load-images=no.

### DIFF
--- a/test/module/webpage/load-images-no.js
+++ b/test/module/webpage/load-images-no.js
@@ -1,0 +1,16 @@
+//! phantomjs: --load-images=no
+
+// Compiled for debug, this tests for leaks when not loading images.
+//
+
+var url = TEST_HTTP_BASE + 'load-images-no.html';
+function do_test() {
+    var page = require('webpage').create();
+
+    page.open(url, this.step_func_done (function (status) {
+        assert_equals(status, "success");
+        page.release();
+    }));
+}
+
+async_test(do_test, "load a page two images with --load-images=no");

--- a/test/www/load-images-no.html
+++ b/test/www/load-images-no.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+    <img src="logo.png"/>
+    <img src="phantomjs.png"/>
+</body>
+</html>


### PR DESCRIPTION
This test, when run with phantomjs built with --debug, demonstrates the leak described in #12903. The html loads specifies two images and results in the output below. I've varied the number of images and it appears to leak the number of images + 1 of each of the two objects. I'm investigating.

module/webpage/load-images-no: ERROR
ERROR: Unexpected output on stderr
  LEAK: 3 CachedResource
  LEAK: 3 WebCoreNode
