### PR TITLE
typo: webserve -> webserver

### DIFF
--- a/_posts/api/webpage/method/2000-01-01-render-buffer.md
+++ b/_posts/api/webpage/method/2000-01-01-render-buffer.md
@@ -7,7 +7,7 @@ permalink: api/webpage/method/render-buffer.html
 
 `renderBuffer(format, quality)`
 
-Renders the web page to an image buffer which can be sent directly to a client (e.g. using the webserve module)
+Renders the web page to an image buffer which can be sent directly to a client (e.g. using the webserver module)
 
 ## Supported formats
 


### PR DESCRIPTION
fixes typo in `page.renderBuffer` documentation
