### PR TITLE
Actual implementation of custom IP in ghostdriver

### DIFF
--- a/src/ghostdriver/main.js
+++ b/src/ghostdriver/main.js
@@ -66,7 +66,7 @@ try {
     router = new ghostdriver.RouterReqHand();
 
     // Start the server
-    if (server.listen(ghostdriver.config.port, { "keepAlive" : true }, router.handle)) {
+    if (server.listen(ghostdriver.config.ip+":"+ghostdriver.config.port, { "keepAlive" : true }, router.handle)) {
         _log.info("Main", "running on port " + server.port);
 
         // If a Selenium Grid HUB was provided, register to it!


### PR DESCRIPTION
Fixes a simple issue with Ghostdriver not using custom defined ip as per #12553.

The problem is solved by allowing Ghostdriver to use the given IP that is set default by the config or as given by a service argument. This allows the use of PhantomJS webdriver in the Openshift PaaS environment.
