### PR TITLE
Add WebPage#cookiesForUrl (#14391)

### DIFF
--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -877,6 +877,12 @@ QVariantList WebPage::cookies() const
     return m_cookieJar->cookiesToMap(this->url());
 }
 
+QVariantList WebPage::cookiesForUrl(const QString& url) const
+{
+    // Return all the Cookies visible to this Page, at the specified URL, as a list of Maps (aka JSON in JS space)
+    return m_cookieJar->cookiesToMap(url);
+}
+
 bool WebPage::addCookie(const QVariantMap& cookie)
 {
     return m_cookieJar->addCookieFromMap(cookie, this->url());

--- a/src/webpage.h
+++ b/src/webpage.h
@@ -407,6 +407,14 @@ public slots:
      */
     QVariantList cookies() const;
     /**
+     * Cookies visible by this Page, at the specified URL.
+     *
+     * @see WebPage::setCookies for details on the format
+     * @brief cookiesForUrl
+     * @return QList of QVariantMap cookies visible to this Page, at the specified URL
+     */
+    QVariantList cookiesForUrl(const QString& url) const;
+    /**
      * Add a Cookie in QVariantMap format
      * @see WebPage::setCookies for details on the format
      * @brief addCookie

--- a/test/module/webpage/cookies.js
+++ b/test/module/webpage/cookies.js
@@ -109,3 +109,40 @@ async_test(function () {
         assert_no_property(headers, 'cookie');
     }));
 }, "page.cookies provides cookies only to appropriate requests");
+
+test(function() {
+    var page = new WebPage();
+    
+    page.cookies = [
+        {
+            'name' : 'Valid-Cookie-Name-1',
+            'value' : 'Valid-Cookie-Value-1',
+            'domain' : 'localhost'
+        },{
+            'name' : 'Valid-Cookie-Name-2',
+            'value' : 'Valid-Cookie-Value-2',
+            'domain' : 'localhost',
+            'path': '/bar'
+        },{
+            'name' : 'Valid-Cookie-Name-3',
+            'value' : 'Valid-Cookie-Value-3',
+            'domain' : 'foo.example',
+            'path': '/bar'
+        },{
+            'name' : 'Valid-Cookie-Name-4',
+            'value' : 'Valid-Cookie-Value-4',
+            'domain' : 'foo.example',
+            'path': '/bar'
+        },{
+            'name' : 'Valid-Cookie-Name-5',
+            'value' : 'Valid-Cookie-Value-5',
+            'domain' : 'foo.example',
+            'path': '/foo'
+        }];
+    
+    assert_equals(page.cookiesForUrl('http://localhost/bar').length, 2);
+    assert_equals(page.cookiesForUrl('http://localhost/').length, 1);
+    assert_equals(page.cookiesForUrl('http://foo.example/').length, 0);
+    assert_equals(page.cookiesForUrl('http://foo.example/bar').length, 2);
+    assert_equals(page.cookiesForUrl('http://foo.example/foo').length, 1);
+}, "page.cookiesForUrl returns the cookies for the specified URL");


### PR DESCRIPTION
This pull request is a simple fix for issue https://github.com/ariya/phantomjs/issues/14391. It adds the method `cookiesForUrl` to the `WebPage` class, and a test.

``` js
page.onResourceRequested = function (request, networkRequest) {
    var cookies = page.cookiesForUrl(request.url);
};
```
