### PR TITLE
add ghostdriver command line option

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -218,7 +218,12 @@ phantom.callback = function(callback) {
         var _paths = [], dir;
 
         if (request[0] === '.') {
-            _paths.push(fs.absolute(joinPath(phantom.webdriverMode ? ":/ghostdriver" : this.dirname, request)));
+            if (phantom.webdriverMode) {
+                _paths.push(fs.absolute(joinPath(phantom.libraryPath, request)));
+                _paths.push(fs.absolute(joinPath(":ghostdriver", request)));
+            } else {
+                _paths.push(fs.absolute(joinPath(this.dirname, request)));
+            }
         } else if (fs.isAbsolute(request)) {
             _paths.push(fs.absolute(request));
         } else {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -78,6 +78,7 @@ static const struct QCommandLineConfigEntry flags[] = {
     { QCommandLine::Option, '\0', "webdriver-logfile", "File where to write the WebDriver's Log (default 'none') (NOTE: needs '--webdriver') ", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "webdriver-loglevel", "WebDriver Logging Level: (supported: 'ERROR', 'WARN', 'INFO', 'DEBUG') (default 'INFO') (NOTE: needs '--webdriver') ", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "webdriver-selenium-grid-hub", "URL to the Selenium Grid HUB: 'URL_TO_HUB' (default 'none') (NOTE: needs '--webdriver') ", QCommandLine::Optional },
+    { QCommandLine::Option, '\0', "webdriver-ghostdriver-path", "Sets the path to Ghostdriver's main.js", QCommandLine::Optional },
     { QCommandLine::Param, '\0', "script", "Script", QCommandLine::Flags(QCommandLine::Optional | QCommandLine::ParameterFence)},
     { QCommandLine::Param, '\0', "argument", "Script argument", QCommandLine::OptionalMultiple },
     { QCommandLine::Switch, 'w', "wd", "Equivalent to '--webdriver' option above", QCommandLine::Optional },
@@ -573,6 +574,16 @@ QString Config::webdriverSeleniumGridHub() const
     return m_webdriverSeleniumGridHub;
 }
 
+void Config::setWebdriverGhostdriverPath(const QString& path)
+{
+    m_webdriverGhostdriverPath = path;
+}
+
+QString Config::webdriverGhostdriverPath() const
+{
+    return m_webdriverGhostdriverPath;
+}
+
 // private:
 void Config::resetToDefaults()
 {
@@ -637,6 +648,7 @@ void Config::resetToDefaults()
     m_webdriverLogFile = QString();
     m_webdriverLogLevel = "INFO";
     m_webdriverSeleniumGridHub = QString();
+    m_webdriverGhostdriverPath = QString();
 }
 
 void Config::setProxyAuthPass(const QString& value)
@@ -831,6 +843,9 @@ void Config::handleOption(const QString& option, const QVariant& value)
     }
     if (option == "webdriver-selenium-grid-hub") {
         setWebdriverSeleniumGridHub(value.toString());
+    }
+    if (option == "webdriver-ghostdriver-path") {
+        setWebdriverGhostdriverPath(value.toString());
     }
 }
 

--- a/src/config.h
+++ b/src/config.h
@@ -69,6 +69,7 @@ class Config: public QObject
     Q_PROPERTY(QString webdriverLogFile READ webdriverLogFile WRITE setWebdriverLogFile)
     Q_PROPERTY(QString webdriverLogLevel READ webdriverLogLevel WRITE setWebdriverLogLevel)
     Q_PROPERTY(QString webdriverSeleniumGridHub READ webdriverSeleniumGridHub WRITE setWebdriverSeleniumGridHub)
+    Q_PROPERTY(QString webdriverGhostdriverPath READ webdriverGhostdriverPath WRITE setWebdriverGhostdriverPath)
 
 public:
     Config(QObject* parent = 0);
@@ -206,6 +207,9 @@ public:
     void setWebdriverSeleniumGridHub(const QString& hubUrl);
     QString webdriverSeleniumGridHub() const;
 
+    void setWebdriverGhostdriverPath(const QString& ghostdriverPath);
+    QString webdriverGhostdriverPath() const;
+
 public slots:
     void handleSwitch(const QString& sw);
     void handleOption(const QString& option, const QVariant& value);
@@ -263,6 +267,7 @@ private:
     QString m_webdriverLogFile;
     QString m_webdriverLogLevel;
     QString m_webdriverSeleniumGridHub;
