### PR TITLE
Issue #14497: Don't force Content-Type header on POST request with empty body

### DIFF
--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -323,11 +323,16 @@ QNetworkReply* NetworkAccessManager::createRequest(Operation op, const QNetworkR
 
     // http://code.google.com/p/phantomjs/issues/detail?id=337
     if (op == QNetworkAccessManager::PostOperation) {
-        if (outgoingData) { postData = outgoingData->peek(MAX_REQUEST_POST_BODY_SIZE); }
-        QString contentType = req.header(QNetworkRequest::ContentTypeHeader).toString();
-        if (contentType.isEmpty()) {
-            req.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
-        }
+      	if (outgoingData) {
+        		postData = outgoingData->peek(MAX_REQUEST_POST_BODY_SIZE);
+        		QString contentType = req.header(QNetworkRequest::ContentTypeHeader).toString();
+        		if (contentType.isEmpty() && postData.size() > 0) {
+        			// Added a test to see if we actually have data before setting the header, some webservices
+        			// crashes when sending an invalid Content-Type (Error 415), so not sending the header at all
+        			// can avoid us those troubles.
+            		req.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
+        		}
+				}
     }
 
     // set custom HTTP headers


### PR DESCRIPTION
QT will still complain about that though if there is a query string in the request because the patch here: https://codereview.qt-project.org/#/c/99686/2/src/network/access/qhttpnetworkrequest.cpp has a flaw. It should not have the OR request.d->url.hasQuery() at the end, that's not what Content-Type is for.

https://github.com/ariya/phantomjs/issues/14497
