### PR TITLE
Test load-images=yes and load-images=no.

### DIFF
--- a/test/lib/www/load-images.html
+++ b/test/lib/www/load-images.html
@@ -1,6 +1,9 @@
+<!DOCTYPE html>
 <html>
+<head>
+</head>
 <body>
-    <img src="logo.png"/>
-    <img src="phantomjs.png"/>
+    <img src="logo.png" alt="logo">
+    <img src="phantomjs.png" alt="phantomjs">
 </body>
 </html>

--- a/test/lib/www/load-images.html
+++ b/test/lib/www/load-images.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+    <img src="logo.png"/>
+    <img src="phantomjs.png"/>
+</body>
+</html>

--- a/test/module/webpage/load-images-no.js
+++ b/test/module/webpage/load-images-no.js
@@ -1,0 +1,52 @@
+//! phantomjs: --load-images=no
+
+// Compiled for debug, this tests for leaks when not loading images.
+//
+
+var url = TEST_HTTP_BASE + 'load-images.html';
+
+function do_test() {
+    var page = require('webpage').create();
+
+    var numImagesRequested = 0;
+    var numImagesLoaded = 0;
+    
+    page.onResourceRequested = this.step_func(function (resource) {
+        if (/\.png$/.test(resource.url)) ++numImagesRequested;
+    });
+
+    page.onResourceReceived = this.step_func(function (resource) {
+        if (resource.stage === 'end' && /\.png$/.test(resource.url)) ++numImagesLoaded;
+    });
+
+    function checkImageCounts ()
+    {
+        var imageCounts = page.evaluate (function() {    
+            "use strict";
+            try
+            {
+                var images = document.getElementsByTagName('img');
+                var imageCounts = {};
+                imageCounts.numImages = images.length;
+                imageCounts.numComplete = Array.prototype.reduce.call(images, function(n, image) { return n + (image.complete? 1 : 0); }, 0);
+                return imageCounts;
+            }
+            catch(err)
+            {
+                return undefined;
+            }
+        });
+        assert_equals(imageCounts.numImages, 2);
+        assert_equals(imageCounts.numComplete, 2);  // Images are complete even when loading suppressed.
+        assert_equals(numImagesRequested, 0);
+        assert_equals(numImagesLoaded, 0);
+        page.release();
+    }
+    
+    page.open(url, this.step_func_done (function (status) {
+        assert_equals(status, "success");
+        checkImageCounts ();
+    }));
+}
+
+async_test(do_test, "load a page two images with --load-images=no");

--- a/test/module/webpage/load-images-no.js
+++ b/test/module/webpage/load-images-no.js
@@ -1,11 +1,11 @@
 //! phantomjs: --load-images=no
+"use strict";
 
 // Compiled for debug, this tests for leaks when not loading images.
-//
 
 var url = TEST_HTTP_BASE + 'load-images.html';
 
