### PR TITLE
Add code to execFile callback

### DIFF
--- a/src/modules/child_process.js
+++ b/src/modules/child_process.js
@@ -89,7 +89,7 @@ exports.execFile = function (cmd, args, opts, cb) {
   })
 
   ctx.on("exit", function (code) {
-    return cb(null, stdout, stderr)
+    return cb(null, stdout, stderr, code)
   })
 
   ctx._start(cmd, args)


### PR DESCRIPTION
Is it possible to add exit code to execFile callback?
So it would be possible to do like

```
execFile("ls", ["-lF", "/usr"], null, function (err, stdout, stderr, code) {
  console.log("execFileSTDOUT:", JSON.stringify(stdout))
  console.log("execFileSTDERR:", JSON.stringify(stderr))
  console.log("execFileEXITCODE:", JSON.stringify(code))
})
```