### PR TITLE
Support building for arm64 hosts

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -18,14 +18,26 @@ of the PhantomJS source repository:
 
 ```bash
  $ git clean -xfd .
- $ docker run -v $PWD:/src debian:wheezy /src/deploy/docker-build.sh
+ $ docker run -v $PWD:/src ubuntu:16.04 /src/deploy/docker-build.sh
 ```
 
 For the 32-bit version:
 
 ```bash
  $ git clean -xfd .
- $ docker run -v $PWD:/src tubia/debian:wheezy /src/deploy/docker-build.sh
+ $ docker run -v $PWD:/src i386/ubuntu:16.04 /src/deploy/docker-build.sh
+```
+
+For an arm64 version natively:
+```bash
+ $ git clean -xfd .
+ $ docker run -v $PWD:/src ubuntu:16.04 /src/deploy/docker-build.sh
+```
+
+For an arm64 version built on an x86\_64 host:
+```bash
+ $ git clean -xfd .
+ $ docker run -v $PWD:/src arm64v8/ubuntu:16.04 /src/deploy/docker-build.sh
 ```
 
 The built binary will be extracted out of the container and copied to

--- a/deploy/docker-build.sh
+++ b/deploy/docker-build.sh
@@ -4,27 +4,29 @@ set -e
 
 SOURCE_PATH=/src
 BUILD_PATH=$HOME/build
-
-# In case the old package URL is still being used
-sed -i 's/http\.debian\.net/httpredir\.debian\.org/g' /etc/apt/sources.list
+ARCH=$(uname  -m)
 
 echo "Installing packages for development tools..." && sleep 1
 apt-get -y update
 apt-get install -y build-essential git flex bison gperf python ruby git libfontconfig1-dev
 echo
 
-echo "Preparing to download Debian source package..."
-echo "deb-src http://httpredir.debian.org/debian wheezy main" >> /etc/apt/sources.list
+echo "Preparing to download Debian/Ubuntu source package..."
+sed -i 's/# deb-src/deb-src/g' /etc/apt/sources.list
 apt-get -y update
 echo
 
-OPENSSL_TARGET='linux-x86_64'
-if [ `getconf LONG_BIT` -eq 32 ]; then
-    OPENSSL_TARGET='linux-generic32'
+if [ "$ARCH" == "aarch64" ]; then
+    OPENSSL_TARGET='linux-aarch64'
+else
+    OPENSSL_TARGET='linux-x86_64'
+    if [ `getconf LONG_BIT` -eq 32 ]; then
+        OPENSSL_TARGET='linux-generic32'
+    fi
 fi
 echo "Recompiling OpenSSL for ${OPENSSL_TARGET}..." && sleep 1
 apt-get source openssl
-cd openssl-1.0.1e
+cd openssl-*
 OPENSSL_FLAGS='no-idea no-mdc2 no-rc5 no-zlib enable-tlsext no-ssl2 no-ssl3 no-ssl3-method enable-rfc3779 enable-cms'
 ./Configure --prefix=/usr --openssldir=/etc/ssl --libdir=lib ${OPENSSL_FLAGS} ${OPENSSL_TARGET}
 make depend && make && make install
@@ -33,7 +35,7 @@ echo
 
 echo "Building the static version of ICU library..." && sleep 1
 apt-get source icu
-cd icu-4.8.1.1/source
+cd icu-*/source
 ./configure --prefix=/usr --enable-static --disable-shared
 make && make install
 cd ..


### PR DESCRIPTION
Since the wheezy repos aren't present anymore, also switch to using
the ubuntu:1604 docker image for compilation.

Compilation of an arm64 image works both on a native host or by docker using an arm64 base image and qemu