### PR TITLE
Stop using redirects on PhantomJS level

### DIFF
--- a/src/modules/webpage.js
+++ b/src/modules/webpage.js
@@ -258,8 +258,6 @@ function decorateNewPage(opts, page) {
 
   definePageSignalHandler(page, handlers, 'onResourceTimeout', 'resourceTimeout');
 
-  definePageSignalHandler(page, handlers, 'onResourceRedirect', 'resourceRedirect');
-
   definePageSignalHandler(page, handlers, 'onAlert', 'javaScriptAlertSent');
 
   definePageSignalHandler(page, handlers, 'onConsoleMessage', 'javaScriptConsoleMessageSent');

--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
   This file is part of the PhantomJS project from Ofi Labs.
 
   Copyright (C) 2011 Ariya Hidayat <ariya.hidayat@gmail.com>
@@ -307,10 +307,6 @@ QNetworkReply* NetworkAccessManager::createRequest(Operation op, const QNetworkR
 {
     QNetworkRequest req(request);
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
-    req.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
-#endif
-
     QString scheme = req.url().scheme().toLower();
 
     if (!QSslSocket::supportsSsl()) {
@@ -395,10 +391,6 @@ QNetworkReply* NetworkAccessManager::createRequest(Operation op, const QNetworkR
     connect(reply, &QNetworkReply::readyRead, this, &NetworkAccessManager::handleStarted);
     connect(reply, &QNetworkReply::sslErrors, this, &NetworkAccessManager::handleSslErrors);
     connect(reply, static_cast<void(QNetworkReply::*)(QNetworkReply::NetworkError)>(&QNetworkReply::error), this, &NetworkAccessManager::handleNetworkError);
-
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
-    connect(reply, &QNetworkReply::redirected, this, &NetworkAccessManager::handleRedirect);
-#endif
 
     // synchronous requests will be finished at this point
     if (reply->isFinished()) {
@@ -546,20 +538,3 @@ QVariantList NetworkAccessManager::getHeadersFromReply(const QNetworkReply* repl
 
     return headers;
 }
-
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
-void NetworkAccessManager::handleRedirect(const QUrl& url)
-{
-    QNetworkReply* reply = qobject_cast<QNetworkReply*>(sender());
-
-    qDebug() << "Network - Redirecting to " << url.toEncoded();
-
-    QVariantMap data;
-    data["id"] = m_ids.value(reply);
-    data["url"] = url.toEncoded().data();
-
-    emit resourceRedirect(data);
-
-    get(QNetworkRequest(url));
-}
-#endif

--- a/src/networkaccessmanager.h
+++ b/src/networkaccessmanager.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
   This file is part of the PhantomJS project from Ofi Labs.
 
   Copyright (C) 2011 Ariya Hidayat <ariya.hidayat@gmail.com>
@@ -109,9 +109,6 @@ Q_SIGNALS:
     void resourceError(const QVariant& data);
     void resourceTimeout(const QVariant& data);
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
-    void resourceRedirect(const QVariant& data);
-#endif
 
 private slots:
     void handleStarted();
@@ -120,10 +117,6 @@ private slots:
     void handleSslErrors(const QList<QSslError>& errors);
     void handleNetworkError(QNetworkReply::NetworkError);
     void handleTimeout();
-
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
-    void handleRedirect(const QUrl& url);
-#endif
 
 private:
     void prepareSslConfiguration(const Config* config);

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
   This file is part of the PhantomJS project from Ofi Labs.
 
   Copyright (C) 2011 Ariya Hidayat <ariya.hidayat@gmail.com>
@@ -436,11 +436,6 @@ WebPage::WebPage(QObject* parent, const QUrl& baseUrl)
             SIGNAL(resourceError(QVariant)));
     connect(m_networkAccessManager, SIGNAL(resourceTimeout(QVariant)),
             SIGNAL(resourceTimeout(QVariant)));
-
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
-    connect(m_networkAccessManager, SIGNAL(resourceRedirect(QVariant)),
-            SIGNAL(resourceRedirect(QVariant)));
-#endif
 
     m_dpi = qRound(QApplication::primaryScreen()->logicalDotsPerInch());
     m_customWebPage->setViewportSize(QSize(400, 300));

--- a/src/webpage.h
+++ b/src/webpage.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
   This file is part of the PhantomJS project from Ofi Labs.
 
   Copyright (C) 2011 Ariya Hidayat <ariya.hidayat@gmail.com>
@@ -503,9 +503,6 @@ signals:
     void resourceReceived(const QVariant& resource);
     void resourceError(const QVariant& errorData);
     void resourceTimeout(const QVariant& errorData);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
-    void resourceRedirect(const QVariant& data);
-#endif
     void urlChanged(const QString& url);
     void navigationRequested(const QString& url, const QString& navigationType, bool navigationLocked, bool isMainFrame);
     void rawPageCreated(QObject* page);


### PR DESCRIPTION
We should not use redirects on PhantomJS level because it breaks
internal network level inside WebKit.