### PR TITLE
Minor re-wording of doc and indentation fix

### DIFF
--- a/_posts/api/webpage/method/2000-01-01-open.md
+++ b/_posts/api/webpage/method/2000-01-01-open.md
@@ -6,11 +6,15 @@ permalink: api/webpage/method/open.html
 ---
 
 `open(url, callback)` {void}
+
 `open(url, method, callback)` {void}
+
 `open(url, method, data, callback)` {void}
+
 `open(url, settings, callback)` {void}
 
-Opens the `url` and loads it to the page. Once the page is loaded, the optional `callback` is called using `page.onLoadFinished`, and also provides the page status to the function (`'success'` or `'fail'`).
+
+Opens the `url` and loads it to the page. Once the page is loaded, the optional `callback` is called using `page.onLoadFinished`, with  the page status (`'success'` or `'fail'`) provided to it.
 
 ## Examples
 


### PR DESCRIPTION
* Re-worded doc of `page.open` to reduce ambiguity
* Added new lines so the multiple possible invocations of `page.open` are shown in separate lines
