### PR TITLE
Added stdin with a close() method to child process

### DIFF
--- a/src/childprocess.cpp
+++ b/src/childprocess.cpp
@@ -86,6 +86,26 @@ bool ChildProcessContext::_start(const QString &cmd, const QStringList &args)
     return m_proc.waitForStarted(1000);
 }
 
+qint64 ChildProcessContext::_write(const QString &chunk, const QString &encoding)
+{
+    // Try to get codec for encoding
+    QTextCodec *codec = QTextCodec::codecForName(encoding.toLatin1());
+
+    // If unavailable, attempt UTF-8 codec
+    if ((QTextCodec *)NULL == codec) {
+        codec = QTextCodec::codecForName("UTF-8");
+
+        // Don't even try to write if UTF-8 codec is unavailable
+        if ((QTextCodec *)NULL == codec) {
+            return -1;
+        }
+    }
+
+    qint64 bytesWritten = m_proc.write(codec->fromUnicode(chunk));
+
+    return bytesWritten;
+}
+
 // private slots:
 
 void ChildProcessContext::_readyReadStandardOutput()

--- a/src/childprocess.cpp
+++ b/src/childprocess.cpp
@@ -106,6 +106,11 @@ qint64 ChildProcessContext::_write(const QString &chunk, const QString &encoding
     return bytesWritten;
 }
 
+void ChildProcessContext::_close()
+{
+    m_proc.close();
+}
+
 // private slots:
 
 void ChildProcessContext::_readyReadStandardOutput()

--- a/src/childprocess.cpp
+++ b/src/childprocess.cpp
@@ -108,7 +108,7 @@ qint64 ChildProcessContext::_write(const QString &chunk, const QString &encoding
 
 void ChildProcessContext::_close()
 {
-    m_proc.close();
+    m_proc.closeWriteChannel();
 }
 
 // private slots:

--- a/src/childprocess.h
+++ b/src/childprocess.h
@@ -53,6 +53,8 @@ public:
     Q_INVOKABLE void _setEncoding(const QString &encoding);
     Q_INVOKABLE bool _start(const QString &cmd, const QStringList &args);
 
+    Q_INVOKABLE qint64 _write(const QString &chunk, const QString &encoding);
+
 signals:
     void exit(const int code) const;
 

--- a/src/childprocess.h
+++ b/src/childprocess.h
@@ -58,6 +58,7 @@ public:
     Q_INVOKABLE bool _start(const QString& cmd, const QStringList& args);
 
     Q_INVOKABLE qint64 _write(const QString &chunk, const QString &encoding);
+    Q_INVOKABLE void _close();
 
 signals:
     void exit(const int code) const;

--- a/src/modules/child_process.js
+++ b/src/modules/child_process.js
@@ -145,6 +145,30 @@ function newContext() {
     }
   }
 
+  ctx.stdin = new FakeWritableStream()
+
+  // Emulates `Writable Stream`
+  function FakeWritableStream() {
+    /**
+     * @param chunk String Data to write.
+     * @param encoding String Optional.  Defaults to "utf8".
+     * @returns Number Bytes written; `-1` for failure.
+     */
+    this.write = function write(chunk, encoding) {
+      if ("string" !== typeof encoding) {
+        encoding = "utf8"
+      }
+
+      var bytesWritten = ctx._write(chunk, encoding)
+
+      return bytesWritten
+    }
+
+    this.end = function () {
+      throw new Error("NotYetImplemented")
+    }
+  }
+
   return ctx
 }
 

--- a/src/modules/child_process.js
+++ b/src/modules/child_process.js
@@ -169,7 +169,7 @@ function newContext() {
     }
 
     this.end = function () {
-      throw new Error("NotYetImplemented")
+        ctx._close();
     }
   }
 

--- a/src/modules/child_process.js
+++ b/src/modules/child_process.js
@@ -164,6 +164,10 @@ function newContext() {
       return bytesWritten
     }
 
+    this.close = function close() {
+        ctx._close();
+    }
+
     this.end = function () {
       throw new Error("NotYetImplemented")
     }

--- a/test/module/child_process/basics.js
+++ b/test/module/child_process/basics.js
@@ -1,10 +1,34 @@
 // Test basic child process functionality
 //
 
