### PR TITLE
Update 2000-01-01-open.md

### DIFF
--- a/_posts/api/webpage/method/2000-01-01-open.md
+++ b/_posts/api/webpage/method/2000-01-01-open.md
@@ -54,7 +54,7 @@ var webPage = require('webpage');
 var page = webPage.create();
 var settings = {
   operation: "POST",
-  encoding: "utf8",
+  encoding: "utf-8",
   headers: {
     "Content-Type": "application/json"
   },


### PR DESCRIPTION
I couldn't really find more documentation on this, but the `utf8` in the example was not effective when dealing with a web page that has no character encoding specified. `ISO-8859-1` was used as a default and some characters corrupted in the process. `utf-8` solves this problem.