### PR TITLE
Fix regression in setEncoding introduced in 9d1c6b9

### DIFF
--- a/src/encoding.cpp
+++ b/src/encoding.cpp
@@ -73,7 +73,7 @@ void Encoding::setEncoding(const QString& encoding)
     if (!encoding.isEmpty()) {
         QTextCodec* codec = QTextCodec::codecForName(encoding.toLatin1());
 
-        if (!codec) {
+        if (codec) {
             m_codec = codec;
         }
     }


### PR DESCRIPTION
This corrects the comparison reversion accidentally introduced in commit 9d1c6b9.

Issue: https://github.com/ariya/phantomjs/issues/14632