### PR TITLE
Update 2000-01-01-quick-start.md - added trailing slash to example.com/ url

### DIFF
--- a/_posts/documentation/learn/2000-01-01-quick-start.md
+++ b/_posts/documentation/learn/2000-01-01-quick-start.md
@@ -44,7 +44,8 @@ The following script demonstrates the simplest use of page object. It loads exam
 
 ```javascript
 var page = require('webpage').create();
-page.open('http://example.com', function(status) {
+page.open('http://example.com/', function(status) {
+  // Trailing slash on the above url is required
   console.log("Status: " + status);
   if(status === "success") {
     page.render('example.png');


### PR DESCRIPTION
I was trying to go through this quickstart and wasted a bunch of time trying to figure out why the simple example wasn't working for me. I entered `google.com` because the example uses `example.com`.

``` javascript
var page = require('webpage').create();
page.open('http://google.com', function(status) {
  console.log("Status: " + status);
  if(status === "success") {
    page.render('google.png');
  }
  phantom.exit();
});
```

I finally checked the screen-capture documentation : `http://phantomjs.org/screen-capture.html` and noticed that nearly the same example adds a trailing slash to the url. 

``` javascript
var page = require('webpage').create();
page.open('http://github.com/', function() {
  page.render('github.png');
  phantom.exit();
});
```

Hopefully this saves someone else a small headache. 
