### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/qcommandline/qcommandline.cpp
+++ b/src/qcommandline/qcommandline.cpp
@@ -150,7 +150,7 @@ QCommandLine::parse()
   QQueue < QCommandLineConfigEntry > params;
   QMap < QString, QList < QString > > optionsFound;
   QMap < QString, int > switchsFound;
-  QStringList options, switchs;
+  QStringList options, switches;
   QStringList args = d->args;
 
   bool allparam = false;
@@ -233,7 +233,7 @@ QCommandLine::parse()
       if (!(entry.flags & QCommandLine::Multiple))
 	params.dequeue();
 
-    } else { /* Options and switchs* */
+    } else { /* Options and switches* */
       QString key;
       QString value;
       int idx = arg.indexOf(QLatin1Char('='));
@@ -256,7 +256,7 @@ QCommandLine::parse()
 
       if (entry.type == QCommandLine::Switch) {
 	if (!switchsFound.contains(entry.longName))
-	  switchs << entry.longName;
+	  switches << entry.longName;
 	if (entry.flags & QCommandLine::Multiple)
 	  switchsFound[entry.longName]++;
 	else
@@ -319,7 +319,7 @@ QCommandLine::parse()
     }
   }
 
-  foreach (QString key, switchs) {
+  foreach (QString key, switches) {
     for (int i = 0; i < switchsFound[key]; i++) {
       if (d->help && key == helpEntry.longName)
 	showHelp();

--- a/src/qcommandline/qcommandline.h
+++ b/src/qcommandline/qcommandline.h
@@ -207,7 +207,7 @@ public:
     bool versionEnabled();
 
     /**
-     * Parse command line and emmit signals when switchs, options, or
+     * Parse command line and emmit signals when switches, options, or
      * param are found.
      * @returns true if successfully parsed; otherwise returns false.
      * @sa parseError

--- a/src/repl.cpp
+++ b/src/repl.cpp
@@ -91,7 +91,7 @@ QStringList REPL::_enumerateCompletions(QObject* obj) const
     const QMetaObject* meta = obj->metaObject();
     QMap<QString, bool> completions;
 
-    // List up slots, signals, and invokable methods
+    // List up slots, signals, and invocable methods
     const int methodOffset = meta->methodOffset();
     const int methodCount = meta->methodCount();
     for (int i = methodOffset; i < methodCount; i++) {

--- a/src/webpage.h
+++ b/src/webpage.h
@@ -459,7 +459,7 @@ public slots:
      * {@see https://developer.mozilla.org/en-US/docs/DOM/window.history#Syntax}.
      * @brief go
      * @param historyRelativeIndex
-     * @return "true" if it does go forward/backgward in the Navigation History, "false" otherwise
+     * @return "true" if it does go forward/backward in the Navigation History, "false" otherwise
      */
     bool go(int historyRelativeIndex);
     /**


### PR DESCRIPTION
There are small typos in:
- src/qcommandline/qcommandline.cpp
- src/qcommandline/qcommandline.h
- src/repl.cpp
- src/webpage.h

Fixes:
- Should read `backward` rather than `backgward`.
- Should read `switches` rather than `switchs`.
- Should read `invocable` rather than `invokable`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md