### PR TITLE
Fix building on Qt 5.8+ (closes #14956)

### DIFF
--- a/src/qt-qpa-platform-plugin/phantom.pri
+++ b/src/qt-qpa-platform-plugin/phantom.pri
@@ -1,4 +1,10 @@
-QT += core-private gui-private platformsupport-private
+QT += core-private gui-private
+
+lessThan(QT_MINOR_VERSION, 8) {
+    QT += platformsupport-private
+} else {
+    QT += fontdatabase_support_private eventdispatcher_support_private
+}
 
 SOURCES += $$PWD/phantomintegration.cpp \
            $$PWD/phantombackingstore.cpp

--- a/src/qt-qpa-platform-plugin/phantomintegration.cpp
+++ b/src/qt-qpa-platform-plugin/phantomintegration.cpp
@@ -42,15 +42,24 @@
 #include "phantomintegration.h"
 #include "phantombackingstore.h"
 
+#include <QtGlobal>
 #include <private/qpixmap_raster_p.h>
 
 #if defined(Q_OS_MAC)
 # include <QtPlatformSupport/private/qcoretextfontdatabase_p.h>
 #else
-# include <QtPlatformSupport/private/qgenericunixfontdatabase_p.h>
+# if QT_VERSION < QT_VERSION_CHECK(5, 8, 0)
+#  include <QtPlatformSupport/private/qgenericunixfontdatabase_p.h>
+# else
+#  include <QtFontDatabaseSupport/private/qgenericunixfontdatabase_p.h>
+# endif
 #endif
 
-#include <QtPlatformSupport/private/qgenericunixeventdispatcher_p.h>
+#if QT_VERSION < QT_VERSION_CHECK(5, 8, 0)
+# include <QtPlatformSupport/private/qgenericunixeventdispatcher_p.h>
+#else
+# include <QtEventDispatcherSupport/private/qgenericunixeventdispatcher_p.h>
+#endif
 
 #include <qpa/qplatformnativeinterface.h>
 #include <qpa/qplatformscreen.h>


### PR DESCRIPTION
Fixes #14956. Tested on Arch Linux with Qt 5.9.1 and QtWebkit 5.212.0alpha2 (annulen's fork)

I didn't touch ```qcoretextfontdatabase_p.h``` as qt-qpa-platform-plugin is [enabled on Linux only](https://github.com/ariya/phantomjs/blob/master/phantomjs.pro#L4-L6).