### PR TITLE
remove phantom.args references

### DIFF
--- a/_posts/api/webpage/property/2000-01-01-viewport-size.md
+++ b/_posts/api/webpage/property/2000-01-01-viewport-size.md
@@ -27,15 +27,17 @@ You must include height for this to work.
 ```javascript
 var page = require('webpage').create(),
 	address, output, size;
+var system = require('system');	
 
-if (phantom.args.length < 4 || phantom.args.length > 5) {
+var arg_count = system.args.length - 1;
+if (arg_count < 4 || arg_count > 5) {
     console.log('Usage: viewport.js URL filename sizeX sizeY');
     phantom.exit();
 } else {
-    address = phantom.args[0];
-    output = phantom.args[1];
-    sizeX = phantom.args[2];
-    sizeY = phantom.args[3];
+    address = system.args[1];
+    output = system.args[2];
+    sizeX = system.args[3];
+    sizeY = system.args[4];
     page.viewportSize = { width: sizeX, height: sizeY };
     page.open(address, function (status) {
         if (status !== 'success') {


### PR DESCRIPTION
phantom.args has been depreciated, system.args has been suggested as the alternative. 

This patch updates documentation to reflect the current situation.