### PR TITLE
add a resourceTimeout parameter to phantomjs from 2.1.1

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -67,6 +67,7 @@ static const struct QCommandLineConfigEntry flags[] = {
     { QCommandLine::Option, '\0', "proxy", "Sets the proxy server, e.g. '--proxy=http://proxy.company.com:8080'", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "proxy-auth", "Provides authentication information for the proxy, e.g. ''-proxy-auth=username:password'", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "proxy-type", "Specifies the proxy type, 'http' (default), 'none' (disable completely), or 'socks5'", QCommandLine::Optional },
+    { QCommandLine::Option, '\0', "resource-timeout", "Sets the timer used for stopping request, default is 0 (no timer)", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "script-encoding", "Sets the encoding used for the starting script, default is 'utf8'", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "script-language", "Sets the script language instead of detecting it: 'javascript'", QCommandLine::Optional },
     { QCommandLine::Option, '\0', "web-security", "Enables web security, 'true' (default) or 'false'", QCommandLine::Optional },
@@ -520,6 +521,16 @@ bool Config::javascriptCanCloseWindows() const
     return m_javascriptCanCloseWindows;
 }
 
+void Config::setResourceTimeout(const int value)
+{
+    m_resourceTimeout = value;
+}
+
+int Config::resourceTimeout() const
+{
+    return m_resourceTimeout;
+}
+
 void Config::setWebdriver(const QString& webdriverConfig)
 {
     // Parse and validate the configuration
@@ -608,6 +619,7 @@ void Config::resetToDefaults()
     m_webSecurityEnabled = true;
     m_javascriptCanOpenWindows = true;
     m_javascriptCanCloseWindows = true;
+    m_resourceTimeout = 0;
     m_helpFlag = false;
     m_printDebugMessages = false;
     m_sslProtocol = "default";
@@ -791,6 +803,10 @@ void Config::handleOption(const QString& option, const QVariant& value)
 
     if (option == "proxy-auth") {
         setProxyAuth(value.toString());
+    }
+
+    if (option == "resource-timeout") {
+        setResourceTimeout(value.toInt());
     }
 
     if (option == "script-encoding") {

--- a/src/config.h
+++ b/src/config.h
@@ -61,6 +61,7 @@ class Config: public QObject
     Q_PROPERTY(bool printDebugMessages READ printDebugMessages WRITE setPrintDebugMessages)
     Q_PROPERTY(bool javascriptCanOpenWindows READ javascriptCanOpenWindows WRITE setJavascriptCanOpenWindows)
     Q_PROPERTY(bool javascriptCanCloseWindows READ javascriptCanCloseWindows WRITE setJavascriptCanCloseWindows)
+    Q_PROPERTY(int resourceTimeout READ resourceTimeout WRITE setResourceTimeout)
     Q_PROPERTY(QString sslProtocol READ sslProtocol WRITE setSslProtocol)
     Q_PROPERTY(QString sslCiphers READ sslCiphers WRITE setSslCiphers)
     Q_PROPERTY(QString sslCertificatesPath READ sslCertificatesPath WRITE setSslCertificatesPath)
@@ -177,6 +178,9 @@ public:
     void setJavascriptCanCloseWindows(const bool value);
     bool javascriptCanCloseWindows() const;
 
+    void setResourceTimeout(const int value);
+    int resourceTimeout() const;
+
     void setSslProtocol(const QString& sslProtocolName);
     QString sslProtocol() const;
 
@@ -256,6 +260,7 @@ private:
     bool m_printDebugMessages;
     bool m_javascriptCanOpenWindows;
     bool m_javascriptCanCloseWindows;
+    int m_resourceTimeout;
     QString m_sslProtocol;
     QString m_sslCiphers;
     QString m_sslCertificatesPath;

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -139,6 +139,7 @@ void Phantom::init()
     m_defaultPageSettings[PAGE_SETTINGS_WEB_SECURITY_ENABLED] = QVariant::fromValue(m_config.webSecurityEnabled());
     m_defaultPageSettings[PAGE_SETTINGS_JS_CAN_OPEN_WINDOWS] = QVariant::fromValue(m_config.javascriptCanOpenWindows());
     m_defaultPageSettings[PAGE_SETTINGS_JS_CAN_CLOSE_WINDOWS] = QVariant::fromValue(m_config.javascriptCanCloseWindows());
+    m_defaultPageSettings[PAGE_SETTINGS_RESOURCE_TIMEOUT] = QVariant::fromValue(m_config.resourceTimeout());
     m_page->applySettings(m_defaultPageSettings);
 
     setLibraryPath(QFileInfo(m_config.scriptFile()).dir().absolutePath());


### PR DESCRIPTION
#14911

No event never trigger on popup opening. Because you can't precise a page.resourceTimeout before a "window.open event" that create the new popup.

And This timeout equals 0 by default. So It could be nice if we can fix it before running execution.
It will avoid crashs on no response services.

Regards