### PR TITLE
Fix for Issues #11944 #12382 - pass along a custom referrer

### DIFF
--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -924,6 +924,13 @@ void WebPage::openUrl(const QString& address, const QVariant& op, const QVariant
         }
     }
 
+    // pass custom Headers to the request
+    QMapIterator<QString, QVariant> i(customHeaders());
+    while (i.hasNext()) {
+        i.next();
+        request.setRawHeader(i.key().toUtf8(), i.value().toString().toUtf8());
+    }
+
     if (operation.isEmpty()) {
         operation = "get";
     }

--- a/test/module/webpage/custom-referrer.js
+++ b/test/module/webpage/custom-referrer.js
@@ -1,0 +1,24 @@
+async_test(function () {
+    var webpage = require('webpage');
+    var page = webpage.create();
+
+    // Set Custom Refer(r)er by using customHeaders
+    // See https://en.wikipedia.org/wiki/HTTP_referer in case you wonder about the spelling.
+    page.customHeaders =  {
+        'Referer': 'http://example.com'
+    };
+
+    page.open(TEST_HTTP_BASE + 'echo', this.step_func_done(function (status) {
+        
+        // Check whether document.referrer returns the custom referrer as set above using a custom Header.
+        var document_referrer = page.evaluate(function () {
+                return document.referrer;
+        });
+
+        assert_equals(document_referrer, 'http://example.com');
+
+    }));
+
+    
+
+}, "A custom referrer as set with page.customHeaders should be accessible using document.referrer");


### PR DESCRIPTION
Currently if you set a custom referrer with page.customHeaders, document.referrer remains untouched. 
This is described in detail within [Issue #11944](https://github.com/ariya/phantomjs/issues/11944).

I've added a test to reflect the issue, and a patch to pass along any custom Headers to the request Object. 

This PR replaces my initial [Pull request #12318](https://github.com/ariya/phantomjs/pull/12318)
