### PR TITLE
corrected syntax in addCookie() example

### DIFF
--- a/_posts/api/phantom/method/2000-01-01-add-cookie.md
+++ b/_posts/api/phantom/method/2000-01-01-add-cookie.md
@@ -15,9 +15,9 @@ Add a Cookie to the CookieJar.  Returns `true` if successfully added, otherwise 
 
 ```javascript
 phantom.addCookie({
-  'name': 'Added-Cookie-Name',
-  'value': 'Added-Cookie-Value',
-  'domain': '.google.com'
+  name: 'Added-Cookie-Name',
+  value: 'Added-Cookie-Value',
+  domain: '.google.com'
 });
 ```
 


### PR DESCRIPTION
name, value and domain should not be quoted