### PR TITLE
Add an organization in "Who's using PhantomJS?"

### DIFF
--- a/_posts/documentation/explore/2000-01-06-users.md
+++ b/_posts/documentation/explore/2000-01-06-users.md
@@ -46,6 +46,7 @@ The following open-source projects are using PhantomJS as part of the testing wo
 * [Impact Marketing Solutions](http://www.solutionsbyimpact.com) uses PhantomJS for dynamic data visualization, high-resolution print graphics generation, CI testing (QUnit+JenkinsCI), screenshot capture for visual proofing and approval workflows and web-to-print rendering solutions.
 * [Pantera Commerce](http://www.panteracom.com) uses PhantomJS on Pantera Store to make large-scale e-commerce stores crawlable by search engines.
 * [Parse.ly](http://parse.ly) uses PhantomJS to generate weekly digest e-mails to writers and editors that include personalized analytics about their content; built with d3.js, Jinja2 and the PhantomJS ``render()`` function. (Source: [Whatever It Takes](http://blog.parsely.com/post/34241210620/whatever-it-takes).)
+* [Phantombuster](https://phantombuster.com/cloud-services) uses PhantomJS to provide a generic task automation service (SaaS)
 * [Shopetti](https://www.shopetti.com) uses PhantomJS with Node.JS to generate price monitoring and sales alerts on different brands.
 * [Superius](http://www.superius.hr) uses PhantomJS for QUnit tests of their dynamically created mobile business web applications.
 * [Test Anywhere](https://testanywhere.co/) uses PhantomJS to deliver testing services to their customers.


### PR DESCRIPTION
Add an organization called Phantombuster in the "Who's using PhantomJS?" page. I'm not sure if I should put it here or in the "Related projects" page so I've made two pull requests.
