### PR TITLE
[WIP] Add callbacks and feature to download files

### DIFF
--- a/src/modules/webpage.js
+++ b/src/modules/webpage.js
@@ -266,6 +266,8 @@ function decorateNewPage(opts, page) {
 
     definePageSignalHandler(page, handlers, "onClosing", "closing");
 
+    definePageSignalHandler(page, handlers, "onFileDownloadError", "fileDownloadError");
+
     // Private callback for "page.open()"
     definePageSignalHandler(page, handlers, "_onPageOpenFinished", "loadFinished");
 
@@ -454,6 +456,9 @@ function decorateNewPage(opts, page) {
 
     // Calls from within the page when some javascript code running to long
     definePageCallbackHandler(page, handlers, "onLongRunningScript", "_getJsInterruptCallback");
+
+    // Calls arrive to this handler when the web page initiates file download
+    definePageCallbackHandler(page, handlers, "onFileDownload", "_getFileDownloadCallback");
 
     page.event = {};
     page.event.modifier = {

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -82,6 +82,7 @@
 
 #define STDOUT_FILENAME "/dev/stdout"
 #define STDERR_FILENAME "/dev/stderr"
+#define MIN_BUFFER_SIZE 4096
 
 
 /**
@@ -249,6 +250,11 @@ protected:
         return newPage->m_customWebPage;
     }
 
+    void fileDownloadRequested(const QString& url, const QVariantMap& responseData)
+    {
+        emit m_webPage->fileDownloadRequested(QUrl(url), responseData);
+    }
+
 private:
     WebPage* m_webPage;
     QString m_userAgent;
@@ -277,6 +283,7 @@ public:
         , m_jsConfirmCallback(NULL)
         , m_jsPromptCallback(NULL)
         , m_jsInterruptCallback(NULL)
+        , m_fileDownloadCallback(NULL)
     {
     }
 
@@ -330,6 +337,17 @@ public:
         return m_jsInterruptCallback;
     }
 
+    QObject *getFileDownloadCallback()
+    {
+        qDebug() << "WebpageCallbacks - getFileDownloadCallback";
+
+        if (!m_fileDownloadCallback) {
+            m_fileDownloadCallback = new Callback(this);
+        }
+
+        return m_fileDownloadCallback;
+    }
+
 public slots:
     QVariant call(const QVariantList& arguments)
     {
@@ -345,6 +363,7 @@ private:
     Callback* m_jsConfirmCallback;
     Callback* m_jsPromptCallback;
     Callback* m_jsInterruptCallback;
+    Callback* m_fileDownloadCallback;
 
     friend class WebPage;
 };
@@ -396,6 +415,7 @@ WebPage::WebPage(QObject* parent, const QUrl& baseUrl)
     connect(m_customWebPage, SIGNAL(windowCloseRequested()), this, SLOT(close()), Qt::QueuedConnection);
     connect(m_customWebPage, SIGNAL(loadProgress(int)), this, SLOT(updateLoadingProgress(int)));
     connect(m_customWebPage, SIGNAL(repaintRequested(QRect)), this, SLOT(handleRepaintRequested(QRect)), Qt::QueuedConnection);
+    connect(m_customWebPage, SIGNAL(unsupportedContent(QNetworkReply*)), this, SLOT(downloadRequested(QNetworkReply*)));
 
 
     // Start with transparent background.
@@ -410,6 +430,7 @@ WebPage::WebPage(QObject* parent, const QUrl& baseUrl)
     m_mainFrame->setScrollBarPolicy(Qt::Horizontal, Qt::ScrollBarAlwaysOff);
     m_mainFrame->setScrollBarPolicy(Qt::Vertical, Qt::ScrollBarAlwaysOff);
 
+    m_customWebPage->setForwardUnsupportedContent(true);
     QWebSettings* pageSettings = m_customWebPage->settings();
     pageSettings->setAttribute(QWebSettings::OfflineStorageDatabaseEnabled, true);
     pageSettings->setAttribute(QWebSettings::OfflineWebApplicationCacheEnabled, true);
@@ -829,6 +850,18 @@ void WebPage::javascriptInterrupt()
             m_shouldInterruptJs = res.toBool();
         }
     }
+}
+
+QString WebPage::fileDownloadPrompt(const QUrl& url, const QVariantMap& responseData)
+{
+    if (m_callbacks->m_fileDownloadCallback) {
+        QVariant res = m_callbacks->m_fileDownloadCallback->call(QVariantList() << url << responseData);
+        if (!res.isNull() && res.canConvert<QString>()) {
+            return res.toString();
+        }
+    }
+
+    return "";
 }
 
 void WebPage::finish(bool ok)
@@ -1417,6 +1450,15 @@ QObject* WebPage::_getJsInterruptCallback()
     return m_callbacks->getJsInterruptCallback();
 }
 
+QObject *WebPage::_getFileDownloadCallback()
+{
+    if (!m_callbacks) {
+        m_callbacks = new WebpageCallbacks(this);
+    }
+
+    return m_callbacks->getFileDownloadCallback();
+}
+
 void WebPage::sendEvent(const QString& type, const QVariant& arg1, const QVariant& arg2, const QString& mouseButton, const QVariant& modifierArg)
 {
     Qt::KeyboardModifiers keyboardModifiers(modifierArg.toInt());
@@ -1777,6 +1819,78 @@ void WebPage::stopJavaScript()
 void WebPage::clearMemoryCache()
 {
     QWebSettings::clearMemoryCaches();
+}
+
+void WebPage::downloadRequested(QNetworkReply* networkReply)
+{
+    QUrl downloadUrl = networkReply->url();
+    qDebug() << "WebPage - downloadRequested:" << downloadUrl;
+
+    QVariant header = networkReply->header(QNetworkRequest::ContentLengthHeader);
+    bool ok;
+    int size = header.toInt(&ok);
+    if (ok && size == 0)
+        return;
+
+    QVariantMap responseData;
+    responseData["filename"] = QFileInfo(downloadUrl.toString()).fileName();
+    responseData["size"] = size;
+    responseData["contentType"] = networkReply->header(QNetworkRequest::ContentTypeHeader).toString();
+
+    QString filename = fileDownloadPrompt(downloadUrl, responseData);
+
+    if (filename.isEmpty()) {
+        qDebug() << "WebPage - downloadRequested. File download aborted (filename is empty)";
+        networkReply->abort();
+    } else {
+        QString downloadingFilename = QFileInfo(downloadUrl.toString()).fileName();
+        QFileInfo fileInfo(filename);
+
+        if (fileInfo.isRelative()) {
+            fileInfo.makeAbsolute();
+        }
+
+        if (fileInfo.isDir()) {
+            // check if the target directory is writable
+            if (!fileInfo.isWritable()) {
+                emit fileDownloadError("Requested path is not writable");
+                networkReply->abort();
+                return;
+            }
+
+            m_downloadingFiles[networkReply] = fileInfo.path() + downloadingFilename;
+        } else {
+            m_downloadingFiles[networkReply]  = fileInfo.filePath();
+        }
+
+        connect(networkReply, SIGNAL(finished()), this, SLOT(downloadFinished()));
+    }
+}
+
+void WebPage::downloadFinished()
+{
+    QNetworkReply* reply = qobject_cast<QNetworkReply*>(sender());
+
+    if (reply && reply->error() == QNetworkReply::NoError && m_downloadingFiles.contains(reply)) {
+        qDebug() << "WebPage - downloadFinished";
+        QFile file(m_downloadingFiles[reply]);
+
+        if (!file.open(QIODevice::WriteOnly)) {
+            emit fileDownloadError("Error opening output file: " + file.errorString());
+        } else {
+            qint64 bufferSize = qMin<qint64>(MIN_BUFFER_SIZE, reply->size());
+            QByteArray buffer;
+            while (!(buffer = reply->read(bufferSize)).isEmpty()) {
+                file.write(buffer);
+            }
+            file.close();
+        }
+
+        m_downloadingFiles.remove(reply);
+
+        // We can safely mark this QNetworkReply for deleting later since Webkit will not handle it
+        reply->deleteLater();
+    }
 }
 
 #include "webpage.moc"

--- a/src/webpage.h
+++ b/src/webpage.h
@@ -261,6 +261,7 @@ public slots:
     QObject* _getJsConfirmCallback();
     QObject* _getJsPromptCallback();
     QObject* _getJsInterruptCallback();
+    QObject *_getFileDownloadCallback();
     void _uploadFile(const QString& selector, const QStringList& fileNames);
     void sendEvent(const QString& type, const QVariant& arg1 = QVariant(), const QVariant& arg2 = QVariant(), const QString& mouseButton = QString(), const QVariant& modifierArg = QVariant());
 
@@ -504,6 +505,9 @@ signals:
     void rawPageCreated(QObject* page);
     void closing(QObject* page);
     void repaintRequested(const int x, const int y, const int width, const int height);
+    void fileDownloadRequested(const QUrl &url, const QVariantMap& responseData);
+    void fileDownloadFinished();
+    void fileDownloadError(const QString &error);
 
 private slots:
     void finish(bool ok);
@@ -512,6 +516,8 @@ private slots:
     void handleRepaintRequested(const QRect& dirtyRect);
     void handleUrlChanged(const QUrl& url);
     void handleCurrentFrameDestroyed();
+    void downloadRequested(QNetworkReply* networkReply);
+    void downloadFinished();
 
 private:
     QImage renderImage();
@@ -531,6 +537,7 @@ private:
     bool javaScriptConfirm(const QString& msg);
     bool javaScriptPrompt(const QString& msg, const QString& defaultValue, QString* result);
     void javascriptInterrupt();
+    QString fileDownloadPrompt(const QUrl& url, const QVariantMap& responseData);
 
 private:
     CustomPage* m_customWebPage;
@@ -550,6 +557,7 @@ private:
     bool m_shouldInterruptJs;
     CookieJar* m_cookieJar;
     qreal m_dpi;
+    QMap<QNetworkReply*, QString> m_downloadingFiles;
 
     friend class Phantom;
     friend class CustomPage;


### PR DESCRIPTION
This is re-implementation of my old branch of the feature to download files.

Per discussion: https://groups.google.com/d/topic/phantomjs/JChUakj--24/discussion

This pull request adds 3 new callbacks to a `WebPage` object: `onFileDownload`, `onFileDownloadError` and `onDownloadFinished`.

**onFileDownload:**

```
page.onFileDownload = function(url, data) {
  return 'path/where/to/save/file';
};
```

You can return a string with a file name, directory (in this case filename will be taken from HTTP headers), or an empty string (this will interrupt downloading).
**Arguments:**
- url - source URL
- data - array with download info: `filename`, `size` (file size) and `contentType`.

**onFileDownloadError:**

```
page.onFileDownloadError = function(error) {
}
```

**Arguments:**
- error - a string representing an error occured.

**onDownloadFinished:**

```
page.onDownloadFinished = function() { }
```

This is a simple callback to notify the user about finished download.

**TODO:**
- [ ] Tests!
- [ ] Expose `downloadFiles` to the user.

**Don't merge without tests.**

Issue: #10052