-function do_test() {
+async_test(function testLoadImagesNo () {
     var page = require('webpage').create();
 
     var numImagesRequested = 0;
@@ -21,7 +21,7 @@ function do_test() {
 
     function checkImageCounts ()
     {
-        var imageCounts = page.evaluate (function() {    
+        var imageCounts = page.evaluate (function countImages() {    
             "use strict";
             try
             {
@@ -40,13 +40,11 @@ function do_test() {
         assert_equals(imageCounts.numComplete, 2);  // Images are complete even when loading suppressed.
         assert_equals(numImagesRequested, 0);
         assert_equals(numImagesLoaded, 0);
-        page.release();
     }
     
-    page.open(url, this.step_func_done (function (status) {
+    page.open(url, this.step_func_done (function pageOpened(status) {
         assert_equals(status, "success");
-        checkImageCounts ();
+        checkImageCounts();
+        page.release();
     }));
-}
-
-async_test(do_test, "load a page two images with --load-images=no");
+}, "load a page two images with --load-images=no");

--- a/test/module/webpage/load-images-no.js
+++ b/test/module/webpage/load-images-no.js
@@ -37,7 +37,7 @@ async_test(function testLoadImagesNo () {
             }
         });
         assert_equals(imageCounts.numImages, 2);
-        assert_equals(imageCounts.numComplete, 2);  // Images are complete even when loading suppressed.
+        assert_equals(imageCounts.numComplete, 0);
         assert_equals(numImagesRequested, 0);
         assert_equals(numImagesLoaded, 0);
     }

--- a/test/module/webpage/load-images-yes.js
+++ b/test/module/webpage/load-images-yes.js
@@ -1,49 +1,48 @@
 //! phantomjs: --load-images=yes
+"use strict";
 
 var url = TEST_HTTP_BASE + 'load-images.html';
 
-function do_test() {
+async_test(function testLoadImagesYes () {
     var page = require('webpage').create();
 
-	var numImagesRequested = 0;
-	var numImagesLoaded = 0;
-	
+    var numImagesRequested = 0;
+    var numImagesLoaded = 0;
+    
     page.onResourceRequested = this.step_func(function (resource) {
-    	if (/\.png$/.test(resource.url)) ++numImagesRequested;
+        if (/\.png$/.test(resource.url)) ++numImagesRequested;
     });
 
     page.onResourceReceived = this.step_func(function (resource) {
         if (resource.stage === 'end' && /\.png$/.test(resource.url)) ++numImagesLoaded;
     });
 
-	function checkImageCounts ()
-	{
-		var imageCounts = page.evaluate (function() {    
-			"use strict";
-			try
-			{
-				var images = document.getElementsByTagName('img');
-				var imageCounts = {};
-				imageCounts.numImages = images.length;
-				imageCounts.numComplete = Array.prototype.reduce.call(images, function(n, image) { return n + (image.complete? 1 : 0); }, 0);
-				return imageCounts;
-			}
-			catch(err)
-			{
-				return undefined;
-			}
-		});
-		assert_equals(imageCounts.numImages, 2);
-		assert_equals(imageCounts.numComplete, 2);	// Images are complete even when loading suppressed.
+    function checkImageCounts ()
+    {
+        var imageCounts = page.evaluate (function countImages() {    
+            "use strict";
+            try
+            {
+                var images = document.getElementsByTagName('img');
+                var imageCounts = {};
+                imageCounts.numImages = images.length;
+                imageCounts.numComplete = Array.prototype.reduce.call(images, function(n, image) { return n + (image.complete? 1 : 0); }, 0);
+                return imageCounts;
+            }
+            catch(err)
+            {
+                return undefined;
+            }
+        });
+        assert_equals(imageCounts.numImages, 2);
+        assert_equals(imageCounts.numComplete, 2);  // Images are complete even when loading suppressed.
         assert_equals(numImagesRequested, 2);
         assert_equals(numImagesLoaded, 2);
-		page.release();
-	}
-	
-    page.open(url, this.step_func_done (function (status) {
+    }
+    
+    page.open(url, this.step_func_done (function pageOpened(status) {
         assert_equals(status, "success");
-        checkImageCounts ();
+        checkImageCounts();
+        page.release();
     }));
-}
-
-async_test(do_test, "load a page two images with --load-images=no");
+}, "load a page two images with --load-images=yes");

--- a/test/module/webpage/load-images-yes.js
+++ b/test/module/webpage/load-images-yes.js
@@ -35,7 +35,7 @@ async_test(function testLoadImagesYes () {
             }
         });
         assert_equals(imageCounts.numImages, 2);
-        assert_equals(imageCounts.numComplete, 2);  // Images are complete even when loading suppressed.
+        assert_equals(imageCounts.numComplete, 2);
         assert_equals(numImagesRequested, 2);
         assert_equals(numImagesLoaded, 2);
     }

--- a/test/module/webpage/load-images-yes.js
+++ b/test/module/webpage/load-images-yes.js
@@ -1,0 +1,49 @@
+//! phantomjs: --load-images=yes
+
+var url = TEST_HTTP_BASE + 'load-images.html';
+
+function do_test() {
+    var page = require('webpage').create();
+
+	var numImagesRequested = 0;
+	var numImagesLoaded = 0;
+	
+    page.onResourceRequested = this.step_func(function (resource) {
+    	if (/\.png$/.test(resource.url)) ++numImagesRequested;
+    });
+
+    page.onResourceReceived = this.step_func(function (resource) {
+        if (resource.stage === 'end' && /\.png$/.test(resource.url)) ++numImagesLoaded;
+    });
+
+	function checkImageCounts ()
+	{
+		var imageCounts = page.evaluate (function() {    
+			"use strict";
+			try
+			{
+				var images = document.getElementsByTagName('img');
+				var imageCounts = {};
+				imageCounts.numImages = images.length;
+				imageCounts.numComplete = Array.prototype.reduce.call(images, function(n, image) { return n + (image.complete? 1 : 0); }, 0);
+				return imageCounts;
+			}
+			catch(err)
+			{
+				return undefined;
+			}
+		});
+		assert_equals(imageCounts.numImages, 2);
+		assert_equals(imageCounts.numComplete, 2);	// Images are complete even when loading suppressed.
+        assert_equals(numImagesRequested, 2);
+        assert_equals(numImagesLoaded, 2);
+		page.release();
+	}
+	
+    page.open(url, this.step_func_done (function (status) {
+        assert_equals(status, "success");
+        checkImageCounts ();
+    }));
+}
+
+async_test(do_test, "load a page two images with --load-images=no");


### PR DESCRIPTION
Tests the function of the --load-images command line option. When compiled with --debug, demonstrates the leak described in #12903.

Replaces previous pull request #13919. 
