### PR TITLE
Clarify renderBuffer is no longer available

### DIFF
--- a/_posts/api/webpage/method/2000-01-01-render-buffer.md
+++ b/_posts/api/webpage/method/2000-01-01-render-buffer.md
@@ -7,46 +7,5 @@ permalink: api/webpage/method/render-buffer.html
 
 `renderBuffer(format, quality)`
 
-Renders the web page to an image buffer which can be sent directly to a client (e.g. using the webserver module)
-
-## Supported formats
-
-* PNG
-* GIF
-* JPEG
-
-## Examples
-
-```javascript
-var server = require('webserver').create();
-
-var listening = server.listen(8001, function(request, response) {
-	var url = "http://phantomjs.org", format = 'png', quality = -1;
-
-	var page = require('webpage').create();
-
-	page.viewportSize = {
-		width: 800,
-		height: 600
-	};
-
-	page.open(url, function start(status) {
-
-		// Buffer is an Uint8ClampedArray
-		var buffer = page.renderBuffer(format, quality);
-
-		response.statusCode = 200;
-		response.headers = {
-			"Cache": "no-cache",
-			"Content-Type": "image/" + format
-		};
-		page.close();
-
-		// Pass the Buffer to 'write' to send the Uint8ClampedArray to the client
-		response.write(buffer);
-		response.close();
-	});
-
-});
-```
+NOTE: This method is no longer supported. Instead, use renderBase64, and decode the resulting output to get the raw buffer data.
 


### PR DESCRIPTION
This method does not appear to be available in the API anymore and should either be indicated as above, or the page removed ( i couldn't figure out how to do that).