### PR TITLE
Allow setting devicePixelRatio

### DIFF
--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -443,6 +443,7 @@ WebPage::WebPage(QObject* parent, const QUrl& baseUrl)
 
     m_dpi = qRound(QApplication::primaryScreen()->logicalDotsPerInch());
     m_customWebPage->setViewportSize(QSize(400, 300));
+    m_customWebPage->setDevicePixelRatio(1.0);
 }
 
 WebPage::~WebPage()
@@ -1380,6 +1381,15 @@ void WebPage::_uploadFile(const QString& selector, const QStringList& fileNames)
     }
 
     el.evaluateJavaScript(JS_ELEMENT_CLICK);
+}
+
+void WebPage::setDevicePixelRatio(float ratio) {
+    m_customWebPage->setDevicePixelRatio(ratio);
+}
+
+float WebPage::devicePixelRatio() const
+{
+    return m_customWebPage->devicePixelRatio();
 }
 
 bool WebPage::injectJs(const QString& jsFilePath)

--- a/src/webpage.h
+++ b/src/webpage.h
@@ -71,6 +71,7 @@ class WebPage : public QObject
     Q_PROPERTY(bool navigationLocked READ navigationLocked WRITE setNavigationLocked)
     Q_PROPERTY(QVariantMap customHeaders READ customHeaders WRITE setCustomHeaders)
     Q_PROPERTY(qreal zoomFactor READ zoomFactor WRITE setZoomFactor)
+    Q_PROPERTY(float devicePixelRatio READ devicePixelRatio WRITE setDevicePixelRatio)
     Q_PROPERTY(QVariantList cookies READ cookies WRITE setCookies)
     Q_PROPERTY(QString windowName READ windowName)
     Q_PROPERTY(QObjectList pages READ pages)
@@ -139,6 +140,9 @@ public:
 
     void setZoomFactor(qreal zoom);
     qreal zoomFactor() const;
+
+    void setDevicePixelRatio(float ratio);
+    float devicePixelRatio() const;
 
     /**
      * Value of <code>"window.name"</code> within the main page frame.

--- a/test/module/webpage/device-pixel-ratio.js
+++ b/test/module/webpage/device-pixel-ratio.js
@@ -1,0 +1,14 @@
+var webpage = require('webpage');
+
+test(function () {
+    var defaultPage = webpage.create();
+    assert_deep_equals(defaultPage.devicePixelRatio, 1.0);
+}, "default device pixel ratio");
+
+test(function () {
+    var options = {
+        devicePixelRatio: 1.5
+    };
+    var customPage = webpage.create(options);
+    assert_deep_equals(customPage.devicePixelRatio, options.devicePixelRatio);
+}, "custom device pixel ratio");


### PR DESCRIPTION
When https://github.com/annulen/webkit/pull/515 is merged, the changes here will become valid and should allow users to overwrite the devicePixelRatio as first introduced in this PR:
https://github.com/ariya/phantomjs/pull/12839

The sample should still be valid:

```
var webPage = require('webpage');
var page = webPage.create();

// An example url that supports @2x background-image with the following css:-
/* body {
     background-image: background-image: url('http://retinajs.s3.amazonaws.com/images/backgrounds/bg.jpg');
  }
  @media all and (-webkit-min-device-pixel-ratio: 1.5) {
     body {
       background-image: background-image: url('http://retinajs.s3.amazonaws.com/images/backgrounds/bg@2x.jpg');
    }
} */
var examplePage = 'http://imulus.github.io/retinajs/';

//Pass a dpr of your choosing
page.devicePixelRatio = 1.5; // in this case, >=1.5 to get the retina-supporting bg-image

page.open(examplePage, function() {
   var backgroundImage = page.evaluate(function() {
     return window.getComputedStyle(document.body).backgroundImage;
   });
   console.log(backgroundImage); // returns http://retinajs.s3.amazonaws.com/images/backgrounds/bg@2x.jpg
   page.render('2x.png');
});
```

Fixes https://github.com/ariya/phantomjs/issues/10964
