### PR TITLE
Remove QString::null deprecation warnings

### DIFF
--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -140,7 +140,7 @@ protected:
 
         // Check if User set a file via File Picker
         QString chosenFile = m_webPage->filePicker(oldFile);
-        if (chosenFile == QString::null && m_uploadFiles.count() > 0) {
+        if (chosenFile.isNull() && m_uploadFiles.count() > 0) {
             // Check if instead User set a file via uploadFile API
             chosenFile = m_uploadFiles.first();
         }
@@ -785,7 +785,7 @@ QString WebPage::filePicker(const QString& oldFile)
             }
         }
     }
-    return QString::null;
+    return QString();
 }
 
 bool WebPage::javaScriptConfirm(const QString& msg)


### PR DESCRIPTION
`QString::null` is deprecated. We should remove it from our codebase and use following:

* For checking a string against the null value - `QString.isNull()`;
* For return a null string - `QString()` (constructor).