### PR TITLE
Get the QNetworkReply response body & Fix QWebSettings::WebSecurityEnabled bug

### DIFF
--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -44,6 +44,10 @@
 #include "cookiejar.h"
 #include "networkaccessmanager.h"
 
+#include <private/qnetworkreplyhttpimpl_p.h>
+
+using namespace QtPrivate;
+
 // 10 MB
 const qint64 MAX_REQUEST_POST_BODY_SIZE = 10 * 1000 * 1000;
 
@@ -302,6 +306,15 @@ void NetworkAccessManager::setCookieJar(QNetworkCookieJar* cookieJar)
     cookieJar->setParent(Phantom::instance());
 }
 
+QString NetworkAccessManager::getCookieStringFromUrl(const QUrl &url)
+{
+    QStringList cookies;
+    foreach (QNetworkCookie cookie, cookieJar()->cookiesForUrl(url)) {
+        cookies.append(cookie.toRawForm(QNetworkCookie::NameAndValueOnly));
+    }
+    return cookies.join("; ");
+}
+
 // protected:
 QNetworkReply* NetworkAccessManager::createRequest(Operation op, const QNetworkRequest& request, QIODevice* outgoingData)
 {
@@ -349,6 +362,15 @@ QNetworkReply* NetworkAccessManager::createRequest(Operation op, const QNetworkR
         QVariantMap header;
         header["name"] = QString::fromUtf8(headerName);
         header["value"] = QString::fromUtf8(req.rawHeader(headerName));
+        headers += header;
+    }
+
+    // get Cookie from cookiejar
+    QString cookie = getCookieStringFromUrl(req.url());
+    if (!cookie.isEmpty()) {
+        QVariantMap header;
+        header["name"] = "Cookie";
+        header["value"] = getCookieStringFromUrl(req.url());
         headers += header;
     }
 
@@ -409,6 +431,59 @@ QNetworkReply* NetworkAccessManager::createRequest(Operation op, const QNetworkR
     return reply;
 }
 
+QVariant NetworkAccessManager::getResponseBodyFromReply(QNetworkReply* reply)
+{
+    QNetworkReplyHttpImpl *http_reply = static_cast<QNetworkReplyHttpImpl*>(reply);
+    QNetworkReplyHttpImplPrivate * const d = http_reply->d_func();
+    QByteArray data;
+
+    // cacheload device
+    if (d->cacheLoadDevice) {
+        if (!d->downloadMultiBuffer.isEmpty()) {
+            QList<QByteArray> buffers;
+            while(!d->downloadMultiBuffer.isEmpty()) {
+                buffers.append(d->downloadMultiBuffer.read());
+            }
+            if(buffers.length() > 0) {
+                foreach (const QByteArray& item, buffers) {
+                    d->downloadMultiBuffer.append(item);
+                }
+            }
+            data += buffers.join();
+            goto end;
+        }
+        QByteArray cached = d->cacheLoadDevice->readAll();
+        d->cacheLoadDevice->reset();
+        data += cached;
+        goto end;
+    }
+    // zerocopy buffer
+    if (d->downloadZerocopyBuffer) {
+        qint64 howMuch = d->downloadBufferCurrentSize - d->downloadBufferReadPosition;
+        data += QByteArray(d->downloadZerocopyBuffer + d->downloadBufferReadPosition,howMuch);
+        goto end;
+    }
+    // normal buffer
+    if (d->downloadMultiBuffer.isEmpty()) {
+        goto end;
+    } else {
+        QList<QByteArray> buffers;
+        while(!d->downloadMultiBuffer.isEmpty()) {
+            buffers.append(d->downloadMultiBuffer.read());
+        }
+        if(buffers.length() > 0) {
+            foreach (const QByteArray& item, buffers) {
+                d->downloadMultiBuffer.append(item);
+            }
+        }
+        data += buffers.join();
+        goto end;
+    }
+
+end:
+    return QString::fromLatin1(data.data(),data.length());
+}
+
 void NetworkAccessManager::handleTimeout()
 {
     TimeoutTimer* nt = qobject_cast<TimeoutTimer*>(sender());
@@ -451,7 +526,7 @@ void NetworkAccessManager::handleStarted()
     data["redirectURL"] = reply->header(QNetworkRequest::LocationHeader);
     data["headers"] = headers;
     data["time"] = QDateTime::currentDateTime();
-    data["body"] = "";
+    data["body"] = getResponseBodyFromReply(reply);
 
     emit resourceReceived(data);
 }

--- a/src/networkaccessmanager.h
+++ b/src/networkaccessmanager.h
@@ -91,6 +91,7 @@ public:
     QVariantMap customHeaders() const;
 
     void setCookieJar(QNetworkCookieJar* cookieJar);
+    QString getCookieStringFromUrl(const QUrl &url);
 
 protected:
     bool m_ignoreSslErrors;
@@ -102,6 +103,7 @@ protected:
     QString m_password;
     QNetworkReply* createRequest(Operation op, const QNetworkRequest& req, QIODevice* outgoingData) Q_DECL_OVERRIDE;
     void handleFinished(QNetworkReply* reply, const QVariant& status, const QVariant& statusText);
+    QVariant getResponseBodyFromReply(QNetworkReply* reply);
 
 Q_SIGNALS:
     void resourceRequested(const QVariant& data, QObject*);

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -366,7 +366,10 @@ WebPage::WebPage(QObject* parent, const QUrl& baseUrl)
     // attribute "WebSecurityEnabled" must be applied during the initializing
     // security context for Document instance. Setting up it later will not cause any effect
     QWebSettings* settings = m_customWebPage->settings();
-    settings->setAttribute(QWebSettings::WebSecurityEnabled, phantomCfg->webSecurityEnabled());
+    // settings->setAttribute(QWebSettings::WebSecurityEnabled, phantomCfg->webSecurityEnabled());
+    // FIXME: 'WebSecurityEnabled' is not a member of 'QWebSettings' ?
+    settings->setAttribute(QWebSettings::XSSAuditingEnabled, phantomCfg->webSecurityEnabled());
+    settings->setAttribute(QWebSettings::JavascriptCanAccessClipboard, phantomCfg->webSecurityEnabled());
 
     m_mainFrame = m_customWebPage->mainFrame();
     m_currentFrame = m_mainFrame;


### PR DESCRIPTION
Get the QNetworkReply response body at `onResourceRequested`.
Fix `WebSecurityEnabled` is not a member of `QWebSettings` bug.