### PR TITLE
Update selector in useragent example to prevent TypeError

### DIFF
--- a/examples/useragent.js
+++ b/examples/useragent.js
@@ -7,7 +7,7 @@ page.open('http://www.httpuseragent.org', function (status) {
         console.log('Unable to access network');
     } else {
         var ua = page.evaluate(function () {
-            return document.getElementById('myagent').innerText;
+            return document.getElementById('qua').value;
         });
         console.log(ua);
     }


### PR DESCRIPTION
The DOM structure of the page that is retrieved by useragent.js
has changed since the example was last updated, and the selector
for the user agent value no longer exists. This causes a TypeError
to be output to the user when running the example. This updates
the example to use a selector that exists on the page and also
uses `value` instead of `innerText` since the element has changed
to a `textarea`.

https://github.com/ariya/phantomjs/issues/15392