### PR TITLE
Update 2000-01-02-headless-testing.md to fix 404 errors

### DIFF
--- a/_posts/documentation/learn/2000-01-02-headless-testing.md
+++ b/_posts/documentation/learn/2000-01-02-headless-testing.md
@@ -16,20 +16,19 @@ The following table summarizes the list of various test frameworks and the corre
 | Framework  | Test Runner |
 |:-----------|:------------|
 | [Buster.JS](http://busterjs.org)| built-in|
-| [Capybara](http://jnicklas.github.com/capybara) |[Poltergeist](https://github.com/jonleighton/poltergeist), [Terminus](http://terminus.jcoglan.com)
+| [Capybara](http://teamcapybara.github.io/capybara/) |[Poltergeist](https://github.com/jonleighton/poltergeist), [Terminus](http://terminus.jcoglan.com)
 | [Mocha](http://mochajs.org) | [Chutzpah](http://mmanela.github.io/chutzpah/), [mocha-phantomjs](https://github.com/nathanboktae/mocha-phantomjs) |
 | [FuncUnit](http://funcunit.com) | built-in|
 | [Hiro](http://hirojs.com) | built-in|
 | [Karma](http://karma-runner.github.com/) (née Testacular) | built-in |
 | [Jasmine](https://github.com/pivotal/jasmine) | [Chutzpah](http://mmanela.github.io/chutzpah/), [grunt-contrib-jasmine](https://github.com/gruntjs/grunt-contrib-jasmine), [guard-jasmine](https://github.com/netzpirat/guard-jasmine), [phantom-jasmine](https://github.com/jcarver989/phantom-jasmine)|
-| [JsTestDriver](http://code.google.com/p/js-test-driver/) | [js-test-driver-phantomjs](https://github.com/larrymyers/js-test-driver-phantomjs) |
 | [Laika](http://arunoda.github.io/laika/) | built-in |
 | [Preamble](http://jeffschwartz.github.io/preamble/)| built-in|
 | [phantom-assert](https://bitbucket.org/eradman/phantom-assert)| built-in|
-| [QUnit](http://qunitjs.com) | [qunit-phantomjs-runner](https://github.com/jonkemp/qunit-phantomjs-runner), [Chutzpah](http://mmanela.github.io/chutzpah/), [JS Test Runner](http://js-testrunner.codehaus.org), [Qlive](https://github.com/proxv/qlive), [QUnited](http://github.com/aaronroyer/qunited)|
+| [QUnit](http://qunitjs.com) | [qunit-phantomjs-runner](https://github.com/jonkemp/qunit-phantomjs-runner), [Chutzpah](http://mmanela.github.io/chutzpah/), [Qlive](https://github.com/proxv/qlive), [QUnited](http://github.com/aaronroyer/qunited)|
 | [Robot Framework](http://code.google.com/p/robotframework/) | [phantomrobot](https://github.com/datakurre/phantomrobot)|
 | [Rx Test Runner](https://github.com/gizur/rxtestrunner) | built-in |
-| [tapedeck](https://github.com/juliangruber/tapedeck) | built-in |
+| [tape-run](https://github.com/juliangruber/tape-run) | built-in |
 | [Testem](https://github.com/airportyh/testem) | built-in |
 | [Venus.js](http://www.venusjs.org/) | built-in |
 | [WebDriver](http://dvcs.w3.org/hg/webdriver/raw-file/tip/webdriver-spec.html) | [GhostDriver](https://github.com/detro/ghostdriver)|


### PR DESCRIPTION
Updated links to fix 404 errors
Capybara moved from jnicklas (gives 404) to teamcapybara
JSTestDriver removed as is it s Google code archive (2013 last update) JS-test-driver-phantom-js & JSTestRunner link gives '404'
tapedeck is deprecated and replaced by tape-run