### PR TITLE
Introduce new API for managing devicePixelRatio

### DIFF
--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -30,10 +30,7 @@
 
 #include "webpage.h"
 
-#include <QApplication>
 #include <QBuffer>
-#include <QContextMenuEvent>
-#include <QDateTime>
 #include <QDebug>
 #include <QDesktopServices>
 #include <QDir>
@@ -41,17 +38,12 @@
 #include <QImageWriter>
 #include <QKeyEvent>
 #include <QMapIterator>
-#include <QMouseEvent>
 #include <QNetworkAccessManager>
-#include <QNetworkCookie>
-#include <QNetworkProxy>
 #include <QNetworkRequest>
-#include <QPainter>
 #include <QScreen>
 #include <QUrl>
 #include <QUuid>
 #include <QWebElement>
-#include <QWebHistory>
 #include <QWebHistoryItem>
 #include <QWebFrame>
 #include <QWebInspector>
@@ -765,12 +757,11 @@ QVariantMap WebPage::paperSize() const
 
 QVariant WebPage::evaluateJavaScript(const QString& code)
 {
-    QVariant evalResult;
-    QString function = "(" + code + ")()";
+	QString function = "(" + code + ")()";
 
     qDebug() << "WebPage - evaluateJavaScript" << function;
 
-    evalResult = m_currentFrame->evaluateJavaScript(function);
+    QVariant evalResult = m_currentFrame->evaluateJavaScript(function);
 
     qDebug() << "WebPage - evaluateJavaScript result" << evalResult;
 
@@ -1797,6 +1788,16 @@ void WebPage::stopJavaScript()
 void WebPage::clearMemoryCache()
 {
     QWebSettings::clearMemoryCaches();
+}
+
+qreal WebPage::devicePixelRatio() const
+{
+    return m_customWebPage->devicePixelRatio();
+}
+
+void WebPage::setDevicePixelRatio(qreal devicePixelRatio)
+{
+    m_customWebPage->setDevicePixelRatio(devicePixelRatio);
 }
 
 #include "webpage.moc"

--- a/src/webpage.h
+++ b/src/webpage.h
@@ -81,6 +81,7 @@ class WebPage : public QObject
     Q_PROPERTY(int framesCount READ framesCount)
     Q_PROPERTY(QString focusedFrameName READ focusedFrameName)
     Q_PROPERTY(QObject* cookieJar READ cookieJar WRITE setCookieJarFromQObject)
+    Q_PROPERTY(qreal devicePixelRatio READ devicePixelRatio WRITE setDevicePixelRatio)
 
 public:
     WebPage(QObject* parent, const QUrl& baseUrl = QUrl());
@@ -488,6 +489,8 @@ public slots:
     qreal stringToPointSize(const QString&) const;
     qreal printMargin(const QVariantMap&, const QString&);
     qreal getHeight(const QVariantMap&, const QString&) const;
+    qreal devicePixelRatio() const;
+    void setDevicePixelRatio(qreal devicePixelRatio);
 
 signals:
     void initialized();

--- a/test/module/webpage/device-pixel-ratio.js
+++ b/test/module/webpage/device-pixel-ratio.js
@@ -1,0 +1,14 @@
+const webpage = require('webpage');
+
+test(function () {
+    const page = webpage.create();
+
+    page.devicePixelRatio = 1.5;
+    assert_equals(page.devicePixelRatio, 1.5);
+
+    page.devicePixelRatio = 2.0;
+    assert_equals(page.devicePixelRatio, 2.0);
+
+    page.devicePixelRatio = 0.5;
+    assert_equals(page.devicePixelRatio, 0.5);
+}, "page.devicePixelRatio");


### PR DESCRIPTION
Issue: https://github.com/ariya/phantomjs/issues/10964

This PR adds 2 new APIs for managing devicePixelRatio:

```
const page = require('webpage').create();

// setting devicePixelRatio
page.devicePixelRatio = 2;

// getting its value
page.devicePixelRatio
```