### PR TITLE
Fix addCookie documentation

### DIFF
--- a/_posts/api/webpage/method/2000-01-01-add-cookie.md
+++ b/_posts/api/webpage/method/2000-01-01-add-cookie.md
@@ -9,7 +9,7 @@ permalink: api/webpage/method/add-cookie.html
 
 **Introduced:** PhantomJS 1.7
 
-Add a Cookie to the page. If the `domain` does not match the current page, the Cookie will be ignored/rejected. Returns `true` if successfully added, otherwise `false`.
+Add a Cookie to the page. If the `domain` does not match the current page, the Cookie will be ignored/rejected.
 
 ## Examples
 
@@ -21,7 +21,7 @@ phantom.addCookie({
   'name'     : 'Valid-Cookie-Name',   /* required property */
   'value'    : 'Valid-Cookie-Value',  /* required property */
   'domain'   : 'localhost',
-  'path'     : '/foo',                /* required property */
+  'path'     : '/foo',
   'httponly' : true,
   'secure'   : false,
   'expires'  : (new Date()).getTime() + (1000 * 60 * 60)   /* <-- expires in 1 hour */


### PR DESCRIPTION
`addCookie` *should* return true on success but actually doesn't.


Tested with following code:
```javascript
var page = require('webpage').create();
var url = 'http://localhost:8000/';

// Will always print `false`
// Btw the domain is required in this case but not always (depending on if a page already been load or not)
console.log(page.addCookie({name: 'foo', value: 'bar', domain: 'localhost'}));
page.open(url, function (status) {
  page.render('page.png'); // The server should print received cookies. And it work perfectly

  phantom.exit();
});
```

*Oh, and path is not a required property.*