### PR TITLE
Wrapping the supplied script to catch syntax errors and exit instead of hanging indefinitely.

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -131,6 +131,10 @@ bool injectJsInFrame(const QString& jsFilePath, const QString& jsFileLanguage, c
         }
         return false;
     }
+    if (startingScript)
+    {
+        scriptBody=QString("var __run; try { __run=eval(\"(function() {%1})\"); } catch(error) { console.log(error); console.log(error.stack); phantom.exit(); } __run();").arg(scriptBody.replace('\\',"\\\\").replace('\n',"\\n").replace('\"',"\\\""));
+    }
     // Execute JS code in the context of the document
     targetFrame->evaluateJavaScript(scriptBody, QString(JAVASCRIPT_SOURCE_CODE_URL).arg(QFileInfo(scriptPath).fileName()));
     return true;


### PR DESCRIPTION
This seems to be at least a partial fix for #10687 which has been around for quite a long time.
