### PR TITLE
Call correct method in example

### DIFF
--- a/_posts/api/fs/method/2000-01-01-make-tree.md
+++ b/_posts/api/fs/method/2000-01-01-make-tree.md
@@ -15,7 +15,7 @@ This will returns true if the creation was successful, otherwise false. If the d
 ```javascript
 var fs = require('fs');
 var path = '/Full/Path/To/Test/';
-if(fs.makeDirectory(path))
+if(fs.makeTree(path))
   console.log('"'+path+'" was created.');
 else
   console.log('"'+path+'" is NOT created.');


### PR DESCRIPTION
The code example for makeTree is copied from the makeDirectory page and still calls makeDirectory instead of makeTree.