### PR TITLE
Fixed required module name and spawn execution

### DIFF
--- a/_posts/api/child_process/method/2000-01-01-spawn.md
+++ b/_posts/api/child_process/method/2000-01-01-spawn.md
@@ -8,16 +8,18 @@ permalink: api/child_process/method/spawn.html
 ## Examples
 
 ```javascript
-var page  = require('page').create();
+var page  = require('webpage').create();
 var spawn = require('child_process').spawn;
 
 page.open('http://google.com', function(status){
   if( status == 'success' ) {
     page.render('/tmp/google-snapshot.jpg');
     spawn('/usr/bin/sensible-browser', 'file:///tmp/google-snapshot.jpg');
-    phantom.exit();
   }
-})
+  setTimeout(function(){
+    phantom.exit();
+  },2000);
+});
 
 ```
 


### PR DESCRIPTION
Fixed required webpage module name, previously it was require('page') which is incorrect. And also added setTimeout function for phantom.exit() as it was getting called before spawn() call can get completed.
