### PR TITLE
Support socket proxy with ghostdriver

### DIFF
--- a/src/ghostdriver/session.js
+++ b/src/ghostdriver/session.js
@@ -148,11 +148,21 @@ ghostdriver.Session = function(desiredCapabilities) {
     _getProxySettingsFromCapabilities = function(proxyCapability) {
         var proxySettings = {};
         if (proxyCapability["proxyType"].toLowerCase() == _const.PROXY_TYPES.MANUAL) {      //< TODO: support other options
-            if (proxyCapability["httpProxy"] !== "null") {                                  //< TODO: support other proxy types
+            if (proxyCapability["httpProxy"] && proxyCapability["httpProxy"] !== "null") {  //< TODO: support other proxy types
                 var urlParts = proxyCapability["httpProxy"].split(':');
                 proxySettings["ip"] = urlParts[0];
                 proxySettings["port"] = urlParts[1];
                 proxySettings["proxyType"] = "http";
+                proxySettings["user"] = "";
+                proxySettings["password"] = "";
+
+                return proxySettings;
+            }
+            if (proxyCapability["socksProxy"] && proxyCapability["socksProxy"] !== "null") {
+                var urlParts = proxyCapability["socksProxy"].split(':');
+                proxySettings["ip"] = urlParts[0];
+                proxySettings["port"] = urlParts[1];
+                proxySettings["proxyType"] = "socks5";
                 proxySettings["user"] = "";
                 proxySettings["password"] = "";
 


### PR DESCRIPTION
I'm trying to use Phantomjs with ghostdriver (seleniumhq - java), everything works fine but I have one scenario where we have a socket proxy (not http proxy) but it throws an exception

[ERROR - 2017-11-17T17:06:36.126Z] RouterReqHand - _handle.error - {"stack":"_getProxySettingsFromCapabilities@phantomjs://code/session.js:133:60\nSession@phantomjs://code/session.js:165:62\n_postNewSessionCommand@phantomjs://code/session_manager_request_handler.js:75:49\n_handle@phantomjs://code/session_manager_request_handler.js:44:35\n_handle@phantomjs://code/router_request_handler.js:70:37","line":133,"sourceURL":"phantomjs://code/session.js"}

  phantomjs://platform/console++.js:263 in error

org.openqa.selenium.WebDriverException: Unable to parse remote response: TypeError - undefined is not an object (evaluating 'proxyCapability["httpProxy"].split')
Build info: version: '3.7.1', revision: '8a0099a', time: '2017-11-06T21:01:39.354Z'
System info: host: 'ubuntu', ip: '127.0.1.1', os.name: 'Linux', os.arch: 'amd64', os.version: '4.13.0-16-generic', java.version: '1.8.0_152'
Driver info: driver.version: PhantomJSDriver
	at org.openqa.selenium.remote.ProtocolHandshake.createSession(ProtocolHandshake.java:111)
	at org.openqa.selenium.remote.ProtocolHandshake.createSession(ProtocolHandshake.java:73)
	at org.openqa.selenium.remote.HttpCommandExecutor.execute(HttpCommandExecutor.java:142)
	at org.openqa.selenium.phantomjs.PhantomJSCommandExecutor.execute(PhantomJSCommandExecutor.java:82)
	at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:600)
	at org.openqa.selenium.remote.RemoteWebDriver.startSession(RemoteWebDriver.java:219)
	at org.openqa.selenium.remote.RemoteWebDriver.<init>(RemoteWebDriver.java:142)
	at org.openqa.selenium.phantomjs.PhantomJSDriver.<init>(PhantomJSDriver.java:116)
	at org.openqa.selenium.phantomjs.PhantomJSDriver.<init>(PhantomJSDriver.java:105)