### PR TITLE
Added a bug-reporting.html page that directs people to crash-reporting.html

### DIFF
--- a/_posts/documentation/contribute/2016-06-03-bug-reporting.md
+++ b/_posts/documentation/contribute/2016-06-03-bug-reporting.md
@@ -1,0 +1,8 @@
+---
+layout: post
+title: Bug Reporting
+categories: docs docs-contribute
+permalink: bug-reporting.html
+---
+
+The content of this page is moved to [Crash Reporting](crash-reporting.html).


### PR DESCRIPTION
phantomjs 2.1.1 writes out:

> Please read the bug reporting guide at
> http://phantomjs.org/bug-reporting.html and file a bug report.

The page just says that it has moved to crash-reporting.html and provides a link.

This is modelled on http://phantomjs.org/contributing.html