+    QString m_webdriverGhostdriverPath;
 };
 
 #endif // CONFIG_H

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -204,9 +204,15 @@ bool Phantom::execute()
     if (m_config->isWebdriverMode()) {                                   // Remote WebDriver mode requested
         qDebug() << "Phantom - execute: Starting Remote WebDriver mode";
 
-        if (!Utils::injectJsInFrame(":/ghostdriver/main.js", QString(), m_scriptFileEnc, QDir::currentPath(), m_page->mainFrame(), true)) {
-            m_returnValue = -1;
-            return false;
+        QString ghostdriver_path = ":/ghostdriver/main.js";
+        if (!m_config->webdriverGhostdriverPath().isEmpty()) {
+          ghostdriver_path = m_config->webdriverGhostdriverPath();
+          setLibraryPath(QFileInfo(ghostdriver_path).dir().absolutePath());
+        }
+
+        if (!Utils::injectJsInFrame(ghostdriver_path, QString(), m_scriptFileEnc, QDir::currentPath(), m_page->mainFrame(), true)) {
+          m_returnValue = -1;
+          return false;
         }
     } else if (m_config->scriptFile().isEmpty()) {                       // REPL mode requested
         qDebug() << "Phantom - execute: Starting REPL mode";
@@ -396,7 +402,7 @@ bool Phantom::injectJs(const QString& jsFilePath)
     qDebug() << "Phantom - injectJs:" << jsFilePath;
 
     // If in Remote Webdriver Mode, we need to manipulate the PATH, to point it to a resource in `ghostdriver.qrc`
-    if (webdriverMode()) {
+    if (webdriverMode() && m_config->webdriverGhostdriverPath().isEmpty()) {
         pre = ":/ghostdriver/";
         qDebug() << "Phantom - injectJs: prepending" << pre;
     }


### PR DESCRIPTION
the user can override the default ghostdriver bundled in phantomjs with
the --webdriver-ghostdriver-path. --webdriver-ghostdriver-path must
point to the main.js in the ghostdriver project.

issue #14553 

the following examples demonstrate the new functionality.
```sh
$ ./bin/phantomjs --debug true --wd --webdriver-ghostdriver-path ../ghostdriver/src/main.js
....
2016-12-07T19:14:55 [DEBUG] Phantom - execute: Starting Remote WebDriver mode
2016-12-07T19:14:55 [DEBUG] WebPage - setupFrame ""
2016-12-07T19:14:55 [DEBUG] FileSystem - _open: ":/modules/fs.js" QMap(("mode", QVariant(QString, "r")))
2016-12-07T19:14:55 [DEBUG] FileSystem - _open: ":/modules/system.js" QMap(("mode", QVariant(QString, "r")))
2016-12-07T19:14:55 [DEBUG] FileSystem - _open: ":/modules/webpage.js" QMap(("mode", QVariant(QString, "r")))
2016-12-07T19:14:55 [DEBUG] FileSystem - _open: ":/modules/webserver.js" QMap(("mode", QVariant(QString, "r")))
2016-12-07T19:14:55 [DEBUG] FileSystem - _open: "/home/jesg/opensource/ghostdriver/src/hub_register.js" QMap(("mode", QVariant(QString, "r")))
2016-12-07T19:14:55 [DEBUG] FileSystem - _open: "/home/jesg/opensource/ghostdriver/src/logger.js" QMap(("mode", QVariant(QString, "r")))
2016-12-07T19:14:55 [DEBUG] FileSystem - _open: "/home/jesg/opensource/ghostdriver/src/third_party/console++.js" QMap(("mode", QVariant(QString, "r")))
2016-12-07T19:14:55 [DEBUG] FileSystem - _open: "/home/jesg/opensource/ghostdriver/src/config.js" QMap(("mode", QVariant(QString, "r")))
2016-12-07T19:14:55 [DEBUG] FileSystem - _open: "/home/jesg/opensource/ghostdriver/src/third_party/parseuri.js" QMap(("mode", QVariant(QString, "r")))
2016-12-07T19:14:55 [DEBUG] Phantom - injectJs: "session.js"
2016-12-07T19:14:55 [DEBUG] Phantom - injectJs: "inputs.js"
2016-12-07T19:14:55 [DEBUG] Phantom - injectJs: "request_handlers/request_handler.js"
2016-12-07T19:14:55 [DEBUG] Phantom - injectJs: "request_handlers/status_request_handler.js"
2016-12-07T19:14:55 [DEBUG] FileSystem - _open: "/home/jesg/opensource/ghostdriver/src/errors.js" QMap(("mode", QVariant(QString, "r")))
2016-12-07T19:14:55 [DEBUG] Phantom - injectJs: "request_handlers/shutdown_request_handler.js"
2016-12-07T19:14:55 [DEBUG] Phantom - injectJs: "request_handlers/session_manager_request_handler.js"
2016-12-07T19:14:55 [DEBUG] Phantom - injectJs: "request_handlers/session_request_handler.js"
2016-12-07T19:14:55 [DEBUG] Phantom - injectJs: "request_handlers/webelement_request_handler.js"
2016-12-07T19:14:55 [DEBUG] Phantom - injectJs: "request_handlers/router_request_handler.js"
2016-12-07T19:14:55 [DEBUG] Phantom - injectJs: "webelementlocator.js"
[INFO  - 2016-12-08T03:14:55.715Z] GhostDriver - Main - running on port 127.0.0.1:8910
```

and running packaged ghostdriver
```sh
$ ./bin/phantomjs --debug true --wd
...
2016-12-07T19:17:21 [DEBUG] Phantom - execute: Starting Remote WebDriver mode
2016-12-07T19:17:21 [DEBUG] WebPage - setupFrame ""
2016-12-07T19:17:21 [DEBUG] FileSystem - _open: ":/modules/fs.js" QMap(("mode", QVariant(QString, "r")))
2016-12-07T19:17:21 [DEBUG] FileSystem - _open: ":/modules/system.js" QMap(("mode", QVariant(QString, "r")))
2016-12-07T19:17:21 [DEBUG] FileSystem - _open: ":/modules/webpage.js" QMap(("mode", QVariant(QString, "r")))
2016-12-07T19:17:21 [DEBUG] FileSystem - _open: ":/modules/webserver.js" QMap(("mode", QVariant(QString, "r")))
2016-12-07T19:17:21 [DEBUG] FileSystem - _open: ":ghostdriver/./hub_register.js" QMap(("mode", QVariant(QString, "r")))
2016-12-07T19:17:21 [DEBUG] FileSystem - _open: ":ghostdriver/./logger.js" QMap(("mode", QVariant(QString, "r")))
2016-12-07T19:17:21 [DEBUG] FileSystem - _open: ":ghostdriver/./third_party/console++.js" QMap(("mode", QVariant(QString, "r")))
2016-12-07T19:17:21 [DEBUG] FileSystem - _open: ":ghostdriver/./config.js" QMap(("mode", QVariant(QString, "r")))
2016-12-07T19:17:21 [DEBUG] FileSystem - _open: ":ghostdriver/./third_party/parseuri.js" QMap(("mode", QVariant(QString, "r")))
2016-12-07T19:17:21 [DEBUG] Phantom - injectJs: "session.js"
2016-12-07T19:17:21 [DEBUG] Phantom - injectJs: prepending ":/ghostdriver/"
2016-12-07T19:17:21 [DEBUG] Phantom - injectJs: "inputs.js"
2016-12-07T19:17:21 [DEBUG] Phantom - injectJs: prepending ":/ghostdriver/"
2016-12-07T19:17:21 [DEBUG] Phantom - injectJs: "request_handlers/request_handler.js"
2016-12-07T19:17:21 [DEBUG] Phantom - injectJs: prepending ":/ghostdriver/"
2016-12-07T19:17:21 [DEBUG] Phantom - injectJs: "request_handlers/status_request_handler.js"
2016-12-07T19:17:21 [DEBUG] Phantom - injectJs: prepending ":/ghostdriver/"
2016-12-07T19:17:21 [DEBUG] FileSystem - _open: ":ghostdriver/./errors.js" QMap(("mode", QVariant(QString, "r")))
2016-12-07T19:17:21 [DEBUG] Phantom - injectJs: "request_handlers/shutdown_request_handler.js"
2016-12-07T19:17:21 [DEBUG] Phantom - injectJs: prepending ":/ghostdriver/"
2016-12-07T19:17:21 [DEBUG] Phantom - injectJs: "request_handlers/session_manager_request_handler.js"
2016-12-07T19:17:21 [DEBUG] Phantom - injectJs: prepending ":/ghostdriver/"
2016-12-07T19:17:21 [DEBUG] Phantom - injectJs: "request_handlers/session_request_handler.js"
2016-12-07T19:17:21 [DEBUG] Phantom - injectJs: prepending ":/ghostdriver/"
2016-12-07T19:17:21 [DEBUG] Phantom - injectJs: "request_handlers/webelement_request_handler.js"
2016-12-07T19:17:21 [DEBUG] Phantom - injectJs: prepending ":/ghostdriver/"
2016-12-07T19:17:21 [DEBUG] Phantom - injectJs: "request_handlers/router_request_handler.js"
2016-12-07T19:17:21 [DEBUG] Phantom - injectJs: prepending ":/ghostdriver/"
2016-12-07T19:17:21 [DEBUG] Phantom - injectJs: "webelementlocator.js"
2016-12-07T19:17:21 [DEBUG] Phantom - injectJs: prepending ":/ghostdriver/"
[INFO  - 2016-12-08T03:17:21.359Z] GhostDriver - Main - running on port 127.0.0.1:8910
```

i built and tested this on linux gcc 5.4.0, qt5.6.1, and annulen/webkit.