+var ECHO_SCRIPT = 'echo.py';
+var CAT_SCRIPT = 'cat.py';
+
+setup(function(){
+    var f;
+    var fs = require('fs');
+
+    // Platform-agnostic drop-in replacements for 'echo -n' and 'cat'.
+    // Using sys.stdout.write rather than print here to make the
+    // python code 2/3 agnostic.
+
+    f = fs.open(ECHO_SCRIPT, 'w');
+    f.writeLine('import sys');
+    f.writeLine('');
+    f.writeLine('sys.stdout.write(" ".join(sys.argv[1:]))');
+    f.close();
+
+    f = fs.open(CAT_SCRIPT, 'w');
+    f.writeLine('import sys');
+    f.writeLine('');
+    f.writeLine('sys.stdout.write(sys.stdin.read())');
+    f.close();
+});
+
 async_test(function(){
     var text = "hello";
     var process = require('child_process');
-    var p = process.spawn("echo", ["-n", text]);
+    var p = process.spawn("python", [ECHO_SCRIPT, text]);
     var out = '';
     p.stdout.on('data', function(data) { out += data; });
     p.on('exit', this.step_func_done(
@@ -17,7 +41,7 @@ async_test(function(){
 async_test(function(){
     var text = "hello";
     var process = require('child_process');
-    var p = process.spawn("cat", []);
+    var p = process.spawn("python", [CAT_SCRIPT]);
     var out = '';
     p.stdout.on('data', function(data) { out += data; });
     p.on('exit', this.step_func_done(

--- a/test/module/child_process/basics.js
+++ b/test/module/child_process/basics.js
@@ -4,7 +4,7 @@
 var ECHO_SCRIPT = 'echo.py';
 var CAT_SCRIPT = 'cat.py';
 
-setup(function(){
+var createScripts = function(){
     var f;
     var fs = require('fs');
 
@@ -23,9 +23,17 @@ setup(function(){
     f.writeLine('');
     f.writeLine('sys.stdout.write(sys.stdin.read())');
     f.close();
-});
+};
+
+var deleteScripts = function() {
+    var fs = require('fs');
+    fs.remove(CAT_SCRIPT);
+    fs.remove(ECHO_SCRIPT);
+};
 
 async_test(function(){
+    createScripts();
+    this.add_cleanup(deleteScripts);
     var text = "hello";
     var process = require('child_process');
     var p = process.spawn("python", [ECHO_SCRIPT, text]);
@@ -39,6 +47,8 @@ async_test(function(){
 }, "call a simple subprocess");
 
 async_test(function(){
+    createScripts();
+    this.add_cleanup(deleteScripts);
     var text = "hello";
     var process = require('child_process');
     var p = process.spawn("python", [CAT_SCRIPT]);

--- a/test/module/child_process/basics.js
+++ b/test/module/child_process/basics.js
@@ -1,0 +1,30 @@
+// Test basic child process functionality
+//
+
+async_test(function(){
+    var text = "hello";
+    var process = require('child_process');
+    var p = process.spawn("echo", ["-n", text]);
+    var out = '';
+    p.stdout.on('data', function(data) { out += data; });
+    p.on('exit', this.step_func_done(
+                    function(exitCode) {
+                        assert_equals(exitCode, 0);
+                        assert_equals(out, text);
+                    }));
+}, "call a simple subprocess");
+
+async_test(function(){
+    var text = "hello";
+    var process = require('child_process');
+    var p = process.spawn("cat", []);
+    var out = '';
+    p.stdout.on('data', function(data) { out += data; });
+    p.on('exit', this.step_func_done(
+                    function(exitCode) {
+                        assert_equals(exitCode, 0);
+                        assert_equals(out, text);
+                    }));
+    p.stdin.write(text);
+    p.stdin.close();
+}, "call a subprocess that reads input");


### PR DESCRIPTION
Based on https://github.com/execjosh/phantomjs/commit/a00d70c5b61aef475cd9bc8b374e1113e21ba59e, but additionally supports `stdin.close()`, which is required for using subprocesses that wait for EOF on stdin before exiting.
