### PR TITLE
Fix for passwordless-credential proxy authentication

### DIFF
--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -419,8 +419,8 @@ void Phantom::setProxy(const QString& ip, const qint64& port, const QString& pro
         if (proxyType == "socks5") {
             networkProxyType = QNetworkProxy::Socks5Proxy;
         }
-        // Checking for passed proxy user and password
-        if (!user.isEmpty() && !password.isEmpty()) {
+        // Checking for passed proxy user and/or password
+        if (!user.isEmpty() || !password.isEmpty()) {
             QNetworkProxy proxy(networkProxyType, ip, port, user, password);
             QNetworkProxy::setApplicationProxy(proxy);
         } else {


### PR DESCRIPTION
Allow empty username or password (but not both) for proxy credentials.
https://github.com/ariya/phantomjs/issues/14886

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ariya/phantomjs/14976)
<!-- Reviewable:end -->
