### PR TITLE
fixes PDF multipaged rendering; swaps incorrect QPageLayout::Orientat…

### DIFF
--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -1212,7 +1212,7 @@ bool WebPage::renderPdf(QPdfWriter& pdfWriter)
     } else if (paperSize.contains("format")) {
         const QPageLayout::Orientation orientation = paperSize.contains("orientation")
                 && paperSize.value("orientation").toString().compare("landscape", Qt::CaseInsensitive) == 0 ?
-                QPageLayout::Portrait : QPageLayout::Landscape;
+                QPageLayout::Landscape : QPageLayout::Portrait;
         pdfWriter.setPageOrientation(orientation);
         static const struct {
             QString format;
@@ -1288,10 +1288,7 @@ bool WebPage::renderPdf(QPdfWriter& pdfWriter)
     }
 
     pdfWriter.setPageMargins(QMarginsF(marginLeft, marginTop, marginRight, marginBottom), QPageLayout::Point);
-
-    QPainter painter(&pdfWriter);
-    m_mainFrame->render(&painter);
-    painter.end();
+    m_mainFrame->print(&pdfWriter, this);
 
     return true;
 }


### PR DESCRIPTION
**For issue https://github.com/ariya/phantomjs/issues/14268**
**Depends on https://github.com/Vitallium/qtwebkit/pull/12** or use my branch: https://github.com/ricokahler/qtwebkit/tree/add-qpdfwriter-support-to-qwebframe

The pull request referenced above adds a `print(...)` method to QWebFrame that takes in a `QPdfWriter`. 

The current master (https://github.com/ariya/phantomjs/commit/6090f5457d2051ab374264efa18f655fa3e15e79) breaks multi-paged PDF support because `WebPage::renderPdf(QPdfWriter& pdfWrtier)` calls `m_mainFrame->render(&painter)` rather than `m_mainFrame->print(&qprinter)`. The pull request https://github.com/Vitallium/qtwebkit/pull/12 simply adds support for `m_mainFrame->print(qpdfWriter)`
