### PR TITLE
Fix weird formatting on REPL documentation page

### DIFF
--- a/_posts/documentation/get-started/2000-01-05-repl.md
+++ b/_posts/documentation/get-started/2000-01-05-repl.md
@@ -9,7 +9,7 @@ From version 1.5 PhantomJS will provide an Interactive Mode, also known as REPL:
 
 ### Why a REPL?
 
-Sometimes you feel the urge to test out some little/medium size Javascript code, to see how `x` or `y` works (and if it does at all). So, usually the choice would be to jump on [Firebug](http://getfirebug.com/) (or the [Webkit Inspector](http://trac.webkit.org/wiki/Web%20Inspector) or [Opera Dragonfly](http://www.opera.com/dragonfly/) or...) and type away.
+Sometimes you feel the urge to test out some little/medium size Javascript code, to see how `x` or `y` works (or if they do at all). So, usually the choice would be to jump on [Firebug](http://getfirebug.com/) (or the [Webkit Inspector](http://trac.webkit.org/wiki/Web%20Inspector) or [Opera Dragonfly](http://www.opera.com/dragonfly/) or...) and type away.
 
 Well, PhantomJS is a commandline tool. It's designed for the commandline; its habitat is your console. So, as such, a way was missing to have a ready to go mode. Even Node.js has one!
 
@@ -63,7 +63,7 @@ To exit? The usual: either type `phantom.exit()` or CTRL+C or CTRL+D.
 
 ### Auto-completion
 
-One of the feature that we saw could bring a lot of value is auto-completion. Sometimes, as much as people like documentation, if they could get a list of methods or properties by just tapping TAB (i.e. →|) it could make all the difference:
+One of the feature that we saw could bring a lot of value is auto-completion. Sometimes, as much as people like documentation, if they could get a list of methods or properties by just tapping TAB (i.e. `→|`) it could make all the difference:
 
 ```bash
 phantomjs> phantom.→|


### PR DESCRIPTION
The | character causes Jekyll to think you're trying to create separate columns, which then makes reading the sentence a bit more of chore. Adding code tags around it stops that behavior.
