### PR TITLE
Correct Mac OS download link

### DIFF
--- a/_posts/documentation/get-started/2000-01-01-download.md
+++ b/_posts/documentation/get-started/2000-01-01-download.md
@@ -12,7 +12,7 @@ The executable `phantomjs.exe` is ready to use.
 
 ## Mac OS X
 
-Download [phantomjs-2.1.3-macosx.zip](https://github.com/ariya/phantomjs/releases/download/2.1.3/phantomjs) (16.4 MB) and extract (unzip) the content.
+Download [phantomjs-2.1.1-macosx.zip](https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-macosx.zip) (16.4 MB) and extract (unzip) the content.
 
 ## Linux 64-bit && and 32-bit
 **32-bit will become deprecated on 31th of December 2018**


### PR DESCRIPTION
The Mac OS download link was pointing to a Linux binary.